### PR TITLE
[Adhoc] Fix setupdemo script with version

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -227,7 +227,7 @@ case $cmd in
         $cmd
         ;;
     setupdemo)
-        npx zx $node_modules_path/scripts/load-demodatabase.mjs &&
+        npx zx $node_modules_path/scripts/load-demodatabase.mjs -v $version &&
         npx zx $node_modules_path/scripts/load-demodataset.mjs
         ;;
     *)
@@ -245,7 +245,7 @@ Commands:
   start       Starts d2e services. Requires d2e init and d2e setup to be run.
   stop        Stops d2e services
   clean       Removes d2e docker containers and volumes
-  setupdemo        Load d2e services. Requires d2e init and d2e setup to be run.
+  setupdemo   Load d2e services. Requires d2e init and d2e setup to be run.
 
 Options:
  -d, --function-path [PATH] Development mode. [PATH] is the path to functions

--- a/scripts/load-demodatabase.mjs
+++ b/scripts/load-demodatabase.mjs
@@ -9,6 +9,14 @@ if ( await $`[ -f .env ]` ) {
     console.log(chalk.red(`FATAL .env file not found`));
     await $`exit 1`
 }
+const args = process.argv.slice(2); 
+const vIndex_version = args.indexOf("-v");
+if (vIndex_version !== -1 && args[vIndex_version + 1]) {
+    version = (args[vIndex_version + 1]);
+} else {
+    version = "0.6.0"; //default version
+}
+console.log(`Version: ${version}`);
 
 // Database variables
 let project_name = process.env.PROJECT_NAME ? `${process.env.PROJECT_NAME}` : 'd2e';
@@ -168,9 +176,9 @@ if (resp_status_code == '200') {
     await $`exit 1`
 }
 
-console.log(chalk.blue(`Restarting services...`));
-await $`d2e -e stop`
-await $`d2e -e start`
+console.log(`Restarting services with d2e -e -v ${version} stop...`);
+await $`d2e -e -v ${version} stop`
+await $`d2e -e -v ${version} start`
 console.log(chalk.blue(`Patching demo database...`));
 await $`d2e patchdemodb`
 console.log(chalk.green(`Completed patching demo database.`));


### PR DESCRIPTION
- Fix setupdemo script to specify version when restarting
- If unspecified, default version is 0.6.0

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [x] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)