### PR TITLE
Fix jobplugins trigger

### DIFF
--- a/functions/jobplugins/index.ts
+++ b/functions/jobplugins/index.ts
@@ -21,7 +21,6 @@ const env = Deno.env.toObject();
 app.use(express.json({ limit: "50mb" }));
 app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
-app.use(express.json());
 app.use(extractUsernameFromJwt);
 app.use("/jobplugins/dqd/data-quality", new DqdController().router);
 app.use("/jobplugins/cohort", new CohortController().router);


### PR DESCRIPTION
With the release of new version of body-parser, a duplicate line express.json() (an error not thrown previously) is causing an issue with jobplugins to trigger jobs such as create cache.

![image](https://github.com/user-attachments/assets/cb59402f-83d6-40b8-8023-c7e04add79e4)


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)