### PR TITLE
[data-2003] Add a cdm version concept ID mapping

### DIFF
--- a/flows/base/omop_cdm_plugin/create.py
+++ b/flows/base/omop_cdm_plugin/create.py
@@ -125,7 +125,17 @@ def insert_cdm_version(cdm_version: str, dbdao: DaoBase, cdm_schema: str, vocab_
     cdm_concept_code = "CDM " + RELEASE_VERSION_MAPPING.get(cdm_version)
     
     if not use_placeholder_values:
-            cdm_version_concept_id = dbdao.get_cdm_version_concept_id(vocab_schema, cdm_concept_code)
+            try:
+                cdm_version_concept_id = dbdao.get_cdm_version_concept_id(vocab_schema, cdm_concept_code)
+            except Exception as e:
+                logger.error(f"Failed to retrieve cdm version 'concept_id' from '{vocab_schema}.concept' table.")
+                cdm_version_concept_code = {
+                    "CDM v5.3.1": 1147638,
+                    "CDM v5.3.2": 902376,
+                    "CDM v5.4.0": 756265,
+                    "CDM v5.4.1": 798878
+                }
+                cdm_version_concept_id = cdm_version_concept_code[cdm_concept_code]
             logger.info(f"Retrieved cdm_version_concept_id '{cdm_version_concept_id}' from vocab schema '{vocab_schema}' with cdm_concept_code '{cdm_concept_code}'..")
             vocabulary_version = dbdao.get_vocabulary_version(vocab_schema)
             logger.info(f"Retrieved vocabulary_version '{vocabulary_version}' from vocab schema '{vocab_schema}' with cdm_concept_code '{cdm_concept_code}'..")


### PR DESCRIPTION
Issue: demodb doesn't have the full vocab (~400 records in concept table) so unable to get the corresponding concept_id for the cdm version. This causes the schema creation to fail on demo db when inserting the cdm version. Added a mapping in place.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)