### PR TITLE
[Integrate-2143] add cdm schema to db vocab schemas for new dataset with existing schema option

### DIFF
--- a/functions/dataset/api/DbCredentialsAPI.ts
+++ b/functions/dataset/api/DbCredentialsAPI.ts
@@ -1,0 +1,72 @@
+// import https from "node:https";
+import { AxiosRequestConfig } from "npm:axios";
+import { services } from "../env.ts";
+import { get, put } from "./request-util.ts";
+
+interface IDatabaseDetailsUpdate {
+  id: string;
+  vocabSchemas: string[];
+}
+
+export class DbCredentialsAPI {
+  private readonly baseURL: string;
+  // private readonly httpsAgent: any;
+  private readonly logger = console; //createLogger(this.constructor.name)
+  private readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+    if (!token) {
+      throw new Error("No token passed for DbCredentials API!");
+    }
+    if (services.trex) {
+      this.baseURL = services.trex;
+      // this.httpsAgent = new https.Agent({
+      //   rejectUnauthorized: true,
+      //   ca: env.GATEWAY_CA_CERT
+      // });
+    } else {
+      this.logger.error("No url is set for DbCredentialsAPI");
+      throw new Error("No url is set for DbCredentialsAPI");
+    }
+  }
+
+  private async getRequestConfig() {
+    let options: AxiosRequestConfig = {};
+
+    options = {
+      headers: {
+        Authorization: this.token,
+      },
+      // httpsAgent: this.httpsAgent,
+    };
+
+    return options;
+  }
+
+  async getDbList() {
+    try {
+      this.logger.info("Get database list");
+      const options = await this.getRequestConfig();
+      const url = `${this.baseURL}/trex/db/`;
+      const result = await get(url, options);
+      return result.data;
+    } catch (error) {
+      console.error(`Error while getting database list`, error);
+      throw error;
+    }
+  }
+
+  async updateDbDetails(db: IDatabaseDetailsUpdate) {
+    try {
+      this.logger.info(`Updating database: ${JSON.stringify(db)}`);
+      const options = await this.getRequestConfig();
+      const url = `${this.baseURL}/trex/db/`;
+      const result = await put(url, db, options);
+      return result.data;
+    } catch (error) {
+      console.error(`Error while updating database`, error);
+      throw error;
+    }
+  }
+}

--- a/functions/dataset/index.ts
+++ b/functions/dataset/index.ts
@@ -6,6 +6,7 @@ import { PortalAPI } from "./api/PortalAPI.ts";
 import { CDMSchemaTypes, DbDialect } from "./const.ts";
 import { env } from "./env.ts";
 import { generateDatasetSchema } from "./GenerateDatasetSchema.ts";
+import { DbCredentialsAPI } from "./api/DbCredentialsAPI.ts";
 
 const GATEWAY_WO_PROTOCOL_FQDN = env.GATEWAY_WO_PROTOCOL_FQDN!;
 const app = express();
@@ -172,6 +173,30 @@ export class DatasetRouter {
                 );
                 return res.status(500).send("Error while creating CDM schema");
               }
+            }
+          }
+
+          if (schemaOption === CDMSchemaTypes.ExistingCDM) {
+            const dbAPI = new DbCredentialsAPI(token);
+            const dbList = await dbAPI.getDbList();
+            const db = dbList.find((d) => d.code === databaseCode);
+
+            if (!db) {
+              this.logger.error(
+                `Database with code ${databaseCode} does not exist`
+              );
+              return res.status(400).send("Database does not exist");
+            }
+
+            if (!db.vocab_schemas.includes(schemaName)) {
+              this.logger.info(
+                `Vocab schema ${schemaName} does not exist in database ${databaseCode}. Appending it to the database`
+              );
+
+              await dbAPI.updateDbDetails({
+                id: databaseCode,
+                vocabSchemas: [...db.vocab_schemas, schemaName],
+              });
             }
           }
 


### PR DESCRIPTION
### Merge Checklist

Current database vocab schema
<img width="944" alt="Screenshot 2025-06-20 at 11 01 59" src="https://github.com/user-attachments/assets/5aaa2e3c-7c11-4c9b-b251-ac387fbf4606" />

Add dataset with existing schema
<img width="928" alt="Screenshot 2025-06-20 at 11 02 59" src="https://github.com/user-attachments/assets/c10352e4-5a73-445f-b4ec-5e5059b29040" />

The dataset cdm schema is added to the database vocab schemas
<img width="932" alt="Screenshot 2025-06-20 at 11 04 18" src="https://github.com/user-attachments/assets/a888f444-80ec-4fe5-aee2-33aa66bd036f" />

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)