### PR TITLE
[Analyze-2173] Add `DOCKER_TAG_NAME=local` to local npm commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "init:minerva": "PROJECT_NAME=alp ENV_TYPE=local ./scripts/cli.sh -v develop -n .env.local init",
-    "local:minerva": "PROJECT_NAME=alp ENV_TYPE=local CADDY__CONFIG=./deploy/caddy-config ./scripts/cli.sh -v develop -e -n .env.local -f -j -m -d ./functions -p 41100",
+    "local:minerva": "PROJECT_NAME=alp ENV_TYPE=local DOCKER_TAG_NAME=local CADDY__CONFIG=./deploy/caddy-config ./scripts/cli.sh -v develop -e -n .env.local -f -j -m -d ./functions -p 41100",
     "build:minerva": "npm run local:minerva -- build",
     "start:minerva": "npm run local:minerva -- start",
     "stop:minerva": "npm run local:minerva -- stop",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "env_names_dev": "local remote base-all base-local base-remote alp-dev-sg-3"
   },
   "scripts": {
-    "init:minerva": "PROJECT_NAME=alp ENV_TYPE=local ./scripts/cli.sh -v develop -n .env.local init",
+    "init:minerva": "PROJECT_NAME=alp ENV_TYPE=local DOCKER_TAG_NAME=local ./scripts/cli.sh -v develop -n .env.local init",
     "local:minerva": "PROJECT_NAME=alp ENV_TYPE=local DOCKER_TAG_NAME=local CADDY__CONFIG=./deploy/caddy-config ./scripts/cli.sh -v develop -e -n .env.local -f -j -m -d ./functions -p 41100",
     "build:minerva": "npm run local:minerva -- build",
     "start:minerva": "npm run local:minerva -- start",


### PR DESCRIPTION
- resolves: https://github.com/data2evidence/internal/issues/2173

1. Add `DOCKER_TAG_NAME=local` to `local:minerva` and `init:minerva`

Extras:
  Workaround command to run docker compose logs with -f flag:
  `npm run logs:minerva -- -s -f`

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)