### PR TITLE
Fix concepts not showing

### DIFF
--- a/ui/apps/portal/src/plugins/Researcher/Terminology/components/TerminologyList/TerminologyList.tsx
+++ b/ui/apps/portal/src/plugins/Researcher/Terminology/components/TerminologyList/TerminologyList.tsx
@@ -74,16 +74,8 @@ const TerminologyList: FC<TerminologyListProps> = ({
     concept: {},
     validity: {},
   });
-  // Initialize columnFilters with defaultFilters for CONCEPT_MULTI_SELECT mode to avoid loading all concepts first
-  const [columnFilters, setColumnFilters] = useState<{ id: string; value: unknown }[]>(() => {
-    if (defaultFilters && defaultFilters.length > 0) {
-      return defaultFilters.map((filter) => ({
-        id: filter.id,
-        value: filter.value,
-      }));
-    }
-    return [];
-  });
+  const [columnFilters, setColumnFilters] = useState<{ id: string; value: unknown }[]>([]);
+  const [useDefaultFilters, setUseDefaultFilters] = useState(true);
   const { setFeedback } = useFeedback();
   const tableRef = useRef<HTMLTableElement>(null);
 
@@ -216,6 +208,31 @@ const TerminologyList: FC<TerminologyListProps> = ({
     },
     [onSelectConceptId]
   );
+
+  useEffect(() => {
+    if (columnFilters.length || !defaultFilters) {
+      setUseDefaultFilters(false);
+    }
+  }, [columnFilters.length, defaultFilters]);
+
+  useEffect(() => {
+    if (useDefaultFilters && defaultFilters && filterOptions && listData.length) {
+      // Only include valid filters
+      const filters = JSON.parse(JSON.stringify(defaultFilters)) as typeof defaultFilters;
+      const validFilters = filters
+        .map((f) => {
+          const valueKeys = filterOptions[f.id as keyof typeof filterOptions];
+          const valueKeysArr = Object.keys(valueKeys);
+          const value = f.value.filter((v) => valueKeysArr.includes(v));
+          return { ...f, value };
+        })
+        .filter((f) => {
+          // Empty value arrays should be removed as it is not compatible with the react table
+          return Object.keys(filterOptions).includes(f.id) && f.value.length;
+        });
+      setColumnFilters(validFilters);
+    }
+  }, [defaultFilters, filterOptions, listData, useDefaultFilters]);
 
   useEffect(() => {
     if (tab === tabNames.SELECTED) {


### PR DESCRIPTION
Fixes issue where concepts were received via api, but not showing the in the terminology UI.

This issue is unusual as it only occurs when portal is built, but not in react dev server.

The causing code change was meant to set default filters immediately when available. The fix reverts this change, which means there will be a quick visible ui update seen when default filters are used where it goes from empty to filled.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)