### PR TITLE
[Fix] Docker build GHA for rkernel image to build push

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -210,7 +210,7 @@ jobs:
 
       - name: Build and Push
         id: build-push
-        if: ${{matrix.build_disable != 'true' }}
+        if: ${{matrix.build_disable != 'true' || github.event_name == 'workflow_dispatch' || github.ref_name == 'develop' || contains('release', github.ref_name) }}
         uses: docker/build-push-action@v6
         with:
           builder: ${{ steps.builder.outputs.name }}


### PR DESCRIPTION
- Allow rkernel docker image to build push every develop, release branch and manual dispatch
- Previously rkernel docker image build was cancelled when merging to develop due to another PR that merged before rkernel build could complete. Did not retrigger rkernel build as there were no file changes

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)