### PR TITLE
[ADHOC] Fix concept search OOM

### DIFF
--- a/flows/base/create_cachedb_file_plugin/fts.py
+++ b/flows/base/create_cachedb_file_plugin/fts.py
@@ -74,7 +74,7 @@ def get_duckdb_fts_creation_sql(schema_name: str,
             {", ".join(columns)},
             stemmer='english', 
             stopwords='english',
-            ignore='(\\.|[^a-z0-9!@#$%^&*()\-`.+,\\\/"])+', 
+            ignore='(\\.|[^a-z!@#$%^&*()\-`.+,\\\/"])+', 
             strip_accents=1, 
             lower=1, 
             overwrite=1)


### PR DESCRIPTION
Remove numbers from duckdb fts index creation regex to fix OOM issue that is occurring due to duckdb `v1.3.2`.

Concept search no longer crashing
<img width="1823" height="1343" alt="image" src="https://github.com/user-attachments/assets/3f4f244f-9380-48b5-92ed-002be658bd7f" />
But searching via numbers now is not supported
<img width="1822" height="569" alt="image" src="https://github.com/user-attachments/assets/ecf100b6-a5f5-4ec4-ac6d-542ed97f0729" />


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)