### PR TITLE
[PA] App crashes when selecting bar chart area

### DIFF
--- a/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
@@ -321,6 +321,10 @@ export default {
         // Persist selection across Plotly react
         const selectedPoints = this.chartData.traces.map(trace => trace.selectedpoints)
         this.dataToTraces(this.chartData, selectedPoints, selectedCount)
+
+        stackBarChart.removeAllListeners('plotly_selected')
+        stackBarChart.removeAllListeners('plotly_deselect')
+
         Plotly.react(stackBarChart, this.chartData.traces, this.layout, this.config)
       }
 
@@ -331,3 +335,4 @@ export default {
   },
 }
 </script>
+


### PR DESCRIPTION
- `Plotly.react()` method will trigger Plotly events (plotly_selected, plotly_deselect), causing an endless loop at times
- Removing said listeners fixes the issue

![Screen Recording 2025-10-24 at 11 02 06 AM](https://github.com/user-attachments/assets/db196643-190f-439f-a2e4-166a1ae69a3b)


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)