### PR TITLE
[Analyze-1134] Truncate x-axis label when exceeding max length

### DIFF
--- a/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
@@ -300,9 +300,11 @@ export default {
           if (!trace.selectedpoints) {
             return
           }
-          const xAxes = trace.customdata.x
-          const yAxis = trace.customdata.y
           trace.selectedpoints.forEach(pointIndex => {
+            const pointCustomData = trace.customdata[pointIndex]
+            const xAxes = pointCustomData.x
+            const yAxis = pointCustomData.y
+
             if (xAxes.length > 1) {
               xAxes.forEach((xAxis, axisIndex) => {
                 pushPoint(xAxis.id, trace.x[axisIndex][pointIndex])

--- a/ui/apps/vue-mri-ui-lib/src/store/modules/chartUtils.ts
+++ b/ui/apps/vue-mri-ui-lib/src/store/modules/chartUtils.ts
@@ -6,6 +6,24 @@ import Sorter from '@/utils/Sorter'
 
 const state = {}
 
+// Helper function to truncate text at word boundary
+const truncateAtWordBoundary = (text: string, maxLength: number): string => {
+  if (!text) return text
+  if (text.length <= maxLength) {
+    return text
+  }
+
+  // Find the last space before maxLength
+  const truncated = text.slice(0, maxLength)
+  const lastSpaceIndex = truncated.lastIndexOf(' ')
+
+  // If there's a space, truncate there; otherwise truncate at maxLength
+  if (lastSpaceIndex > 0) {
+    return text.slice(0, lastSpaceIndex) + '...'
+  }
+  return truncated + '...'
+}
+
 const getters = {
   /*
     Adds bar chart traces expected by Plotly based on chartData
@@ -54,19 +72,33 @@ const getters = {
       // Reversed since the last trace will appear at the top
       chartData.traces = categoryArray.reverse().map((category, index) => {
         let xData = []
-        // Custom hover labelling
+        let customdataArray = []
+        // Custom tooltip labelling
         let hoverTemplate = ''
         if (xAxes.length === 1) {
-          xData = category.data.map(data => data[xAxes[0].id])
-          hoverTemplate += '%{data.customdata.x[0].name}: %{x}<br>'
+          xData = category.data.map(data => truncateAtWordBoundary(data[xAxes[0].id], Constants.XAxisLabelMaxLength))
+          customdataArray = category.data.map(dataPoint => ({
+            x: xAxes,
+            y: yAxis,
+            fullLabels: [dataPoint[xAxes[0].id]],
+          }))
+          hoverTemplate += '%{customdata.x[0].name}: %{customdata.fullLabels[0]}<br>'
         } else {
-          xData = xAxes.map(xAxis => category.data.map(data => data[xAxis.id]))
+          // Truncate labels for x-axis display
+          xData = xAxes.map(xAxis =>
+            category.data.map(data => truncateAtWordBoundary(data[xAxis.id], Constants.XAxisLabelMaxLength))
+          )
+          // Build customdata array with full labels for each data point
+          customdataArray = category.data.map(dataPoint => {
+            const fullLabels = xAxes.map(xAxis => dataPoint[xAxis.id])
+            return { x: xAxes, y: yAxis, fullLabels }
+          })
           for (let i = 0; i < xAxes.length; i++) {
-            hoverTemplate += '%{data.customdata.x[' + i + '].name}: %{x[' + i + ']}<br>'
+            hoverTemplate += '%{customdata.x[' + i + '].name}: %{customdata.fullLabels[' + i + ']}<br>'
           }
         }
         if (category.name !== '') {
-          hoverTemplate += '%{data.customdata.y[0].name}: ' + category.name + '<br>'
+          hoverTemplate += '%{customdata.y[0].name}: ' + category.name + '<br>'
         }
         hoverTemplate += toolTipSelected
 
@@ -75,10 +107,7 @@ const getters = {
           y: category.data.map(data => data[measureId]),
           type: 'bar',
           hovertemplate: hoverTemplate,
-          customdata: {
-            x: xAxes,
-            y: yAxis,
-          },
+          customdata: customdataArray,
           selectedpoints: selection ? selection[index] : [],
           name: category.name,
         }
@@ -291,3 +320,4 @@ export default {
   actions,
   mutations,
 }
+

--- a/ui/apps/vue-mri-ui-lib/src/utils/Constants.ts
+++ b/ui/apps/vue-mri-ui-lib/src/utils/Constants.ts
@@ -292,6 +292,7 @@ const PlotlyConsts = {
       automargin: true,
       tickson: 'boundaries',
       ticks: 'outside',
+      dividercolor: 'rgba(0,0,0,0.3)',
       type: 'multicategory', // Dynamically toggled with "category" while converting data into Plotly traces
     },
     yaxis: {
@@ -315,6 +316,8 @@ const CohortEntryExit = {
   EXIT_KEY: 'isExit',
 }
 
+const XAxisLabelMaxLength = 30
+
 export default {
   sap,
   events,
@@ -331,4 +334,6 @@ export default {
   AxisIcons,
   AxisId,
   CohortEntryExit,
+  XAxisLabelMaxLength,
 }
+


### PR DESCRIPTION
Changes:
- Truncate x-axis label when exceeding max length for PA bar chart
- Make x-axis tick dividers 30% transparent to prevent them from appearing like strikethroughs on labels.

<img width="1512" height="859" alt="Screenshot 2025-11-24 at 2 44 29 PM" src="https://github.com/user-attachments/assets/33d151af-8baa-42ed-bc6b-06c9bdc47551" />


### Merge Checklist
Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)