### PR TITLE
Enable inclusion rules reordering in inclusion report attrition view

### DIFF
--- a/ui/apps/vue-mri-ui-lib/src/components/ChevronButton.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/ChevronButton.vue
@@ -1,0 +1,61 @@
+<template>
+  <button @click="handleClick" class="btn-chevron" :disabled="disabled">
+    <ChevronIcon class="chevron-icon" :direction="direction" />
+  </button>
+</template>
+
+<script setup lang="ts">
+import ChevronIcon from './icons/ChevronIcon.vue'
+
+const props = withDefaults(
+  defineProps<{
+    direction: 'up' | 'down'
+    disabled?: boolean
+    title?: string
+  }>(),
+  {
+    disabled: false,
+    title: '',
+  }
+)
+
+const emit = defineEmits<{
+  click: []
+}>()
+
+const handleClick = () => {
+  emit('click')
+}
+</script>
+
+<style scoped>
+.btn-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--color-ui-medium-text, #666);
+}
+
+.btn-chevron:focus {
+  outline: none;
+  border-color: var(--color-focus, #005483);
+}
+.btn-chevron:hover {
+  color: var(--color-background-button-primary-hover);
+}
+
+.btn-chevron:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.chevron-icon {
+  width: 24px;
+  height: 24px;
+}
+</style>
+

--- a/ui/apps/vue-mri-ui-lib/src/components/ChevronButton.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/ChevronButton.vue
@@ -1,9 +1,3 @@
-<template>
-  <button @click="handleClick" class="btn-chevron" :disabled="disabled">
-    <ChevronIcon class="chevron-icon" :direction="direction" />
-  </button>
-</template>
-
 <script setup lang="ts">
 import ChevronIcon from './icons/ChevronIcon.vue'
 
@@ -28,6 +22,12 @@ const handleClick = () => {
 }
 </script>
 
+<template>
+  <button @click="handleClick" class="btn-chevron" :disabled="disabled" :title="title">
+    <ChevronIcon class="chevron-icon" :direction="direction" />
+  </button>
+</template>
+
 <style scoped>
 .btn-chevron {
   display: flex;
@@ -41,8 +41,8 @@ const handleClick = () => {
 }
 
 .btn-chevron:focus {
-  outline: none;
-  border-color: var(--color-focus, #005483);
+  outline: 2px solid var(--color-focus, #005483);
+  outline-offset: 2px;
 }
 .btn-chevron:hover {
   color: var(--color-background-button-primary-hover);
@@ -58,4 +58,3 @@ const handleClick = () => {
   height: 24px;
 }
 </style>
-

--- a/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
@@ -384,6 +384,7 @@ export default {
     },
     getActiveBookmarkName() {
       if (this.getActiveBookmark) {
+        console.log('activeBookmark', this.getActiveBookmark)
         return this.getActiveBookmark.bookmarkname
       } else {
         return ''
@@ -486,3 +487,4 @@ export default {
   },
 }
 </script>
+

--- a/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
@@ -384,7 +384,6 @@ export default {
     },
     getActiveBookmarkName() {
       if (this.getActiveBookmark) {
-        console.log('activeBookmark', this.getActiveBookmark)
         return this.getActiveBookmark.bookmarkname
       } else {
         return ''
@@ -487,4 +486,3 @@ export default {
   },
 }
 </script>
-

--- a/ui/apps/vue-mri-ui-lib/src/components/icons/ChevronIcon.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/icons/ChevronIcon.vue
@@ -1,0 +1,20 @@
+<template>
+  <svg :class="['chevron-icon', direction]" width="16" height="16" viewBox="0 0 24 24">
+    <path :d="pathD" fill="currentColor" />
+  </svg>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  direction: 'up' | 'down'
+}>()
+
+const pathD = computed(() => {
+  return props.direction === 'up'
+    ? 'M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z'
+    : 'M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6z'
+})
+</script>
+

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
@@ -159,7 +159,6 @@ const hasCohortGenerated = computed(() => {
             v-if="selectedView === 'inclusion-report'"
             :cohort-definition-id="cohortDefinitionId"
             :source-key="activeDataset"
-            :modeId="1"
             :generation-status="generationStatus[activeDataset]"
             :patient-count="patientCounts?.[activeDataset]"
           />

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
@@ -14,7 +14,7 @@ import InclusionReport from './InclusionReport/index.vue'
 import Samples from './Samples.vue'
 
 const props = defineProps<{
-  cohortDefinitionId: number
+  cohortDefinitionId: string
   availableSources: any[]
   patientCounts?: Record<string, number | null>
   isGeneratingCohort?: boolean
@@ -178,4 +178,3 @@ const hasCohortGenerated = computed(() => {
 <style lang="scss" scoped>
 @import '../styles/ExecuteSidePanel.scss';
 </style>
-

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/__tests__/computeAttritionStats.test.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/__tests__/computeAttritionStats.test.ts
@@ -2,6 +2,82 @@ import { computeAttritionStats } from '../computeAttritionStats'
 import type { InclusionReportResponse } from '../../../types/InclusionReportTypes'
 
 describe('Attrition Stats Computation', () => {
+  const multipleRulesReport: InclusionReportResponse = {
+    summary: {
+      baseCount: 230,
+      finalCount: 44,
+      lostCount: 0,
+      percentMatched: '19.13%',
+    },
+    inclusionRuleStats: [
+      {
+        id: 0,
+        name: 'Gender female and gender diverse',
+        percentExcluded: '19.13%',
+        percentSatisfying: '54.35%',
+        countSatisfying: 125,
+      },
+      {
+        id: 1,
+        name: 'Age>30',
+        percentExcluded: '0.87%',
+        percentSatisfying: '98.70%',
+        countSatisfying: 227,
+      },
+      {
+        id: 2,
+        name: 'Age<70',
+        percentExcluded: '34.35%',
+        percentSatisfying: '39.57%',
+        countSatisfying: 91,
+      },
+    ],
+    treemapData: JSON.stringify({
+      name: 'Everyone',
+      children: [
+        {
+          name: 'Group 3',
+          children: [
+            {
+              name: '111',
+              size: 44,
+            },
+            {
+              name: 'Group 2',
+              children: [
+                {
+                  name: '110',
+                  size: 79,
+                },
+                {
+                  name: '101',
+                  size: 2,
+                },
+                {
+                  name: '011',
+                  size: 44,
+                },
+                {
+                  name: 'Group 1',
+                  children: [
+                    {
+                      name: '001',
+                      size: 1,
+                    },
+                    {
+                      name: '010',
+                      size: 60,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+  }
+
   describe('basic functionality', () => {
     it('should return empty array for null/undefined report', () => {
       expect(computeAttritionStats(null as any)).toEqual([])
@@ -47,83 +123,7 @@ describe('Attrition Stats Computation', () => {
     })
 
     it('should compute stats for multiple rules', () => {
-      const report: InclusionReportResponse = {
-        summary: {
-          baseCount: 230,
-          finalCount: 44,
-          lostCount: 0,
-          percentMatched: '19.13%',
-        },
-        inclusionRuleStats: [
-          {
-            id: 0,
-            name: 'Gender female and gender diverse',
-            percentExcluded: '19.13%',
-            percentSatisfying: '54.35%',
-            countSatisfying: 125,
-          },
-          {
-            id: 1,
-            name: 'Age>30',
-            percentExcluded: '0.87%',
-            percentSatisfying: '98.70%',
-            countSatisfying: 227,
-          },
-          {
-            id: 2,
-            name: 'Age<70',
-            percentExcluded: '34.35%',
-            percentSatisfying: '39.57%',
-            countSatisfying: 91,
-          },
-        ],
-        treemapData: JSON.stringify({
-          name: 'Everyone',
-          children: [
-            {
-              name: 'Group 3',
-              children: [
-                {
-                  name: '111',
-                  size: 44,
-                },
-                {
-                  name: 'Group 2',
-                  children: [
-                    {
-                      name: '110',
-                      size: 79,
-                    },
-                    {
-                      name: '101',
-                      size: 2,
-                    },
-                    {
-                      name: '011',
-                      size: 44,
-                    },
-                    {
-                      name: 'Group 1',
-                      children: [
-                        {
-                          name: '001',
-                          size: 1,
-                        },
-                        {
-                          name: '010',
-                          size: 60,
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        }),
-      }
-
-      const stats = computeAttritionStats(report)
+      const stats = computeAttritionStats(multipleRulesReport)
 
       expect(stats).toHaveLength(3)
 
@@ -202,6 +202,42 @@ describe('Attrition Stats Computation', () => {
       const stats = computeAttritionStats(report)
 
       expect(stats).toEqual([])
+    })
+  })
+
+  describe('custom order', () => {
+    it('should compute stats with custom rule order', () => {
+      // Apply custom order: [2, 0, 1] instead of [0, 1, 2]
+      const stats = computeAttritionStats(multipleRulesReport, [2, 0, 1])
+
+      expect(stats).toHaveLength(3)
+
+      // Rule 2 first (checking position [2])
+      expect(stats[0]).toEqual({
+        id: 2,
+        name: 'Age<70',
+        countSatisfying: 91,
+        percentSatisfying: '39.57%',
+        pctDiff: '60.43%',
+      })
+
+      // Rule 0 second (checking positions [2, 0])
+      expect(stats[1]).toEqual({
+        id: 0,
+        name: 'Gender female and gender diverse',
+        countSatisfying: 46,
+        percentSatisfying: '20.00%',
+        pctDiff: '19.57%',
+      })
+
+      // Rule 1 third (checking positions [2, 0, 1])
+      expect(stats[2]).toEqual({
+        id: 1,
+        name: 'Age>30',
+        countSatisfying: 44,
+        percentSatisfying: '19.13%',
+        pctDiff: '0.87%',
+      })
     })
   })
 })

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeAttritionStats.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeAttritionStats.ts
@@ -48,7 +48,9 @@ export function computeAttritionStats(report: InclusionReportResponse, order?: n
   let priorPct = 1.0
   const stats = ruleOrder.map((ruleId: number) => {
     const rule = report.inclusionRuleStats.find(r => r.id === ruleId)
-    if (!rule) return null
+    if (!rule) {
+      throw new Error(`Invalid rule ID: ${ruleId}`)
+    }
     const rulesToCheck = ruleOrder.slice(0, ruleOrder.indexOf(ruleId) + 1)
     const countSatisfying = countMatch(treemapData, rulesToCheck, report.inclusionRuleStats.length)
     const percentSatisfying = baseCount !== 0 ? countSatisfying / baseCount : 0

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeAttritionStats.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeAttritionStats.ts
@@ -9,11 +9,12 @@ type AttritionStat = {
 }
 
 /**
- * Count matches in treemap data based on a binary mask pattern
- * Recursively traverses the tree and counts leaf nodes whose names start with the mask
+ * Count matches in treemap data based on rule IDs
+ * Recursively traverses the tree and counts leaf nodes where all specified rules pass
  * Adapted from Ohdsi Atlas codebase
  * @param node - The treemap node to search (can have children or be a leaf)
- * @param mask - Binary string pattern to match (e.g., "11" matches nodes starting with "11")
+ * @param ruleIds - Array of rule IDs to check (positions in the binary string that must be '1')
+ * @param totalRuleCount - Total number of rules (unused but kept for API consistency)
  * @returns Total count of matching leaf nodes
  */
 const countMatch = (node: any, ruleIds: number[], totalRuleCount: number): number => {
@@ -68,4 +69,3 @@ export function computeAttritionStats(report: InclusionReportResponse, order?: n
 
   return stats as AttritionStat[]
 }
-

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeAttritionStats.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeAttritionStats.ts
@@ -16,14 +16,17 @@ type AttritionStat = {
  * @param mask - Binary string pattern to match (e.g., "11" matches nodes starting with "11")
  * @returns Total count of matching leaf nodes
  */
-const countMatch = (node: any, mask: string): number => {
+const countMatch = (node: any, ruleIds: number[], totalRuleCount: number): number => {
   let count = 0
   if (node.hasOwnProperty('children')) {
     node.children.forEach((c: any) => {
-      count += countMatch(c, mask)
+      count += countMatch(c, ruleIds, totalRuleCount)
     })
   } else {
-    count = node.name.startsWith(mask) ? node.size : 0
+    const name = node.name as string
+    // Check if ALL rules in ruleIds have '1' at their original position
+    const allPass = ruleIds.every(ruleId => name.charAt(ruleId) === '1')
+    count = allPass ? node.size : 0
   }
   return count
 }
@@ -35,14 +38,19 @@ const countMatch = (node: any, mask: string): number => {
  * @param report - The inclusion report containing treemap data and rule definitions
  * @returns Array of attrition statistics, one for each inclusion rule
  */
-export function computeAttritionStats(report: InclusionReportResponse): AttritionStat[] {
+export function computeAttritionStats(report: InclusionReportResponse, order?: number[]): AttritionStat[] {
   if (!report) return []
+
   const treemapData = JSON.parse(report.treemapData)
   const baseCount = report.summary.baseCount
+  const ruleOrder: number[] = order || report.inclusionRuleStats.map(rule => rule.id)
 
   let priorPct = 1.0
-  const stats = report.inclusionRuleStats.map((rule: any, i: number) => {
-    const countSatisfying = countMatch(treemapData, '1'.repeat(i + 1))
+  const stats = ruleOrder.map((ruleId: number) => {
+    const rule = report.inclusionRuleStats.find(r => r.id === ruleId)
+    if (!rule) return null
+    const rulesToCheck = ruleOrder.slice(0, ruleOrder.indexOf(ruleId) + 1)
+    const countSatisfying = countMatch(treemapData, rulesToCheck, report.inclusionRuleStats.length)
     const percentSatisfying = baseCount !== 0 ? countSatisfying / baseCount : 0
     const pctDiff = priorPct - percentSatisfying
     priorPct = percentSatisfying
@@ -56,6 +64,6 @@ export function computeAttritionStats(report: InclusionReportResponse): Attritio
     }
   })
 
-  return stats
+  return stats as AttritionStat[]
 }
 

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeTreemapStats.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/computeTreemapStats.ts
@@ -1,18 +1,11 @@
 import { InclusionReportResponse } from '@/query-filter/types/InclusionReportTypes'
+import { INCLUSION_REPORT_COLORS } from './constants'
 
 type TooltipData = {
   count: string
   summary: string
   passed: string[]
   failed: string[]
-}
-
-const RULE_FAILURE_COLORS = {
-  allFailedOr5Plus: '#fabfb4',
-  threeToFour: '#fcdab6',
-  two: '#dedcab',
-  one: '#cdd99e',
-  allPassed: '#53bead',
 }
 
 /**
@@ -42,16 +35,16 @@ function calculateRuleCounts(bits: string): { passCount: number; failCount: numb
  */
 function getColorByFailureCount(failCount: number): string {
   if (failCount === 0) {
-    return RULE_FAILURE_COLORS.allPassed
+    return INCLUSION_REPORT_COLORS.allPassed
   } else if (failCount === 1) {
-    return RULE_FAILURE_COLORS.one
+    return INCLUSION_REPORT_COLORS.one
   } else if (failCount === 2) {
-    return RULE_FAILURE_COLORS.two
+    return INCLUSION_REPORT_COLORS.two
   } else if (failCount < 5) {
-    return RULE_FAILURE_COLORS.threeToFour
+    return INCLUSION_REPORT_COLORS.threeToFour
   } else {
     // 5+ failed or all failed
-    return RULE_FAILURE_COLORS.allFailedOr5Plus
+    return INCLUSION_REPORT_COLORS.allFailedOr5Plus
   }
 }
 
@@ -154,8 +147,9 @@ export function convertTreemapData(data: any, inclusionReportResponse: Inclusion
 
     // Calculate number of failed rules based on the binary string name
     const { failCount } = calculateRuleCounts(node.name)
+    const color = getColorByFailureCount(failCount)
     newNode.itemStyle = {
-      color: getColorByFailureCount(failCount),
+      color: color,
     }
 
     return newNode

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/constants.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/constants.ts
@@ -1,0 +1,59 @@
+/**
+ * Color palette for inclusion report visualizations
+ * Colors represent different levels of rule failures, from most failures (red) to no failures (green)
+ */
+export const INCLUSION_REPORT_COLORS = {
+  allFailedOr5Plus: '#fabfb4',
+  threeToFour: '#fcdab6',
+  two: '#dedcab',
+  one: '#cdd99e',
+  allPassed: '#53bead',
+} as const
+
+/**
+ * Array of colors ordered from most failures to least failures
+ * Used for funnel chart visualization
+ */
+export const COLORS_ARRAY = [
+  INCLUSION_REPORT_COLORS.allFailedOr5Plus,
+  INCLUSION_REPORT_COLORS.threeToFour,
+  INCLUSION_REPORT_COLORS.two,
+  INCLUSION_REPORT_COLORS.one,
+  INCLUSION_REPORT_COLORS.allPassed,
+] as const
+
+/**
+ * Thresholds for funnel chart color mapping
+ * Represents the ratio of remaining population after each rule
+ */
+export const FUNNEL_THRESHOLDS = [0.1, 0.25, 0.5, 0.75] as const
+
+/**
+ * Legend labels for funnel chart
+ * Corresponds to the color thresholds
+ */
+export const FUNNEL_LEGEND_LABELS = [
+  '≤10% remain',
+  '10-25% remain',
+  '25-50% remain',
+  '50-75% remain',
+  '>75% remain',
+] as const
+
+/**
+ * Legend items for treemap visualization
+ * Maps failure counts to human-readable labels and colors
+ */
+export const TREEMAP_LEGEND_ITEMS = [
+  { name: 'All criteria passed', color: INCLUSION_REPORT_COLORS.allPassed },
+  { name: '1 criterion failed', color: INCLUSION_REPORT_COLORS.one },
+  { name: '2 criteria failed', color: INCLUSION_REPORT_COLORS.two },
+  { name: '3-4 criteria failed', color: INCLUSION_REPORT_COLORS.threeToFour },
+  { name: '5+ criteria failed', color: INCLUSION_REPORT_COLORS.allFailedOr5Plus },
+] as const
+
+/**
+ * Gray color used for filtered out/excluded items in treemap
+ */
+export const EXCLUDED_COLOR = '#CCCCCC' as const
+

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
@@ -431,7 +431,7 @@ const fetchInclusionReport = async (cohortDefinitionId: string, sourceKey: strin
   }
 }
 
-function handleDragEnd(event: any) {
+function handleDragEnd() {
   const newOrder = draggableAttritionStats.value.map(stat => stat.id)
   draggableAttritionStats.value = computeAttritionStats(inclusionReportResponse.value, newOrder)
 }
@@ -665,7 +665,6 @@ watch(
                 v-for="stat in inclusionReportResponse.inclusionRuleStats"
                 :key="stat.id"
                 :class="{ 'grayed-out': !isRuleChecked(stat.id) }"
-                class="cursor-move"
               >
                 <td>
                   <input type="checkbox" :checked="isRuleChecked(stat.id)" @change="toggleRuleSelection(stat.id)" />

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
@@ -19,7 +19,7 @@ import * as echarts from 'echarts'
 import { VueDraggable } from 'vue-draggable-plus'
 
 const props = defineProps<{
-  cohortDefinitionId: number
+  cohortDefinitionId: string
   sourceKey: string
   patientCount: number | null
   generationStatus?: 'idle' | 'pending' | 'complete' | 'failed'
@@ -406,7 +406,7 @@ function toggleAllRules() {
   }
 }
 
-const fetchInclusionReport = async (cohortDefinitionId: number, sourceKey: string) => {
+const fetchInclusionReport = async (cohortDefinitionId: string, sourceKey: string) => {
   isLoadingInclusionReport.value = true
 
   const modeId = selectedPersonEventView.value === 'PERSON' ? 1 : 0
@@ -706,4 +706,3 @@ watch(
 <style scoped>
 @import '../../styles/InclusionReport.scss';
 </style>
-

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
@@ -6,6 +6,13 @@ import { d2eWebapiService } from '@/query-filter/services/D2eWebapiService'
 import { computeAttritionStats } from './computeAttritionStats'
 import { convertTreemapData, formatTreemapTooltip } from './computeTreemapStats'
 import { shouldIncludeRect, calculateFilteredSummary } from './ruleSelectionFilter'
+import {
+  COLORS_ARRAY,
+  FUNNEL_THRESHOLDS,
+  FUNNEL_LEGEND_LABELS,
+  TREEMAP_LEGEND_ITEMS,
+  EXCLUDED_COLOR,
+} from './constants'
 import GroupButtons from '../GroupButtons.vue'
 import ChevronButton from '@/components/ChevronButton.vue'
 import * as echarts from 'echarts'
@@ -39,8 +46,6 @@ const visualizationOptions = [
   { value: 'ATTRITION', label: 'Attrition' },
   { value: 'INTERSECT', label: 'Intersect' },
 ]
-
-const colors = ['#fabfb4', '#fcdab6', '#dedcab', '#cdd99e', '#53bead']
 
 const inclusionReportResponse = computed(() => {
   return selectedPersonEventView.value === 'PERSON'
@@ -109,18 +114,15 @@ const funnelChartData = computed(() => {
 const renderFunnelChart = () => {
   if (!funnelChartRef.value || !funnelChartData.value) return
 
-  // Define thresholds and colors (hex codes from ohdsi atlas)
-  const thresholds = [0.1, 0.25, 0.5, 0.75]
-
   // Compute ratios relative to previous layer
   const ratios = funnelChartData.value.values.map((v, i) => (i === 0 ? 1 : v / funnelChartData.value.values[i - 1]))
 
   // Map each ratio to a color based on thresholds
   const layerColors = ratios.map(ratio => {
-    for (let i = 0; i < thresholds.length; i++) {
-      if (ratio <= thresholds[i]) return colors[i]
+    for (let i = 0; i < FUNNEL_THRESHOLDS.length; i++) {
+      if (ratio <= FUNNEL_THRESHOLDS[i]) return COLORS_ARRAY[i]
     }
-    return colors[colors.length - 1]
+    return COLORS_ARRAY[COLORS_ARRAY.length - 1]
   })
 
   const trace = {
@@ -130,7 +132,7 @@ const renderFunnelChart = () => {
     text: funnelChartData.value.hoverTexts,
     hoverinfo: 'text',
     textposition: 'inside',
-    texttemplate: '%{x}<br>%{percentInitial:.2%}',
+    texttemplate: 'N: %{x}<br> % remain: %{percentInitial:.2%}',
     constraintext: 'outside',
     textinfo: 'value+percent initial',
     marker: {
@@ -139,12 +141,47 @@ const renderFunnelChart = () => {
     hoverlabel: {
       bgcolor: '#f9f9f9', // css var doesn't work here
     },
+    showlegend: false, // Hide legend for main trace
   }
+
+  // Create dummy traces for legend - only for colors actually used
+  const usedColors = new Set(layerColors)
+  const legendTraces = COLORS_ARRAY.map((color, index) => ({
+    type: 'scatter',
+    x: [null],
+    y: [null],
+    mode: 'markers',
+    marker: {
+      size: 10,
+      color: color,
+    },
+    name: FUNNEL_LEGEND_LABELS[index],
+    showlegend: true,
+  })).filter((trace, index) => usedColors.has(COLORS_ARRAY[index]))
 
   const layout = {
     height: 800,
-    yaxis: { automargin: true },
-    xaxis: { automargin: true },
+    yaxis: {
+      automargin: true,
+      autorange: 'reversed',
+      showgrid: false,
+      zeroline: false,
+    },
+    xaxis: {
+      automargin: true,
+      showgrid: false,
+      showline: false,
+      showticklabels: false,
+      zeroline: false,
+    },
+    showlegend: true,
+    legend: {
+      orientation: 'v',
+      x: 1.02,
+      y: 1,
+      xanchor: 'left',
+      yanchor: 'top',
+    },
   }
 
   const chartConfig = {
@@ -152,7 +189,7 @@ const renderFunnelChart = () => {
     displayModeBar: false,
   }
 
-  plotly.newPlot(funnelChartRef.value, [trace], layout, chartConfig)
+  plotly.newPlot(funnelChartRef.value, [trace, ...legendTraces], layout, chartConfig)
 }
 
 const disposeTreemap = () => {
@@ -162,19 +199,77 @@ const disposeTreemap = () => {
   }
 }
 
-const renderTreemap = async () => {
-  if (!treemapChartRef.value || !treemapData.value) return
+// get colors used in the treemap data, except the EXCLUDED_COLOR (gray) used for filtered out rectangles
+const collectUsedColors = (node: any): Set<string> => {
+  const usedColors = new Set<string>()
 
-  await nextTick()
-  avaiableWidth.value = treemapChartRef.value.clientWidth
-  // Dispose and reinitialize chart
-  disposeTreemap()
-  echartsTreemap.value = echarts.init(treemapChartRef.value)
+  const collect = (n: any) => {
+    const isLeafNode = !n.children || n.children.length === 0
+    if (isLeafNode && n.itemStyle?.color && n.itemStyle.color !== EXCLUDED_COLOR) {
+      usedColors.add(n.itemStyle.color)
+    }
+    if (n.children) {
+      n.children.forEach(collect)
+    }
+  }
 
-  // Always apply filtering to treemap data
-  const dataToRender = applyFiltering(treemapData.value)
+  collect(node)
+  return usedColors
+}
 
-  const option: echarts.EChartsOption = {
+// filter legend items to only include colors that are actually used in the data
+const getActiveLegendItems = (usedColors: Set<string>) => {
+  return TREEMAP_LEGEND_ITEMS.filter(item => usedColors.has(item.color))
+}
+
+// create ECharts graphic for legend at the bottom center of the chart
+const createLegendGraphics = (legendItems: Array<{ name: string; color: string }>, chartWidth: number) => {
+  const ITEM_WIDTH = 180 // Approximate width per legend item
+  const LEGEND_BOTTOM = 17.5
+  const CIRCLE_RADIUS = 7.5
+  const TEXT_OFFSET = 20
+
+  const totalLegendWidth = legendItems.length * ITEM_WIDTH
+  const legendStartX = (chartWidth - totalLegendWidth) / 2
+
+  return legendItems
+    .map((item, index) => {
+      const xPos = legendStartX + index * ITEM_WIDTH
+      return [
+        {
+          type: 'circle',
+          id: `legend-circle-${index}`,
+          left: xPos,
+          bottom: LEGEND_BOTTOM,
+          z: 100,
+          shape: {
+            r: CIRCLE_RADIUS,
+          },
+          style: {
+            fill: item.color,
+          },
+        },
+        {
+          type: 'text',
+          id: `legend-text-${index}`,
+          left: xPos + TEXT_OFFSET,
+          bottom: LEGEND_BOTTOM,
+          z: 100,
+          style: {
+            text: item.name,
+            fontSize: 16,
+            fill: '#333',
+            textAlign: 'left',
+            textVerticalAlign: 'middle',
+          },
+        },
+      ]
+    })
+    .flat()
+}
+
+const createTreemapOption = (dataToRender: any, legendGraphics: any[]): echarts.EChartsOption => {
+  return {
     tooltip: {
       show: true,
       formatter: (params: any) => formatTreemapTooltip(params.data?.tooltip),
@@ -186,6 +281,7 @@ const renderTreemap = async () => {
       confine: true,
       padding: [8, 12],
     },
+    graphic: legendGraphics,
     series: [
       {
         type: 'treemap',
@@ -202,10 +298,32 @@ const renderTreemap = async () => {
           borderColor: '#000', // css var doesn't work here
           borderWidth: 0.3,
         },
+        bottom: 40, // Reserve space for legend at the bottom
       },
     ],
   }
+}
 
+const renderTreemap = async () => {
+  if (!treemapChartRef.value || !treemapData.value) return
+
+  await nextTick()
+  avaiableWidth.value = treemapChartRef.value.clientWidth
+
+  // Dispose and reinitialize chart
+  disposeTreemap()
+  echartsTreemap.value = echarts.init(treemapChartRef.value)
+
+  // Apply filtering to treemap data
+  const dataToRender = applyFiltering(treemapData.value)
+
+  // Collect colors and create legend
+  const usedColors = collectUsedColors(dataToRender)
+  const legendItems = getActiveLegendItems(usedColors)
+  const legendGraphics = createLegendGraphics(legendItems, treemapChartRef.value.clientWidth)
+
+  // Create and apply chart option
+  const option = createTreemapOption(dataToRender, legendGraphics)
   echartsTreemap.value.setOption(option)
 }
 
@@ -230,7 +348,7 @@ const applyFiltering = (node: any): any => {
   if (isLeafNode && !isIncluded) {
     // Gray out excluded leaf nodes
     newNode.itemStyle = {
-      color: '#CCCCCC', // gray out excluded rect in treemap
+      color: EXCLUDED_COLOR,
     }
   }
 
@@ -520,7 +638,7 @@ watch(
             </thead>
             <tbody v-if="selectedVisualization === 'ATTRITION'">
               <tr v-for="stat in draggableAttritionStats" :key="stat.id">
-                <td class="drag-icon">⋮⋮</td>
+                <td class="drag-icon">⋮</td>
                 <td class="reorder-buttons">
                   <ChevronButton
                     direction="up"

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
@@ -308,7 +308,7 @@ const renderTreemap = async () => {
   if (!treemapChartRef.value || !treemapData.value) return
 
   await nextTick()
-  avaiableWidth.value = treemapChartRef.value.clientWidth
+  availableWidth.value = treemapChartRef.value.clientWidth
 
   // Dispose and reinitialize chart
   disposeTreemap()
@@ -460,7 +460,7 @@ function moveRowDown(statId: number) {
   }
 }
 
-const avaiableWidth = ref(0)
+const availableWidth = ref(0)
 
 onMounted(() => {
   inclusionReportPersonResponse.value = null

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
@@ -1,11 +1,3 @@
-<script lang="ts">
-export default {
-  compatConfig: {
-    MODE: 3,
-  },
-}
-</script>
-
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue'
 import type { InclusionReportResponse } from '@/query-filter/types/InclusionReportTypes'
@@ -15,7 +7,9 @@ import { computeAttritionStats } from './computeAttritionStats'
 import { convertTreemapData, formatTreemapTooltip } from './computeTreemapStats'
 import { shouldIncludeRect, calculateFilteredSummary } from './ruleSelectionFilter'
 import GroupButtons from '../GroupButtons.vue'
+import ChevronButton from '@/components/ChevronButton.vue'
 import * as echarts from 'echarts'
+import { VueDraggable } from 'vue-draggable-plus'
 
 const props = defineProps<{
   cohortDefinitionId: number
@@ -35,6 +29,7 @@ const echartsTreemap = ref<any>(null)
 const allAnyOption = ref<'ALL' | 'ANY'>('ANY')
 const passedFailedOption = ref<'PASSED' | 'FAILED'>('PASSED')
 const checkedRulesIds = ref<number[]>([])
+const draggableAttritionStats = ref<ReturnType<typeof computeAttritionStats>>([])
 
 const personEventOptions = [
   { value: 'PERSON', label: 'By person' },
@@ -63,10 +58,6 @@ const treemapData = computed(() => {
   return convertTreemapData(data, inclusionReportResponse.value)
 })
 
-const attritionStats = computed(() => {
-  return computeAttritionStats(inclusionReportResponse.value)
-})
-
 const filteredSummary = computed(() => {
   if (!treemapData.value || checkedRulesIds.value.length === 0) {
     return { value: 0, percent: '0%' }
@@ -89,10 +80,10 @@ const shouldFetchInclusionReport = computed(() => {
 })
 
 const funnelChartData = computed(() => {
-  if (!inclusionReportResponse.value || attritionStats.value.length === 0) return null
+  if (!inclusionReportResponse.value || draggableAttritionStats.value.length === 0) return null
 
   const summary = inclusionReportResponse.value.summary
-  const stats = attritionStats.value
+  const stats = draggableAttritionStats.value
 
   // Build funnel data with base count as first level
   const labels = ['Total']
@@ -322,6 +313,35 @@ const fetchInclusionReport = async (cohortDefinitionId: number, sourceKey: strin
   }
 }
 
+function handleDragEnd(event: any) {
+  const newOrder = draggableAttritionStats.value.map(stat => stat.id)
+  draggableAttritionStats.value = computeAttritionStats(inclusionReportResponse.value, newOrder)
+}
+
+function getRowIndex(statId: number): number {
+  return draggableAttritionStats.value.findIndex(s => s.id === statId)
+}
+
+function moveRowUp(statId: number) {
+  const index = getRowIndex(statId)
+  if (index > 0) {
+    const newStats = [...draggableAttritionStats.value]
+    ;[newStats[index - 1], newStats[index]] = [newStats[index], newStats[index - 1]]
+    const newOrder = newStats.map(s => s.id)
+    draggableAttritionStats.value = computeAttritionStats(inclusionReportResponse.value, newOrder)
+  }
+}
+
+function moveRowDown(statId: number) {
+  const index = getRowIndex(statId)
+  if (index < draggableAttritionStats.value.length - 1) {
+    const newStats = [...draggableAttritionStats.value]
+    ;[newStats[index], newStats[index + 1]] = [newStats[index + 1], newStats[index]]
+    const newOrder = newStats.map(s => s.id)
+    draggableAttritionStats.value = computeAttritionStats(inclusionReportResponse.value, newOrder)
+  }
+}
+
 const avaiableWidth = ref(0)
 
 onMounted(() => {
@@ -340,6 +360,7 @@ watch(
     if (newResponse && newResponse.inclusionRuleStats) {
       // Initialize checkedRulesIds with all rule IDs
       checkedRulesIds.value = newResponse.inclusionRuleStats.map(r => r.id)
+      draggableAttritionStats.value = computeAttritionStats(newResponse)
     }
   }
 )
@@ -464,57 +485,84 @@ watch(
       </div>
 
       <div class="rules-section">
-        <table class="rules-table">
-          <thead>
-            <tr>
-              <th v-if="selectedVisualization === 'INTERSECT'">
-                <input
-                  type="checkbox"
-                  :checked="areAllRulesChecked()"
-                  @change="toggleAllRules()"
-                  title="Select/unselect all rules"
-                />
-              </th>
-              <th>ID</th>
-              <th class="rule-name">Inclusion rule</th>
-              <!-- count satisfying -->
-              <th>N</th>
-              <!-- percent satisfying -->
-              <th v-if="selectedVisualization === 'ATTRITION'">% remain</th>
-              <th v-else>% satisfied</th>
-              <!-- percent excluded -->
-              <th v-if="selectedVisualization === 'ATTRITION'">% diff</th>
-              <th v-else>% to-gain</th>
-            </tr>
-          </thead>
-          <tbody v-if="selectedVisualization === 'ATTRITION'">
-            <tr v-for="stat in attritionStats" :key="stat.id">
-              <td>{{ stat.id + 1 }}</td>
-              <td class="rule-name">{{ stat.name }}</td>
-              <td>{{ stat.countSatisfying.toLocaleString() }}</td>
-              <td>{{ stat.percentSatisfying }}</td>
-              <td>{{ stat.pctDiff }}</td>
-            </tr>
-          </tbody>
-          <tbody v-else>
-            <tr
-              v-for="stat in inclusionReportResponse.inclusionRuleStats"
-              :key="stat.id"
-              :class="{ 'grayed-out': !isRuleChecked(stat.id) }"
-            >
-              <td>
-                <input type="checkbox" :checked="isRuleChecked(stat.id)" @change="toggleRuleSelection(stat.id)" />
-              </td>
-              <td>{{ stat.id + 1 }}</td>
-              <td class="rule-name">
-                {{ stat.name }}
-              </td>
-              <td>{{ stat.countSatisfying.toLocaleString() }}</td>
-              <td>{{ stat.percentSatisfying }}</td>
-              <td>{{ stat.percentExcluded }}</td>
-            </tr>
-          </tbody>
-        </table>
+        <VueDraggable
+          :key="`${selectedPersonEventView}-${selectedVisualization}`"
+          v-model="draggableAttritionStats"
+          target=".rules-table tbody"
+          :disabled="selectedVisualization === 'INTERSECT'"
+          :animation="150"
+          @end="handleDragEnd"
+        >
+          <table class="rules-table">
+            <thead>
+              <tr>
+                <th v-if="selectedVisualization === 'INTERSECT'">
+                  <input
+                    type="checkbox"
+                    :checked="areAllRulesChecked()"
+                    @change="toggleAllRules()"
+                    title="Select/unselect all rules"
+                  />
+                </th>
+                <th v-if="selectedVisualization === 'ATTRITION'"></th>
+                <th v-if="selectedVisualization === 'ATTRITION'"></th>
+                <th class="rule-id">ID</th>
+                <th class="rule-name">Inclusion rule</th>
+                <!-- count satisfying -->
+                <th>N</th>
+                <!-- percent satisfying -->
+                <th v-if="selectedVisualization === 'ATTRITION'">% remain</th>
+                <th v-else>% satisfied</th>
+                <!-- percent excluded -->
+                <th v-if="selectedVisualization === 'ATTRITION'">% diff</th>
+                <th v-else>% to-gain</th>
+              </tr>
+            </thead>
+            <tbody v-if="selectedVisualization === 'ATTRITION'">
+              <tr v-for="stat in draggableAttritionStats" :key="stat.id">
+                <td class="drag-icon">⋮⋮</td>
+                <td class="reorder-buttons">
+                  <ChevronButton
+                    direction="up"
+                    :disabled="getRowIndex(stat.id) === 0"
+                    title="Move up"
+                    @click="moveRowUp(stat.id)"
+                  />
+                  <ChevronButton
+                    direction="down"
+                    :disabled="getRowIndex(stat.id) === draggableAttritionStats.length - 1"
+                    title="Move down"
+                    @click="moveRowDown(stat.id)"
+                  />
+                </td>
+                <td class="rule-id">{{ stat.id + 1 }}</td>
+                <td class="rule-name">{{ stat.name }}</td>
+                <td>{{ stat.countSatisfying.toLocaleString() }}</td>
+                <td>{{ stat.percentSatisfying }}</td>
+                <td>{{ stat.pctDiff }}</td>
+              </tr>
+            </tbody>
+            <tbody v-else>
+              <tr
+                v-for="stat in inclusionReportResponse.inclusionRuleStats"
+                :key="stat.id"
+                :class="{ 'grayed-out': !isRuleChecked(stat.id) }"
+                class="cursor-move"
+              >
+                <td>
+                  <input type="checkbox" :checked="isRuleChecked(stat.id)" @change="toggleRuleSelection(stat.id)" />
+                </td>
+                <td class="rule-id">{{ stat.id + 1 }}</td>
+                <td class="rule-name">
+                  {{ stat.name }}
+                </td>
+                <td>{{ stat.countSatisfying.toLocaleString() }}</td>
+                <td>{{ stat.percentSatisfying }}</td>
+                <td>{{ stat.percentExcluded }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </VueDraggable>
 
         <div v-if="selectedVisualization === 'INTERSECT'" class="filtered-summary">
           <p>Filtered Population: {{ filteredSummary.value.toLocaleString() }} ({{ filteredSummary.percent }})</p>

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/components/Samples.vue
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/components/Samples.vue
@@ -221,7 +221,7 @@ import { AgeFilter, GenderFilter, Sample, CreateSampleDTO } from '../types/Sampl
 import AppButton from '@/lib/ui/app-button.vue'
 
 const props = defineProps<{
-  cohortDefinitionId: number
+  cohortDefinitionId: string
   sourceKey: string
   patientCount: number | null
 }>()
@@ -494,4 +494,3 @@ const getGenderFromId = (conceptId: number) => {
 <style lang="scss" scoped>
 @import '../styles/Samples.scss';
 </style>
-

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/services/D2eWebapiService.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/services/D2eWebapiService.ts
@@ -198,7 +198,7 @@ export class D2eWebapiService {
   }
 
   public async getInclusionReport(
-    cohortDefinitionId: string | number,
+    cohortDefinitionId: string,
     sourceKey: string,
     modeId: number
   ): Promise<InclusionReportResponse> {

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/services/D2eWebapiService.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/services/D2eWebapiService.ts
@@ -198,7 +198,7 @@ export class D2eWebapiService {
   }
 
   public async getInclusionReport(
-    cohortDefinitionId: number,
+    cohortDefinitionId: string | number,
     sourceKey: string,
     modeId: number
   ): Promise<InclusionReportResponse> {
@@ -213,4 +213,3 @@ export class D2eWebapiService {
 }
 
 export const d2eWebapiService = new D2eWebapiService()
-

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/styles/InclusionReport.scss
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/styles/InclusionReport.scss
@@ -88,11 +88,12 @@ h4 {
   }
 
   &.reorder-buttons {
-    display:flex;
+    display: flex;
     flex-direction: column;
     align-items: center;
     padding: 0.1rem;
   }
+  cursor:inherit
 }
 
 .summary-table,

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/styles/InclusionReport.scss
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/styles/InclusionReport.scss
@@ -17,10 +17,15 @@
 }
 table {
   font-size: 16px;
-}
-.rule-name {
-  max-width: 70ch;
-  text-align: left;
+
+  .rule-name {
+    max-width: 70ch;
+    text-align: left;
+  }
+  
+  .rule-id {
+    text-align: left;
+  }
 }
 
 .inclusion-report-container {
@@ -65,7 +70,7 @@ h4 {
 
 .summary-table th,
 .rules-table th {
-  padding: 0.75rem;
+  padding: 0.5rem;
   font-weight: 500;
   border-bottom: 2px solid var(--color-ui-light-border, #ddd);
   color: #333;
@@ -73,8 +78,21 @@ h4 {
 
 .summary-table td,
 .rules-table td {
-  padding: 0.75rem;
-  border-bottom: 1px solid var(--color-ui-light-border, #ddd);
+  padding: 0.5rem;
+
+  &.drag-icon {
+    cursor: move;
+    padding: 0.1rem;
+    font-size: 24px;
+    text-align: center;
+  }
+
+  &.reorder-buttons {
+    display:flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.1rem;
+  }
 }
 
 .summary-table,
@@ -82,6 +100,9 @@ h4 {
   color: var(--color-ui-medium-text);
   tr.grayed-out {
     color: var(--color-mri-disabled-text);
+  }
+  tr {
+    border-bottom: 1px solid var(--color-ui-light-border, #ddd);
   }
 }
 

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/types/SamplesTypes.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/types/SamplesTypes.ts
@@ -39,7 +39,7 @@ export interface Sample {
 }
 
 export interface FetchSamplesResponse {
-  cohortDefinitionId: number | string
+  cohortDefinitionId: string
   sourceId: number
   generationStatus: 'COMPLETE' | 'PENDING' | 'FAILED' | string
   samples: Sample[]

--- a/ui/apps/vue-mri-ui-lib/src/query-filter/types/SamplesTypes.ts
+++ b/ui/apps/vue-mri-ui-lib/src/query-filter/types/SamplesTypes.ts
@@ -31,7 +31,7 @@ export interface Sample {
   name: string
   size: number
   createdDate: number
-  cohortDefinitionId: number
+  cohortDefinitionId: string
   sourceId: number
   age?: AgeFilter
   gender: GenderFilter
@@ -39,7 +39,7 @@ export interface Sample {
 }
 
 export interface FetchSamplesResponse {
-  cohortDefinitionId: number
+  cohortDefinitionId: number | string
   sourceId: number
   generationStatus: 'COMPLETE' | 'PENDING' | 'FAILED' | string
   samples: Sample[]


### PR DESCRIPTION
1. Enable inclusion rules reordering via drag-and-drop or buttons.
2. Add color legend for inclusion report charts


https://github.com/user-attachments/assets/4ac4fabf-5d62-49b9-a72a-6ce1e699e65b



### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)