### PR TITLE
[Integrate-1255] Fix update dataset metadata

### DIFF
--- a/ui/apps/portal/src/plugins/SystemAdmin/StudyOverview/StudyOverview.tsx
+++ b/ui/apps/portal/src/plugins/SystemAdmin/StudyOverview/StudyOverview.tsx
@@ -249,16 +249,33 @@ const StudyOverview: FC = () => {
     setFetchUpdatesLoading(true);
     const datasetsByFlow: Record<string, Study[]> = {};
     const apiRequests = [];
+
+    const sourceDatasets: Study[] = [];
+    const cacheDatasets: Study[] = [];
+
     datasets.forEach((item: Study) => {
       const flowName = item.plugin;
 
-      if (flowName === "custom-flow") return;
-      if (!datasetsByFlow[flowName]) {
-        datasetsByFlow[flowName] = [];
+      // Skip datasets with null plugin, custom-flow, or FHIR datasets
+      if (!flowName || flowName === "custom-flow" || item.type === "fhir" || item.type === "non_omop") return;
+
+      // Check if this is a cache/datamart dataset (has source_dataset_id attribute)
+      const hasSourceDatasetId = item.attributes?.some(
+        (attribute) => attribute.attributeId === "source_dataset_id"
+      );
+
+      if (hasSourceDatasetId) {
+        cacheDatasets.push(item);
+      } else if (item.type === "source") {
+        if (!datasetsByFlow[flowName]) {
+          datasetsByFlow[flowName] = [];
+        }
+        datasetsByFlow[flowName].push(item);
+        sourceDatasets.push(item);
       }
-      datasetsByFlow[flowName].push(item);
     });
 
+    // Create get_version_info flow runs for source datasets grouped by plugin
     for (const flow in datasetsByFlow) {
       apiRequests.push(
         api.dataflow.createGetVersionInfoFlowRun({
@@ -270,31 +287,31 @@ const StudyOverview: FC = () => {
               database_code: "",
               data_model: "",
               plugin: flow,
-              datasets: datasetsByFlow[flow].filter((dataset) =>
-                dataset.attributes?.some((attribute) => attribute.attributeId !== "source_dataset_id")
-              ),
+              datasets: datasetsByFlow[flow],
             },
           },
         })
       );
     }
-    apiRequests.push(
-      api.dataflow.createGetVersionInfoFlowRun({
-        flowRunName: "cache-get_version_info",
-        options: {
+
+    // Create get_version_info flow run for cache datasets
+    if (cacheDatasets.length > 0) {
+      apiRequests.push(
+        api.dataflow.createGetVersionInfoFlowRun({
+          flowRunName: "cache-get_version_info",
           options: {
-            flowActionType: "get_version_info",
-            token: "",
-            database_code: "",
-            data_model: "",
-            plugin: "create_cachedb_file_plugin",
-            datasets: datasets.filter(
-              (dataset) => dataset.attributes?.some((attribute) => attribute.attributeId === "source_dataset_id") // Filter out the datamart dataset
-            ),
+            options: {
+              flowActionType: "get_version_info",
+              token: "",
+              database_code: "",
+              data_model: "",
+              plugin: "create_cachedb_file_plugin",
+              datasets: cacheDatasets,
+            },
           },
-        },
-      })
-    );
+        })
+      );
+    }
 
     try {
       await Promise.all(apiRequests);


### PR DESCRIPTION
1. FHIR datasets are excluded ✓
Added check: if (item.type === "fhir") return;
Both source FHIR and cache FHIR datasets will NOT call get_version_info flows
2. Source datasets call plugin-specific get_version_info ✓
Only datasets with type === "source" (and not FHIR/non_omop) will call their plugin's get_version_info flow
This includes: omop_cdm_plugin, i2b2_plugin, data_management_plugin, hana_load_plugin, etc.
3. non_omop datasets are excluded ✓
Added check: if (item.type === "non_omop") return;
These datasets will NOT trigger get_version_info flows


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)