### PR TITLE
[Analyze-1264] Fix repeated axis prefixs in tooltip

### DIFF
--- a/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
@@ -272,10 +272,15 @@ export default {
             filterCardPath.pop()
             if (filterCardPath.length <= 1) {
               const defaultTitle = this.getText('MRI_PA_FILTERCARD_TITLE_BASIC_DATA')
-              category.name = `${defaultTitle} - ${category.name}`
+              // Only add prefix if it's not already there to prevent duplicate prefixes
+              if (!category.name || !category.name.startsWith(defaultTitle + ' - ')) {
+                category.name = `${defaultTitle} - ${category.name}`
+              }
             } else {
               const filterCard = this.getChartableFilterCardByInstanceId(filterCardPath.join('.'))
-              category.name = `${filterCard.name} - ${category.name}`
+              if (!category.name || !category.name.startsWith(filterCard.name + ' - ')) {
+                category.name = `${filterCard.name} - ${category.name}`
+              }
             }
           }
         })
@@ -337,4 +342,3 @@ export default {
   },
 }
 </script>
-

--- a/ui/apps/vue-mri-ui-lib/src/components/StackBarCohortCompare.vue
+++ b/ui/apps/vue-mri-ui-lib/src/components/StackBarCohortCompare.vue
@@ -156,7 +156,11 @@ export default {
           } else {
             filterCardName = this.getMriFrontendConfig.getFilterCardByPath(sParent).getName()
           }
-          category.name = `${filterCardName} - ${this.getMriFrontendConfig.getAttributeByPath(category.id).getName()}`
+          const attributeName = this.getMriFrontendConfig.getAttributeByPath(category.id).getName()
+          // prevent duplicate prefixes
+          if (!category.name || !category.name.startsWith(filterCardName + ' - ')) {
+            category.name = `${filterCardName} - ${attributeName}`
+          }
         } else {
           category.name = this.getText('MRI_PA_VIEW_COHORT_TITLE')
           category.id = 'cohortName' // Use saved name for bar label

--- a/ui/apps/vue-mri-ui-lib/src/store/modules/chartUtils.ts
+++ b/ui/apps/vue-mri-ui-lib/src/store/modules/chartUtils.ts
@@ -137,7 +137,12 @@ const getters = {
             filterCardName = getters.getMriFrontendConfig.getFilterCardByPath(sParent).getName()
           }
 
-          measure.name = `${filterCardName} - ${getters.getMriFrontendConfig.getAttributeByPath(measure.id).getName()}`
+          // Only add prefix if it's not already there to prevent duplicate prefixes
+          const attributeName = getters.getMriFrontendConfig.getAttributeByPath(measure.id).getName()
+
+          if (!measure.name || !measure.name.startsWith(filterCardName + ' - ')) {
+            measure.name = `${filterCardName} - ${attributeName}`
+          }
         })
 
         let bHasDummyCategory = false


### PR DESCRIPTION
Fix repeated axis prefixs in PA bar chart's tooltip.

<img width="1100" height="816" alt="Screenshot 2025-12-04 at 2 50 38 PM" src="https://github.com/user-attachments/assets/d0930455-374b-4202-84a4-5f5eabfef09b" />


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)