### PR TITLE
[Analyze-1285] Display only leaf-level concept for treemap rect name

### DIFF
--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.scss
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.scss
@@ -1,0 +1,13 @@
+.treemap-tooltip {
+  max-width: 80ch;
+  word-wrap: break-word;
+  white-space: normal;
+
+  .tooltip-title {
+    div {
+      word-wrap: break-word;
+      white-space: normal;
+      overflow-wrap: break-word;
+    }
+  }
+}

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.scss
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.scss
@@ -5,7 +5,6 @@
 
   .tooltip-title {
     div {
-      word-wrap: break-word;
       white-space: normal;
       overflow-wrap: break-word;
     }

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -17,16 +17,16 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConceptId
     tooltip: {
       formatter: function (info: any) {
         const value = info.value;
-        const conceptPath = info.name;
         const numPersons = value[0];
         const recordsPerPerson = value[1];
         const percentPersons = value[2];
+        const conceptPath = value[4] || info.name;
 
         // Parse conceptPath string, replace || with breaklines with growing indentation
         const parsedConceptPath = conceptPath
           .split("||")
           .map((e: string, index: number) => {
-            return e + "<br>" + "&nbsp;".repeat(index + 1);
+            return `<div style="padding-left: ${index * 10}px">${e.trim()}</div>`;
           })
           .join("");
         return [
@@ -37,10 +37,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConceptId
         ].join("");
       },
       confine: true,
-      textStyle: {
-        overflow: "break",
-        width: 10,
-      },
+      className: "treemap-tooltip",
     },
     toolbox: {
       show: true,

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
@@ -74,12 +74,13 @@ const TreeMapChartTable: FC<TreeMapChartTableProps> = ({ title, data, setSelecte
     } else {
       // Parse existing format for treemap chart
       const mappedData = treeMapTableData.map((obj: any) => ({
-        name: obj["CONCEPTPATH"],
+        name: obj["CONCEPTPATH"]?.split("||").pop()?.trim() || obj["CONCEPTPATH"],
         value: [
           obj["NUMPERSONS"],
           obj["RECORDSPERPERSON"] ? obj["RECORDSPERPERSON"] : obj["LENGTHOFERA"],
           obj["PERCENTPERSONS"],
           obj["CONCEPTID"],
+          obj["CONCEPTPATH"],
         ],
       }));
       setTreeMapChartData(mappedData);


### PR DESCRIPTION
Display only leaf-level concept for treemap rect name and limit width of tooltip to 80ch.
<img width="1021" height="755" alt="Screenshot 2025-12-08 at 5 27 33 PM" src="https://github.com/user-attachments/assets/fa529340-0902-4dea-805c-323f6d8067e3" />


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)