### PR TITLE
Fix numeric barchart. Improve typing

### DIFF
--- a/ui/apps/vue-mri-ui-lib/src/store/modules/chartUtils.ts
+++ b/ui/apps/vue-mri-ui-lib/src/store/modules/chartUtils.ts
@@ -31,13 +31,15 @@ const getters = {
   dataToTraces:
     (state, getters) =>
     (chartData, selection = [], totalSelected = 0) => {
-      const xAxes = chartData.categories.filter(category => category.axis === Constants.AxisId.X)
+      const xAxes: { id: string; axis: number; name: string }[] = chartData.categories.filter(
+        category => category.axis === Constants.AxisId.X
+      )
       // Flag to toggle the bar chart category type
       chartData.axisType = xAxes.length > 1 ? 'multicategory' : 'category'
       // Get the unique y-axis attribute id if any
       const yAxis = chartData.categories.filter(category => category.axis === Constants.AxisId.Y)
 
-      const categoryArray = []
+      const categoryArray: { name: string | number; data: Record<string, string | number>[] }[] = []
       if (yAxis.length !== 0) {
         // Dictionary-based data categorization based on the unique y-axis attribute
         const yAttrKey = yAxis[0].id
@@ -76,7 +78,9 @@ const getters = {
         // Custom tooltip labelling
         let hoverTemplate = ''
         if (xAxes.length === 1) {
-          xData = category.data.map(data => truncateAtWordBoundary(data[xAxes[0].id], Constants.XAxisLabelMaxLength))
+          xData = category.data.map(data =>
+            truncateAtWordBoundary(String(data[xAxes[0].id]), Constants.XAxisLabelMaxLength)
+          )
           customdataArray = category.data.map(dataPoint => ({
             x: xAxes,
             y: yAxis,
@@ -86,7 +90,7 @@ const getters = {
         } else {
           // Truncate labels for x-axis display
           xData = xAxes.map(xAxis =>
-            category.data.map(data => truncateAtWordBoundary(data[xAxis.id], Constants.XAxisLabelMaxLength))
+            category.data.map(data => truncateAtWordBoundary(String(data[xAxis.id]), Constants.XAxisLabelMaxLength))
           )
           // Build customdata array with full labels for each data point
           customdataArray = category.data.map(dataPoint => {
@@ -325,4 +329,3 @@ export default {
   actions,
   mutations,
 }
-


### PR DESCRIPTION
`patient.attribute.Age` is number `39`. `patient.attribute.raceconceptid` is string `"0"`. Barchart works for raceconceptid but was blank for age. Code was failing where a string method was being used on the number.

<img width="584" height="280" alt="Screenshot 2025-12-11 at 1 28 41 PM" src="https://github.com/user-attachments/assets/812a73fd-ac3e-4dc8-9c5d-f95f4dcb2849" />
<img width="626" height="277" alt="Screenshot 2025-12-11 at 1 29 11 PM" src="https://github.com/user-attachments/assets/b51e4cb8-e494-4641-b927-4597aa205f7c" />

X1 with age works now:
<img width="1128" height="475" alt="Screenshot 2025-12-11 at 1 34 44 PM" src="https://github.com/user-attachments/assets/d6518369-ebea-4e11-8f63-6a6fe4513b99" />
