### PR TITLE
[Analyze 1680] Add catch on error when db operations fail for concept records count

### DIFF
--- a/functions/d2e-webapi/src/api/JobPluginsAPI.ts
+++ b/functions/d2e-webapi/src/api/JobPluginsAPI.ts
@@ -48,7 +48,7 @@ export class JobPluginsAPI {
     }
   }
 
-  async getLatestSuccessfulDataCharacterizationResultsSchemaName(
+  async getConceptRecordsCountResultsSchemaName(
     datasetId: string
   ): Promise<string> {
     try {
@@ -64,7 +64,10 @@ export class JobPluginsAPI {
         return "";
       }
 
-      if (result.data.state_type === "COMPLETED") {
+      if (
+        result.data.state_type === "COMPLETED" &&
+        result.data.parameters.options.executeConceptRecordCount !== false
+      ) {
         return result.data.parameters.options.resultsSchema;
       } else {
         return "";

--- a/functions/d2e-webapi/src/services/cdmresults.service.ts
+++ b/functions/d2e-webapi/src/services/cdmresults.service.ts
@@ -1,24 +1,32 @@
 import { TrexDAO } from "../dao/trex.dao.ts";
 import { ICdmresultsConceptRecordCountResponseDto } from "../dto/cdmresults.ts";
 import { JobPluginsAPI } from "../api/JobPluginsAPI.ts";
+import { IConceptRecordCount } from "../dao/types.ts";
 
 export const getConceptRecordCount = async (
   token: string,
   datasetId: string,
   conceptIds: number[]
 ): Promise<ICdmresultsConceptRecordCountResponseDto> => {
-  const trexDao = await TrexDAO.getTrexDao(token, datasetId);
-
   const jobPluginsApi = new JobPluginsAPI(token);
   const dcResultSchemaName =
-    await jobPluginsApi.getLatestSuccessfulDataCharacterizationResultsSchemaName(
-      datasetId
-    );
+    await jobPluginsApi.getConceptRecordsCountResultsSchemaName(datasetId);
 
-  const results = await trexDao.getConceptRecordCount(
-    conceptIds,
-    dcResultSchemaName
-  );
+  let results: IConceptRecordCount[] = [];
+  try {
+    const trexDao = await TrexDAO.getTrexDao(token, datasetId);
+    results = await trexDao.getConceptRecordCount(
+      conceptIds,
+      dcResultSchemaName
+    );
+  } catch (error) {
+    // HOTFIX:
+    // If there is an issue with db connection or query to get concept count,
+    // dont throw error, instead log error message and set results to empty array
+    console.error(`Error querying for concept record count: ${error}`);
+    results = [];
+  }
+
   const mappedResults: ICdmresultsConceptRecordCountResponseDto = results.map(
     (e) => ({
       [e.CONCEPT_ID.toString()]: [


### PR DESCRIPTION
- partially resolves: https://github.com/OHDSI/Data2Evidence/issues/1680

1. hotfix for release

- Example scenario: When dc results schema exist, but `achilles_result_concept_count` table does not exist 
  Error is logged on console as:
  <img width="1915" height="1064" alt="conceptbug" src="https://github.com/user-attachments/assets/57d7e95a-13dc-4936-8176-b763869261cc" />

  And concepts are still shown on concept screen
  <img width="2549" height="1309" alt="image" src="https://github.com/user-attachments/assets/8c79d7a1-8dac-48f6-8fe4-d9149c652e7c" />


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)