### PR TITLE
get sql query from admin portal

### DIFF
--- a/functions/parquet-export/env.ts
+++ b/functions/parquet-export/env.ts
@@ -4,4 +4,5 @@ export const env = {
   NODE_ENV: _env.NODE_ENV,
   SERVICE_ROUTES: _env.SERVICE_ROUTES ? JSON.parse(_env.SERVICE_ROUTES) : {},
   SQL_QUERY_TEMPLATES: _env.SQL_QUERY_TEMPLATES ? JSON.parse(_env.SQL_QUERY_TEMPLATES) : null,
+  DEFAULT_QUERY_TYPE: _env.DEFAULT_QUERY_TYPE || "shinylive",
 };

--- a/functions/parquet-export/index.ts
+++ b/functions/parquet-export/index.ts
@@ -18,7 +18,7 @@ interface DatasetMetadata {
   databaseCode: string;
   schemaName: string;
   vocabSchemaName: string;
-  resultSchemaName: string;
+  resultsSchemaName: string;
 }
 
 function isValidUUID(str: unknown): str is string {

--- a/functions/parquet-export/index.ts
+++ b/functions/parquet-export/index.ts
@@ -146,7 +146,17 @@ async function resolveTemplate(
 
   try {
     const result = await channel.get(url, { headers: { Authorization: token }, timeout: 20000 });
-    const data = result.data as { sql: string; queryName: string };
+    const data = result.data as { sql?: unknown; queryName?: unknown };
+    if (typeof data.sql !== "string" || data.sql.trim() === "" ||
+        typeof data.queryName !== "string" || data.queryName.trim() === "") {
+      logger.error("Invalid portal service response for SQL template", {
+        templateId,
+        datasetId,
+        type,
+        name,
+      });
+      throw new Error("Invalid portal service response");
+    }
     return { id: data.queryName, name: data.queryName, sqlText: data.sql, createdAt: "", updatedAt: "" };
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 404) {
@@ -216,13 +226,13 @@ router.get("/", async (req: Request, res: Response) => {
       return res.status(400).json({ error: "Invalid parameter", message: "cohortId must be numeric" });
     }
     if (!isValidTemplateId(templateId)) {
-      return res.status(400).json({ error: "Invalid parameter", message: "templateId contains invalid characters" });
+      return res.status(400).json({ error: "Invalid parameter", message: "templateId must contain only letters, numbers, underscores, or hyphens" });
     }
     if (!isValidTemplateId(name)) {
-      return res.status(400).json({ error: "Invalid parameter", message: "name contains invalid characters" });
+      return res.status(400).json({ error: "Invalid parameter", message: "name must contain only letters, numbers, underscores, or hyphens" });
     }
     if (!isValidTemplateId(type)) {
-      return res.status(400).json({ error: "Invalid parameter", message: "type contains invalid characters" });
+      return res.status(400).json({ error: "Invalid parameter", message: "type must contain only letters, numbers, underscores, or hyphens" });
     }
 
     let template: SqlQueryTemplate;

--- a/functions/parquet-export/index.ts
+++ b/functions/parquet-export/index.ts
@@ -114,7 +114,13 @@ function substituteTemplateParams(
   return result;
 }
 
-async function resolveTemplate(templateId: string, token: string): Promise<SqlQueryTemplate> {
+async function resolveTemplate(
+  templateId: string,
+  datasetId: string,
+  type: string,
+  name: string,
+  token: string
+): Promise<SqlQueryTemplate> {
   const envTemplates = env.SQL_QUERY_TEMPLATES;
   if (envTemplates) {
     const sqlText = envTemplates[templateId];
@@ -125,23 +131,28 @@ async function resolveTemplate(templateId: string, token: string): Promise<SqlQu
   }
 
   const serviceRoutes = env.SERVICE_ROUTES || {};
-  const baseUrl = serviceRoutes.strategusAnalysis || serviceRoutes["strategus-analysis"] || "";
+  const baseUrl = serviceRoutes.portalServer || serviceRoutes["portal-server"] || "";
   if (!baseUrl) {
-    throw new Error("Strategus Analysis Service URL not configured and SQL_QUERY_TEMPLATES not set");
+    throw new Error("Portal Server URL not configured and SQL_QUERY_TEMPLATES not set");
   }
 
   // @ts-ignore Trex global
-  const channel = Trex.tokioChannel("d2e-functions/strategus-analysis");
-  const url = `${baseUrl}/strategus/analysis/template/${templateId}`;
+  const channel = Trex.tokioChannel("d2e-functions/portal");
+  const url = `${baseUrl}/system-portal/dataset/dashboard-code-query?` +
+    `datasetId=${encodeURIComponent(datasetId)}` +
+    `&type=${encodeURIComponent(type)}` +
+    `&name=${encodeURIComponent(name)}` +
+    `&queryName=${encodeURIComponent(templateId)}`;
 
   try {
     const result = await channel.get(url, { headers: { Authorization: token }, timeout: 20000 });
-    return result.data as SqlQueryTemplate;
+    const data = result.data as { sql: string; queryName: string };
+    return { id: data.queryName, name: data.queryName, sqlText: data.sql, createdAt: "", updatedAt: "" };
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 404) {
       throw new Error(`Template not found: ${templateId}`);
     }
-    throw new Error("Template service unavailable");
+    throw new Error("Portal service unavailable");
   }
 }
 
@@ -181,11 +192,20 @@ router.get("/", async (req: Request, res: Response) => {
     const datasetId = req.query.datasetId as string | undefined;
     const cohortId = req.query.cohortId as string | undefined;
     const templateId = req.query.templateId as string | undefined;
+    const name = req.query.name as string | undefined;
+    const type = (req.query.type as string | undefined) || env.DEFAULT_QUERY_TYPE;
 
     if (!datasetId || !cohortId || !templateId) {
       return res.status(400).json({
         error: "Missing required parameters",
         message: "datasetId, cohortId, and templateId are required",
+      });
+    }
+
+    if (!name) {
+      return res.status(400).json({
+        error: "Missing required parameter",
+        message: "name is required",
       });
     }
 
@@ -198,10 +218,16 @@ router.get("/", async (req: Request, res: Response) => {
     if (!isValidTemplateId(templateId)) {
       return res.status(400).json({ error: "Invalid parameter", message: "templateId contains invalid characters" });
     }
+    if (!isValidTemplateId(name)) {
+      return res.status(400).json({ error: "Invalid parameter", message: "name contains invalid characters" });
+    }
+    if (!isValidTemplateId(type)) {
+      return res.status(400).json({ error: "Invalid parameter", message: "type contains invalid characters" });
+    }
 
     let template: SqlQueryTemplate;
     try {
-      template = await resolveTemplate(templateId, token);
+      template = await resolveTemplate(templateId, datasetId, type, name, token);
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes("not found")) {
@@ -226,7 +252,7 @@ router.get("/", async (req: Request, res: Response) => {
       return res.status(400).json({ error: "Invalid parameter", message: "format must be 'parquet' or 'json'" });
     }
 
-    const reservedQueryParams = new Set(['datasetId', 'cohortId', 'templateId', 'format']);
+    const reservedQueryParams = new Set(['datasetId', 'cohortId', 'templateId', 'format', 'name', 'type']);
 
     const additionalParams: Record<string, string> = {};
     for (const [key, value] of Object.entries(req.query)) {


### PR DESCRIPTION
This pull request updates the `parquet-export` function to enhance how SQL query templates are resolved and to improve parameter validation and error handling. The changes primarily focus on switching to a new portal service endpoint for fetching query templates, requiring additional parameters, and making naming more consistent.
