### PR TITLE
[Analyze-605] Add endpoint to check if schema is able to materialize cohorts

### DIFF
--- a/functions/analytics-svc/api/swagger/swagger.yaml
+++ b/functions/analytics-svc/api/swagger/swagger.yaml
@@ -628,6 +628,28 @@ paths:
           description: Error
           schema:
             $ref: "#/definitions/Error"
+  /cohort/can-materialize-cohort:
+      x-swagger-router-controller: cohort
+      get:
+        description: Checks if the resultsSchema based on the datasetId is compatible for cohorts to be materialized
+        operationId: checkIfSchemaCanMaterializeCohort
+        produces:
+          - application/json
+        parameters:
+          - name: datasetId
+            in: query
+            description: Id of dataset
+            required: true
+            type: string
+        responses:
+          "200":
+            description: success
+            schema: 
+              type: boolean
+          default:
+            description: Error
+            schema:
+              $ref: "#/definitions/Error"
   /cohort/{filterColumn}/{filterValue}:
     x-swagger-router-controller: cohort
     get:

--- a/functions/analytics-svc/src/api/controllers/cohort.ts
+++ b/functions/analytics-svc/src/api/controllers/cohort.ts
@@ -488,6 +488,28 @@ export async function deleteCohort(req: IMRIRequest, res: Response) {
     }
 }
 
+export async function checkIfSchemaCanMaterializeCohort(
+    req: IMRIRequest,
+    res: Response
+) {
+    try {
+        const analyticsConnection = await getCohortAnalyticsConnection(req);
+
+        const cohortEndpoint = await CohortEndpoint.createCohortEndpoint(
+            analyticsConnection,
+            req.dbCredentials.studyAnalyticsCredential.resultsSchemaName,
+            req.dbCredentials.studyAnalyticsCredential.dialect,
+            req.dbCredentials.studyAnalyticsCredential.authentication_mode
+        );
+
+        const result = await cohortEndpoint.checkIfSchemaCanMaterializeCohort();
+        res.status(200).send(result);
+    } catch (err) {
+        logger.error(err);
+        res.status(500).send(MRIEndpointErrorHandler({ err, language }));
+    }
+}
+
 // Form and return cohort object
 async function getCohortFromMriQuery(
     req: IMRIRequest,

--- a/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
+++ b/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
@@ -576,4 +576,53 @@ export class CohortEndpoint {
             throw err;
         }
     }
+
+    public async checkIfSchemaCanMaterializeCohort(): Promise<boolean> {
+        // Checks if the schema has the required tables to materialize cohorts
+        // To successfully materialize cohort, schema must have the following tables
+        // 1. cohort
+        // 2. cohort_definition
+
+        let sql, sqlParams;
+        if (this.connection.constructor.name === "TrexConnection") {
+            sql = `
+                    select
+                        count(1) AS COUNT_TABLES
+                    from
+                        information_schema.tables
+                    where
+                        table_catalog = %s
+                        and table_schema = %s
+                        and table_name in ('cohort', 'cohort_definition');
+                    `;
+            sqlParams = [
+                this.connection.connection.__database, // Check against cache file instead of source db
+                this.schemaName,
+            ];
+        } else {
+            sql = `
+                    SELECT
+                        COUNT(1) AS COUNT_TABLES
+                    FROM
+                        SYS.TABLES
+                    WHERE
+                        SCHEMA_NAME = %s
+                        AND TABLE_NAME IN ('COHORT', 'COHORT_DEFINITION');
+                    `;
+            sqlParams = [this.schemaName];
+        }
+        try {
+            const query = QueryObject.format(sql, ...sqlParams);
+            const result = await this.executeCohortQuery(query);
+            if (result.data[0]) {
+                // Result must be 2 for function to return true, meaning that both cohort and cohort definition tables exist
+                return result.data[0].COUNT_TABLES === 2;
+            } else {
+                return false;
+            }
+        } catch (err) {
+            logger.error(`Failed to check if schema can materialize cohort`);
+            throw err;
+        }
+    }
 }


### PR DESCRIPTION
- partially resolves: https://github.com/OHDSI/Data2Evidence/issues/605

1. Add new endpoint to analytics-svc `/cohort/can-materialize-cohort`, to check if schema is compatible to materialize cohort, returns a boolean

Still requires frontend change to call this new endpoint

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)