### PR TITLE
feat: enhance TypeaheadField filtering and sorting logic; add AnalyticsIcon component

### DIFF
--- a/ui/apps/wizards/src/components/StepForm.tsx
+++ b/ui/apps/wizards/src/components/StepForm.tsx
@@ -6,6 +6,7 @@ import { generateFormSubmitDeepLink } from "../utils/deepLinks";
 import { fetchCdwConfig } from "../config/cdwConfig";
 import type { ConfigMeta } from "../config/cdwConfig";
 import { TypeaheadField } from "./TypeaheadField";
+import { AnalyticsIcon } from "./icons/AnalyticsIcon";
 import styles from "./StepForm.module.css";
 
 /**
@@ -382,7 +383,7 @@ export function StepForm() {
             disabled={!allRequiredFieldsFilled() || !isValid}
             className={`${styles.button} ${styles.buttonPrimary}`}
           >
-            <span>▦</span> {submitLabel}
+            <AnalyticsIcon /> {submitLabel}
           </button>
         </div>
       </form>

--- a/ui/apps/wizards/src/components/TypeaheadField.tsx
+++ b/ui/apps/wizards/src/components/TypeaheadField.tsx
@@ -29,7 +29,7 @@ interface Option {
  * Filter and sort options: exact matches first, then starts-with, then contains.
  * Case-insensitive. Returns all options if query is empty.
  */
-function filterAndSort(items: Option[], query: string): Option[] {
+export function filterAndSort(items: Option[], query: string): Option[] {
   if (!query) return items;
   const q = query.toLowerCase();
   const exact: Option[] = [];
@@ -38,9 +38,10 @@ function filterAndSort(items: Option[], query: string): Option[] {
 
   for (const item of items) {
     const label = item.label.toLowerCase();
-    if (label === q) exact.push(item);
-    else if (label.startsWith(q)) startsWith.push(item);
-    else if (label.includes(q)) contains.push(item);
+    const value = item.value.toLowerCase();
+    if (label === q || value === q) exact.push(item);
+    else if (label.startsWith(q) || value.startsWith(q)) startsWith.push(item);
+    else if (label.includes(q) || value.includes(q)) contains.push(item);
   }
 
   return [...exact, ...startsWith, ...contains];
@@ -228,7 +229,7 @@ export function TypeaheadField({
                       }}
                       onMouseEnter={() => setHighlightIndex(i)}
                     >
-                      {option.label}
+                      {option.label !== option.value ? `${option.label} (${option.value})` : option.label}
                     </li>
                   ))}
               </ul>

--- a/ui/apps/wizards/src/components/__tests__/TypeaheadField.test.ts
+++ b/ui/apps/wizards/src/components/__tests__/TypeaheadField.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { filterAndSort } from "../TypeaheadField";
+
+describe("filterAndSort", () => {
+  it("should return all items when query is empty", () => {
+    const items = [
+      { label: "Alpha", value: "A1" },
+      { label: "Beta", value: "B2" },
+    ];
+    expect(filterAndSort(items, "")).toEqual(items);
+  });
+
+  describe("text and value are different", () => {
+    const items = [
+      { label: "Alpha", value: "A1" },
+      { label: "Alpha extended", value: "A1-A5" },
+      { label: "Alpha minor", value: "A1.0" },
+      { label: "Beta", value: "B2" },
+    ];
+
+    it("should match by value when label does not contain query", () => {
+      const result = filterAndSort(items, "A1");
+      expect(result).toHaveLength(3);
+      expect(result.map((r) => r.value)).toEqual(["A1", "A1-A5", "A1.0"]);
+    });
+
+    it("should match by label text", () => {
+      const result = filterAndSort(items, "alpha");
+      expect(result).toHaveLength(3);
+      expect(result.map((r) => r.value)).toContain("A1");
+      expect(result.map((r) => r.value)).toContain("A1-A5");
+      expect(result.map((r) => r.value)).toContain("A1.0");
+    });
+
+    it("should not filter out items when query matches value but not label", () => {
+      // Searching by value code "A1" — labels like "Alpha" don't contain "A1"
+      // but should still appear because the value matches
+      const result = filterAndSort(items, "A1");
+      expect(result).not.toHaveLength(0);
+      expect(result.find((r) => r.value === "A1")).toBeDefined();
+      expect(result.find((r) => r.value === "A1-A5")).toBeDefined();
+      expect(result.find((r) => r.value === "A1.0")).toBeDefined();
+    });
+
+    it("should prioritize exact value match over starts-with", () => {
+      const result = filterAndSort(items, "A1");
+      expect(result[0].value).toBe("A1");
+    });
+  });
+
+  describe("text and value are the same", () => {
+    const items = [
+      { label: "A1", value: "A1" },
+      { label: "A1.0", value: "A1.0" },
+      { label: "B2", value: "B2" },
+    ];
+
+    it("should match items where label equals value", () => {
+      const result = filterAndSort(items, "A1");
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ label: "A1", value: "A1" });
+      expect(result[1]).toEqual({ label: "A1.0", value: "A1.0" });
+    });
+  });
+
+  describe("only value present (label falls back to value)", () => {
+    const items = [
+      { label: "A1", value: "A1" },
+      { label: "A1-A5", value: "A1-A5" },
+      { label: "B2", value: "B2" },
+    ];
+
+    it("should match via the fallback label that equals value", () => {
+      const result = filterAndSort(items, "A1");
+      expect(result).toHaveLength(2);
+      expect(result.map((r) => r.value)).toEqual(["A1", "A1-A5"]);
+    });
+
+    it("should not match unrelated items", () => {
+      const result = filterAndSort(items, "B2");
+      expect(result).toHaveLength(1);
+      expect(result[0].value).toBe("B2");
+    });
+  });
+
+  describe("sorting priority", () => {
+    it("should order exact > starts-with > contains", () => {
+      const items = [
+        { label: "contains abc in middle", value: "X3" },
+        { label: "abc starts here", value: "X2" },
+        { label: "abc", value: "X1" },
+      ];
+      const result = filterAndSort(items, "abc");
+      expect(result[0].label).toBe("abc");
+      expect(result[1].label).toBe("abc starts here");
+      expect(result[2].label).toBe("contains abc in middle");
+    });
+
+    it("should order exact value match before starts-with value match", () => {
+      const items = [
+        { label: "Gamma", value: "A1.0" },
+        { label: "Delta", value: "A1" },
+      ];
+      const result = filterAndSort(items, "A1");
+      expect(result[0].value).toBe("A1");
+      expect(result[1].value).toBe("A1.0");
+    });
+  });
+});

--- a/ui/apps/wizards/src/components/icons/AnalyticsIcon.tsx
+++ b/ui/apps/wizards/src/components/icons/AnalyticsIcon.tsx
@@ -1,0 +1,34 @@
+interface AnalyticsIconProps {
+  size?: number;
+}
+
+export function AnalyticsIcon({ size = 16 }: AnalyticsIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 45 45"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ verticalAlign: "middle" }}
+    >
+      <mask
+        id="analytics-icon-mask"
+        style={{ maskType: "alpha" }}
+        maskUnits="userSpaceOnUse"
+        x="0"
+        y="0"
+        width="45"
+        height="45"
+      >
+        <rect width="44.353" height="44.3539" fill="currentColor" />
+      </mask>
+      <g mask="url(#analytics-icon-mask)">
+        <path
+          d="M13.4228 31.8293H16.503V22.4351H13.4228V31.8293ZM28.4663 31.8293H31.5465V12.7327H28.4663V31.8293ZM20.9411 31.8293H24.0209V26.3465H20.9411V31.8293ZM20.9411 22.4351H24.0209V19.3548H20.9411V22.4351ZM9.03925 39.4388C8.08443 39.4388 7.26236 39.0941 6.57304 38.4048C5.88372 37.7155 5.53906 36.8934 5.53906 35.9385V9.05453C5.53906 8.09784 5.88372 7.27406 6.57304 6.58319C7.26236 5.89231 8.08443 5.54688 9.03925 5.54688H35.9227C36.8794 5.54688 37.7031 5.89231 38.394 6.58319C39.0849 7.27406 39.4303 8.09784 39.4303 9.05453V35.9385C39.4303 36.8934 39.0849 37.7155 38.394 38.4048C37.7031 39.0941 36.8794 39.4388 35.9227 39.4388H9.03925ZM9.03925 35.9385H35.9227V9.05453H9.03925V35.9385Z"
+          fill="currentColor"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/ui/apps/wizards/vite.config.ts
+++ b/ui/apps/wizards/vite.config.ts
@@ -63,8 +63,6 @@ export default defineConfig(({ command, mode }) => {
     },
     test: {
       globals: true,
-      environment: "jsdom",
-      setupFiles: ["./src/test/setup.ts"],
     },
   };
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,7 +14,7 @@
     "build-ui5": "bunx ui5 build -a --clean-dest --dest ./resources/ui5",
     "build-gateway": "cd apps/gateway-proxy && bun run build",
     "build-starboard": "node scripts/build-starboard.js",
-    "build-wizards": "cd apps/wizards && bun run build",
+    "build-wizards": "cd apps/wizards && bun run test && bun run build",
     "mri-vue": "bun install; bunx nx build vue-mri",
     "portal-ui": "bun install; bunx nx build @portal/plugin; bunx nx build @portal/components; bunx nx build portal; bunx nx build-mri portal",
     "flow": "bun install; bunx nx build @portal/plugin; bunx nx build @portal/components; bunx nx build flow",


### PR DESCRIPTION
Fix issue in wizards value search where ui is filtering only based on label, but should also filter by value

Use icon from figma:
<img width="159" height="53" alt="Screenshot 2026-02-20 at 4 41 11 PM" src="https://github.com/user-attachments/assets/fbd84354-8f04-4fe6-94ca-0635d286109c" />

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)