### PR TITLE
Fix stale results shown on failed concept search (#1917)

### DIFF
--- a/ui/apps/concept-sets/src/Terminology/components/TerminologyList/TerminologyList.tsx
+++ b/ui/apps/concept-sets/src/Terminology/components/TerminologyList/TerminologyList.tsx
@@ -370,6 +370,7 @@ const TerminologyList: FC<TerminologyListProps> = ({
         return;
       }
       console.error(e);
+      setConceptsResult(null);
       setFeedback({
         type: "error",
         message: getText(i18nKeys.TERMINOLOGY_LIST__ERROR),


### PR DESCRIPTION
Clear conceptsResult state in the error catch block of fetchData() so that previous search results are not displayed when a new search fails.

Instead of persisting old results:
<img width="1200" height="760" alt="bug-reproduced-stale-results" src="https://github.com/user-attachments/assets/5e9868eb-490c-40dc-af6f-d7227d3789c1" />

Show no results:
<img width="1200" height="760" alt="fix-verified-no-stale-results" src="https://github.com/user-attachments/assets/64b75619-49f1-46fb-912b-cac95a07a452" />

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)