### PR TITLE
[Analyze-1958] Split nested filtercard into individual exclusions

### DIFF
--- a/functions/analytics-svc/src/mri/endpoint/InclusionReportEndpoint.ts
+++ b/functions/analytics-svc/src/mri/endpoint/InclusionReportEndpoint.ts
@@ -82,12 +82,30 @@ export class InclusionReportEndpoint extends BaseQueryEngineEndpoint {
                         );
                         // Set filter to an exclusion filtercard if op is 0
                         if (op === "0") {
-                            bitmaskContent["op"] = "NOT";
-                            bitmapMriquery.filter.cards.content.push({
-                                content: [bitmaskContent],
-                                type: "BooleanContainer",
-                                op: "OR",
-                            });
+                            // If filtercard is nested, split them up into individual exclusions
+                            if (bitmaskContent.content.length > 1) {
+                                bitmaskContent.content.forEach((e) => {
+                                    bitmapMriquery.filter.cards.content.push({
+                                        content: [
+                                            {
+                                                content: [e],
+                                                type: "BooleanContainer",
+                                                op: "NOT",
+                                            },
+                                        ],
+                                        type: "BooleanContainer",
+                                        op: "OR",
+                                    });
+                                });
+                            } else {
+                                // Else Push filtercard as an exclusion
+                                bitmaskContent["op"] = "NOT";
+                                bitmapMriquery.filter.cards.content.push({
+                                    content: [bitmaskContent],
+                                    type: "BooleanContainer",
+                                    op: "OR",
+                                });
+                            }
                         } else {
                             bitmapMriquery.filter.cards.content.push(
                                 bitmaskContent


### PR DESCRIPTION
- resolves: https://github.com/OHDSI/Data2Evidence/issues/1958

Transforms nested filtercard joined with OR condition into individual exclusions
e.g `not (A or B) = (not A) and (not B)`
Reference:
<img width="1011" height="1161" alt="image" src="https://github.com/user-attachments/assets/ce4d590e-9bbc-4f27-9c5d-76be491c306f" />

Input filtercards to inclusion report
  1. Condition Occurrence A
  2. Death A OR Drug Exposure A

Validating patient count with PA
11
  - <img width="1691" height="606" alt="11" src="https://github.com/user-attachments/assets/71b89941-5c7d-4ace-8028-d8c92de6c8a9" />

10
  - <img width="1687" height="352" alt="10i" src="https://github.com/user-attachments/assets/4240909a-7798-4810-ac25-ade8d699a78d" />
  - <img width="1691" height="449" alt="10e" src="https://github.com/user-attachments/assets/343b7604-2971-4258-a2db-eeefc6634105" />

01
  - <img width="1691" height="377" alt="01i" src="https://github.com/user-attachments/assets/6fbdf4e7-1e63-4c18-92c0-4ac81f413217" />
  - <img width="1687" height="405" alt="01e" src="https://github.com/user-attachments/assets/3451bc5d-3899-47b9-895b-8e44c35f6ac0" />


00
  - <img width="1687" height="580" alt="00" src="https://github.com/user-attachments/assets/dfc040ee-eb0c-4605-a11b-495f43719599" />

Below shows the `inclusionreport` results for filtercards with input following screenshot from `11` above.
baseCount as well correctly sums up to total patient count`116352`.
sql has been additionally included for further scrutiny
```
{
    "summary": {
        "baseCount": 116352,
        "finalCount": 98076,
        "lostCount": 0,
        "percentMatched": "84.29%"
    },
    "inclusionRuleStats": [
        {
            "id": 0,
            "name": "Condition Occurrence A",
            "percentExcluded": "5.48%",
            "percentSatisfying": "84.67%",
            "countSatisfying": 98515
        },
        {
            "id": 1,
            "name": "Death A OR Drug Exposure A",
            "percentExcluded": "0.38%",
            "percentSatisfying": "89.77%",
            "countSatisfying": 104452
        }
    ],
    "treemapData": {
        "name": "Everyone",
        "children": [
            {
                "name": "Group 0",
                "children": [
                    {
                        "name": "00",
                        "size": 11461,
                        "sql": "WITH PatientRequest1 AS (SELECT P1.\"person_id\" AS \"patient.attributes.pcount.0\", P1.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P1 LEFT JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P1.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"death\" \"patient.death1\" ON (P1.\"person_id\" = \"patient.death1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"drug_exposure\" \"patient.drugexposure1\" ON (P1.\"person_id\" = \"patient.drugexposure1\".\"person_id\") WHERE ((\"patient.conditionoccurrence1\".\"condition_occurrence_id\" IS NULL ) AND (\"patient.death1\".\"person_id\" IS NULL ) AND (\"patient.drugexposure1\".\"drug_exposure_id\" IS NULL )) GROUP BY P1.\"person_id\", P1.\"person_id\") , PatientRequest0 AS (SELECT P0.\"person_id\" AS \"patient.attributes.pcount.0\", P0.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P0 LEFT JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P0.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"death\" \"patient.death1\" ON (P0.\"person_id\" = \"patient.death1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"drug_exposure\" \"patient.drugexposure1\" ON (P0.\"person_id\" = \"patient.drugexposure1\".\"person_id\") WHERE ((\"patient.conditionoccurrence1\".\"condition_occurrence_id\" IS NULL ) AND (\"patient.death1\".\"person_id\" IS NULL ) AND (\"patient.drugexposure1\".\"drug_exposure_id\" IS NULL )) GROUP BY P0.\"person_id\", P0.\"person_id\") , PatientRequests AS ( SELECT * FROM PatientRequest0 UNION SELECT * FROM PatientRequest1 ) , MeasurePopulation AS (SELECT COUNT(DISTINCT(PatientRequests.\"patient.attributes.pcount.0\")) AS \"patient.attributes.pcount\" , PatientRequests.\"patient.attributes.pid\" AS \"patient.attributes.pid\" ,COUNT(1) over(partition by CURRENT_USER ) as \"gr_cnt\" FROM PatientRequests GROUP BY PatientRequests.\"patient.attributes.pid\") , TotalPatientCount AS (SELECT COUNT(distinct MeasurePopulation.\"patient.attributes.pid\") as \"patient.attributes.pcount\" FROM MeasurePopulation WHERE MeasurePopulation.\"gr_cnt\" >= 1 ) SELECT * FROM TotalPatientCount"
                    }
                ]
            },
            {
                "name": "Group 1",
                "children": [
                    {
                        "name": "01",
                        "size": 6376,
                        "sql": "WITH PatientRequest1 AS (SELECT P1.\"person_id\" AS \"patient.attributes.pcount.0\", P1.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P1 LEFT JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P1.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") INNER JOIN cdm_5pct_bt.\"drug_exposure\" \"patient.drugexposure1\" ON (P1.\"person_id\" = \"patient.drugexposure1\".\"person_id\") WHERE (\"patient.conditionoccurrence1\".\"condition_occurrence_id\" IS NULL ) GROUP BY P1.\"person_id\", P1.\"person_id\") , PatientRequest0 AS (SELECT P0.\"person_id\" AS \"patient.attributes.pcount.0\", P0.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P0 LEFT JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P0.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") INNER JOIN cdm_5pct_bt.\"death\" \"patient.death1\" ON (P0.\"person_id\" = \"patient.death1\".\"person_id\") WHERE (\"patient.conditionoccurrence1\".\"condition_occurrence_id\" IS NULL ) GROUP BY P0.\"person_id\", P0.\"person_id\") , PatientRequests AS ( SELECT * FROM PatientRequest0 UNION SELECT * FROM PatientRequest1 ) , MeasurePopulation AS (SELECT COUNT(DISTINCT(PatientRequests.\"patient.attributes.pcount.0\")) AS \"patient.attributes.pcount\" , PatientRequests.\"patient.attributes.pid\" AS \"patient.attributes.pid\" ,COUNT(1) over(partition by CURRENT_USER ) as \"gr_cnt\" FROM PatientRequests GROUP BY PatientRequests.\"patient.attributes.pid\") , TotalPatientCount AS (SELECT COUNT(distinct MeasurePopulation.\"patient.attributes.pid\") as \"patient.attributes.pcount\" FROM MeasurePopulation WHERE MeasurePopulation.\"gr_cnt\" >= 1 ) SELECT * FROM TotalPatientCount"
                    },
                    {
                        "name": "10",
                        "size": 439,
                        "sql": "WITH PatientRequest1 AS (SELECT P1.\"person_id\" AS \"patient.attributes.pcount.0\", P1.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P1 INNER JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P1.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"death\" \"patient.death1\" ON (P1.\"person_id\" = \"patient.death1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"drug_exposure\" \"patient.drugexposure1\" ON (P1.\"person_id\" = \"patient.drugexposure1\".\"person_id\") WHERE ((\"patient.death1\".\"person_id\" IS NULL ) AND (\"patient.drugexposure1\".\"drug_exposure_id\" IS NULL )) GROUP BY P1.\"person_id\", P1.\"person_id\") , PatientRequest0 AS (SELECT P0.\"person_id\" AS \"patient.attributes.pcount.0\", P0.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P0 INNER JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P0.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"death\" \"patient.death1\" ON (P0.\"person_id\" = \"patient.death1\".\"person_id\") LEFT JOIN cdm_5pct_bt.\"drug_exposure\" \"patient.drugexposure1\" ON (P0.\"person_id\" = \"patient.drugexposure1\".\"person_id\") WHERE ((\"patient.death1\".\"person_id\" IS NULL ) AND (\"patient.drugexposure1\".\"drug_exposure_id\" IS NULL )) GROUP BY P0.\"person_id\", P0.\"person_id\") , PatientRequests AS ( SELECT * FROM PatientRequest0 UNION SELECT * FROM PatientRequest1 ) , MeasurePopulation AS (SELECT COUNT(DISTINCT(PatientRequests.\"patient.attributes.pcount.0\")) AS \"patient.attributes.pcount\" , PatientRequests.\"patient.attributes.pid\" AS \"patient.attributes.pid\" ,COUNT(1) over(partition by CURRENT_USER ) as \"gr_cnt\" FROM PatientRequests GROUP BY PatientRequests.\"patient.attributes.pid\") , TotalPatientCount AS (SELECT COUNT(distinct MeasurePopulation.\"patient.attributes.pid\") as \"patient.attributes.pcount\" FROM MeasurePopulation WHERE MeasurePopulation.\"gr_cnt\" >= 1 ) SELECT * FROM TotalPatientCount"
                    }
                ]
            },
            {
                "name": "Group 2",
                "children": [
                    {
                        "name": "11",
                        "size": 98076,
                        "sql": "WITH PatientRequest1 AS (SELECT P1.\"person_id\" AS \"patient.attributes.pcount.0\", P1.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P1 INNER JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P1.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") INNER JOIN cdm_5pct_bt.\"drug_exposure\" \"patient.drugexposure1\" ON (P1.\"person_id\" = \"patient.drugexposure1\".\"person_id\") GROUP BY P1.\"person_id\", P1.\"person_id\") , PatientRequest0 AS (SELECT P0.\"person_id\" AS \"patient.attributes.pcount.0\", P0.\"person_id\" AS \"patient.attributes.pid\" FROM cdm_5pct_bt.\"person\" P0 INNER JOIN cdm_5pct_bt.\"condition_occurrence\" \"patient.conditionoccurrence1\" ON (P0.\"person_id\" = \"patient.conditionoccurrence1\".\"person_id\") INNER JOIN cdm_5pct_bt.\"death\" \"patient.death1\" ON (P0.\"person_id\" = \"patient.death1\".\"person_id\") GROUP BY P0.\"person_id\", P0.\"person_id\") , PatientRequests AS ( SELECT * FROM PatientRequest0 UNION SELECT * FROM PatientRequest1 ) , MeasurePopulation AS (SELECT COUNT(DISTINCT(PatientRequests.\"patient.attributes.pcount.0\")) AS \"patient.attributes.pcount\" , PatientRequests.\"patient.attributes.pid\" AS \"patient.attributes.pid\" ,COUNT(1) over(partition by CURRENT_USER ) as \"gr_cnt\" FROM PatientRequests GROUP BY PatientRequests.\"patient.attributes.pid\") , TotalPatientCount AS (SELECT COUNT(distinct MeasurePopulation.\"patient.attributes.pid\") as \"patient.attributes.pcount\" FROM MeasurePopulation WHERE MeasurePopulation.\"gr_cnt\" >= 1 ) SELECT * FROM TotalPatientCount"
                    }
                ]
            }
        ]
    }
}
```

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)