### PR TITLE
Fix basic data filter in inclusion report

### DIFF
--- a/functions/query-gen-svc/src/api/controllers/query.ts
+++ b/functions/query-gen-svc/src/api/controllers/query.ts
@@ -300,7 +300,7 @@ function enrichConfigWithBasicDataInteraction(
         placeholder: "@PATIENT",
         attributeTables: [],
         hierarchy: false,
-        time: true,
+        time: false,
         oneToN: false,
         condition: false,
     });


### PR DESCRIPTION
Setting `time: true` for the `@PATIENT` dim table in `enrichConfigWithBasicDataInteraction` caused a SQL Binder Error when the Inclusion Report is run with Basic Data filters (e.g. Age) on a dataset with `cohortEntryExit: true`.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)