### PR TITLE
feat: add empty state message to Concept Sets list (#2023)

### DIFF
--- a/ui/apps/concept-sets/src/ConceptSets/ConceptSets.tsx
+++ b/ui/apps/concept-sets/src/ConceptSets/ConceptSets.tsx
@@ -254,40 +254,48 @@ export const ConceptSets: FC<ConceptSetsProps> = ({ isAtlas }) => {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {pageData.map((row) => {
-                      return (
-                        <TableRow key={row.id}>
-                          <TableCell>{row.id}</TableCell>
-                          <TableCell>
-                            {row.name}
-                            {row.shared
-                              ? ` (${getText(i18nKeys.CONCEPT_SETS__SHARED)})`
-                              : ""}
-                          </TableCell>
-                          <TableCell>{row.createdDate}</TableCell>
-                          <TableCell>{row.modifiedDate}</TableCell>
-                          <TableCell>{row.userName}</TableCell>
-                          <TableCell>
-                            <IconButton
-                              startIcon={
-                                row.createdBy === userName ? (
-                                  <EditIcon />
-                                ) : (
-                                  <VisibilityOnIcon />
-                                )
-                              }
-                              onClick={() => handleAddAndEditConceptSet(row.id)}
-                            />
-                            {row.createdBy === userName && (
+                    {pageData.length > 0 ? (
+                      pageData.map((row) => {
+                        return (
+                          <TableRow key={row.id}>
+                            <TableCell>{row.id}</TableCell>
+                            <TableCell>
+                              {row.name}
+                              {row.shared
+                                ? ` (${getText(i18nKeys.CONCEPT_SETS__SHARED)})`
+                                : ""}
+                            </TableCell>
+                            <TableCell>{row.createdDate}</TableCell>
+                            <TableCell>{row.modifiedDate}</TableCell>
+                            <TableCell>{row.userName}</TableCell>
+                            <TableCell>
                               <IconButton
-                                startIcon={<DeleteIcon />}
-                                onClick={() => handleDeleteClick(row)}
+                                startIcon={
+                                  row.createdBy === userName ? (
+                                    <EditIcon />
+                                  ) : (
+                                    <VisibilityOnIcon />
+                                  )
+                                }
+                                onClick={() => handleAddAndEditConceptSet(row.id)}
                               />
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
+                              {row.createdBy === userName && (
+                                <IconButton
+                                  startIcon={<DeleteIcon />}
+                                  onClick={() => handleDeleteClick(row)}
+                                />
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
+                    ) : (
+                      <TableRow>
+                        <TableCell colSpan={6} align="center">
+                          {getText(i18nKeys.CONCEPT_SETS__NO_CONCEPT_SETS)}
+                        </TableCell>
+                      </TableRow>
+                    )}
                   </TableBody>
                 </Table>
               </TableContainer>

--- a/ui/apps/concept-sets/src/context/state/translation-state.ts
+++ b/ui/apps/concept-sets/src/context/state/translation-state.ts
@@ -14,6 +14,7 @@ export const i18nDefault = {
     CONCEPT_SETS__REFERENCE_CONCEPTS: "Reference concepts from dataset",
     CONCEPT_SETS__SHARED: "Shared",
     CONCEPT_SETS__UPDATED: "Updated",
+    CONCEPT_SETS__NO_CONCEPT_SETS: "No concept sets to display",
     CONCEPT_SET_DELETE_DIALOG__DELETE_CONCEPT_SET: "Delete concept set",
     CONCEPT_SET_DELETE_DIALOG__ARE_YOU_SURE:
       "Are you sure you want to delete this concept set",


### PR DESCRIPTION
Show "No concept sets to display" when the Concept Sets table has no data, instead of rendering a blank table body.
<img width="1512" height="824" alt="Screenshot 2026-03-23 at 2 12 54 PM" src="https://github.com/user-attachments/assets/294400bf-3456-4f36-b861-5750e8a2d302" />
