### PR TITLE
Further improvements to PA load times in Portal

### DIFF
--- a/ui/apps/portal/src/plugins/mri/utils/PAPlugin.tsx
+++ b/ui/apps/portal/src/plugins/mri/utils/PAPlugin.tsx
@@ -17,9 +17,49 @@ const VUE_APP_HOST = env.REACT_APP_DN_BASE_URL.endsWith("/")
   ? `${env.REACT_APP_DN_BASE_URL}d2e`
   : `${env.REACT_APP_DN_BASE_URL}/d2e`;
 
+// Fire once when this module is first imported — resolves before the component mounts.
+// By the time the user navigates to PA, the fetch is already in-flight or resolved.
+const assetsPromise = fetch(PA_ASSETS_URL)
+  .then((res) => res.json())
+  .catch((err) => {
+    console.error("Failed to prefetch Patient Analytics assets:", err);
+    return { css: [], js: [] };
+  });
+
+let paAssetsLoadedPromise: Promise<void> | null = null;
+
+const loadEsModuleScriptAsync = (src: string): Promise<void> =>
+  new Promise((resolve) => {
+    loadEsModuleScript(src, resolve);
+  });
+
+const ensurePAAssetsLoaded = (): Promise<void> => {
+  if (paAssetsLoadedPromise) {
+    return paAssetsLoadedPromise;
+  }
+
+  paAssetsLoadedPromise = assetsPromise
+    .then(({ css, js }) =>
+      new Promise<void>((resolve) => {
+        loadSapScript(resolve);
+      }).then(async () => {
+        css.forEach((href: string) => {
+          loadStyleSheet(href);
+        });
+
+        await Promise.all(js.map((src: string) => loadEsModuleScriptAsync(src)));
+      }),
+    )
+    .catch((error) => {
+      paAssetsLoadedPromise = null;
+      throw error;
+    });
+
+  return paAssetsLoadedPromise;
+};
+
 const PAPlugin: FC<PAPluginProps> = ({ studyId, releaseId, getToken, toggleAtlas }) => {
   const [isLoading, setIsLoading] = useState(false);
-  const isLocalDev = window.location.hostname === "localhost";
 
   const hideLogoutButton = () => {
     const logoutButton: HTMLButtonElement | null = document.querySelector('button[id="mriBtnLogout"]');
@@ -30,39 +70,35 @@ const PAPlugin: FC<PAPluginProps> = ({ studyId, releaseId, getToken, toggleAtlas
 
   useEffect(() => {
     let isMounted = true;
-    const callbacks: (() => void)[] = [];
-    const cacheKey = `${studyId || "default"}_${releaseId || "default"}_${Date.now()}`;
+
     setIsLoading(true);
 
-    fetch(PA_ASSETS_URL)
-      .then((response) => response.json())
-      .then(({ css, js }) => {
+    ensurePAAssetsLoaded()
+      .then(() => {
         if (!isMounted) return;
 
-        loadSapScript(() => {
-          if (!isMounted) return;
+        window.mountPA?.();
 
-          css.forEach((href: string) => {
-            callbacks.push(loadStyleSheet(href));
-          });
-
-          js.forEach((src: string) => {
-            const cacheBustedSrc = `${src}?v=${cacheKey}`;
-            callbacks.push(loadEsModuleScript(cacheBustedSrc, () => {}));
-          });
-
+        try {
           hideLogoutButton();
-        });
+        } catch (error) {
+          console.error("Failed to hide logout button:", error);
+        }
+
+        setIsLoading(false);
       })
       .catch((error) => {
         console.error("Failed to load Patient Analytics assets:", error);
+        if (isMounted) {
+          setIsLoading(false);
+        }
       });
 
     return () => {
       isMounted = false;
-      callbacks.forEach((cleanup) => cleanup());
+      window.unmountPA?.();
     };
-  }, [isLocalDev]);
+  }, []);
 
   return (
     <PluginContainer
@@ -72,7 +108,12 @@ const PAPlugin: FC<PAPluginProps> = ({ studyId, releaseId, getToken, toggleAtlas
       qeSvcUrl={VUE_APP_HOST}
       toggleAtlas={toggleAtlas}
     >
-      <div className="vue-main">{isLoading && <Loader />}</div>
+      {isLoading && (
+        <div className="pa-loader-overlay">
+          <Loader />
+        </div>
+      )}
+      <div className="vue-main" />
     </PluginContainer>
   );
 };

--- a/ui/apps/portal/src/plugins/mri/utils/PAPlugin.tsx
+++ b/ui/apps/portal/src/plugins/mri/utils/PAPlugin.tsx
@@ -33,7 +33,7 @@ const loadEsModuleScriptAsync = (src: string): Promise<void> =>
     loadEsModuleScript(src, resolve);
   });
 
-const ensurePAAssetsLoaded = (): Promise<void> => {
+export const prewarmPAAssets = (): Promise<void> => {
   if (paAssetsLoadedPromise) {
     return paAssetsLoadedPromise;
   }
@@ -57,6 +57,13 @@ const ensurePAAssetsLoaded = (): Promise<void> => {
 
   return paAssetsLoadedPromise;
 };
+
+const ensurePAAssetsLoaded = (): Promise<void> => prewarmPAAssets();
+
+// Start prewarming real PA assets as soon as this module is imported.
+void prewarmPAAssets().catch(() => {
+  // Fail quietly here; mount flow handles and reports errors.
+});
 
 const PAPlugin: FC<PAPluginProps> = ({ studyId, releaseId, getToken, toggleAtlas }) => {
   const [isLoading, setIsLoading] = useState(false);

--- a/ui/apps/portal/src/plugins/mri/utils/PluginContainer.scss
+++ b/ui/apps/portal/src/plugins/mri/utils/PluginContainer.scss
@@ -1,6 +1,18 @@
 .plugin-container {
+  position: relative;
   display: flex;
   flex-direction: column;
+
+  .pa-loader-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.65);
+  }
+
   .vue-main {
     height: calc(100vh - 3.5rem);
   }

--- a/ui/apps/portal/src/shims.d.ts
+++ b/ui/apps/portal/src/shims.d.ts
@@ -2,6 +2,8 @@ interface Window {
   d2eListeners: {
     [key: string]: { type: string; app: string; listener: any }[];
   };
+  mountPA?: () => void;
+  unmountPA?: () => void;
   System: any;
   importMapOverrides?: {
     getOverrideMap: () => { imports?: Record<string, string> };

--- a/ui/apps/vue-mri-ui-lib/.env
+++ b/ui/apps/vue-mri-ui-lib/.env
@@ -16,3 +16,4 @@ VITE_DATASET_ID=
 VITE_DEBUG=false
 # Feature flags as JSON array
 VITE_FEATURES=[{"feature": "adminOnlySharing", "isEnabled": false}, {"feature": "wizards", "isEnabled": true}]
+VITE_DEV=true

--- a/ui/apps/vue-mri-ui-lib/src/main.ts
+++ b/ui/apps/vue-mri-ui-lib/src/main.ts
@@ -1,11 +1,11 @@
 // Must be first import to set up sap mock before any component uses it
 import './globals'
-import { createApp, Component } from 'vue'
+import { createApp } from 'vue'
 import Multiselect from 'vue-multiselect'
 import { applyPolyfills, defineCustomElements } from '@d4l/web-components-library/dist/loader'
 import vuetify from './plugins/vuetify'
 
-import App from './App.vue'
+import AppRoot from './App.vue'
 import RootLayout from './RootLayout.vue'
 import clickFocus from './directives/clickFocus'
 import focus from './directives/focus'
@@ -27,49 +27,71 @@ import { initializeApps } from './utils/AppRegistry'
 import { initializeComponents } from './utils/ComponentRegistry'
 import { applyTheme } from './utils/ThemeManager'
 
-let app: Component
-const portalAPI = getPortalAPI()
-const isLocal = 'isLocal' in portalAPI && portalAPI.isLocal === true
 import './styles/themes/_main.scss'
 
-if (isLocal) {
-  app = createApp(RootLayout as unknown as Component)
-  applyTheme('atlas')
+let app: ReturnType<typeof createApp> | null = null
 
-  // For local development, uncomment to use D2E theme
-  // applyTheme('d2e')
+const createPAApp = () => {
+  const portalAPI = getPortalAPI()
 
-  // Initialize registries
-  initializeApps()
-  initializeComponents()
-} else {
-  app = createApp(App as unknown as Component)
-  applyTheme('d2e')
+  const isLocal = 'isLocal' in portalAPI && portalAPI.isLocal === true
+  const paApp = createApp(isLocal ? RootLayout : AppRoot)
+
+  if (isLocal) {
+    applyTheme('atlas')
+
+    // For local development, uncomment to use D2E theme
+    // applyTheme('d2e')
+
+    // Initialize registries
+    initializeApps()
+    initializeComponents()
+  } else {
+    applyTheme('d2e')
+  }
+
+  const pinia = createPinia()
+  paApp.use(store)
+  paApp.use(pinia)
+  paApp.use(vuetify)
+  paApp.component('app-label', appLabelVue)
+  paApp.component('app-tag-input', appTagInputVue)
+  paApp.component('app-range', appRangeVue)
+  paApp.component('app-variant-range', appVariantRangeVue)
+  paApp.component('app-button', appButtonVue)
+  paApp.component('app-date-range', appDateRangeVue as any)
+  paApp.component('app-datetime-range', appDatetimeRangeVue as any)
+  paApp.component('app-single-select', appSingleSelect)
+  paApp.component('multiselect', Multiselect)
+  paApp.directive('focus', focus)
+  paApp.directive('click-focus', clickFocus)
+  paApp.directive('position-center', positionCenter)
+  paApp.directive('mouse-scroll', mouseScroll)
+  paApp.directive('resize-table', resizeTable)
+
+  // Suppress errors and warnings in production unless VITE_DEBUG is enabled
+  if (import.meta.env.VITE_DEBUG !== 'true') {
+    paApp.config.errorHandler = () => null
+    paApp.config.warnHandler = () => null
+  }
+
+  return paApp
 }
 
-const pinia = createPinia()
-app.use(store)
-app.use(pinia)
-app.use(vuetify)
-app.component('app-label', appLabelVue)
-app.component('app-tag-input', appTagInputVue)
-app.component('app-range', appRangeVue)
-app.component('app-variant-range', appVariantRangeVue)
-app.component('app-button', appButtonVue)
-app.component('app-date-range', appDateRangeVue as any)
-app.component('app-datetime-range', appDatetimeRangeVue as any)
-app.component('app-single-select', appSingleSelect)
-app.component('multiselect', Multiselect)
-app.directive('focus', focus)
-app.directive('click-focus', clickFocus)
-app.directive('position-center', positionCenter)
-app.directive('mouse-scroll', mouseScroll)
-app.directive('resize-table', resizeTable)
+const mountPA = () => {
+  if (app) {
+    app.unmount()
+    app = null
+  }
 
-// Suppress errors and warnings in production unless VITE_DEBUG is enabled
-if (import.meta.env.VITE_DEBUG !== 'true') {
-  app.config.errorHandler = () => null
-  app.config.warnHandler = () => null
+  app = createPAApp()
+  app.mount('.vue-main')
+}
+
+const unmountPA = () => {
+  if (!app) return
+  app.unmount()
+  app = null
 }
 
 // Bind the custom elements to the window object
@@ -77,4 +99,9 @@ applyPolyfills().then(() => {
   defineCustomElements()
 })
 
-app.mount('.vue-main')
+window.mountPA = mountPA
+window.unmountPA = unmountPA
+
+if (import.meta.env.DEV) {
+  mountPA()
+}

--- a/ui/apps/vue-mri-ui-lib/src/main.ts
+++ b/ui/apps/vue-mri-ui-lib/src/main.ts
@@ -22,6 +22,7 @@ import appSingleSelect from './lib/ui/app-single-select.vue'
 import appTagInputVue from './lib/ui/app-tag-input.vue'
 import { createPinia } from 'pinia'
 import store from './store'
+import { SET_ACTIVE_BOOKMARK } from './store/mutation-types'
 import { getPortalAPI } from './utils/PortalUtils'
 import { initializeApps } from './utils/AppRegistry'
 import { initializeComponents } from './utils/ComponentRegistry'
@@ -91,6 +92,7 @@ const mountPA = () => {
 const unmountPA = () => {
   if (!app) return
   app.unmount()
+  store.commit(SET_ACTIVE_BOOKMARK, null)
   app = null
 }
 

--- a/ui/apps/vue-mri-ui-lib/src/shims.d.ts
+++ b/ui/apps/vue-mri-ui-lib/src/shims.d.ts
@@ -18,4 +18,6 @@ interface Window {
   d2eListeners: {
     [key: string]: { type: string; app: string; listener: any }[]
   }
+  mountPA?: () => void
+  unmountPA?: () => void
 }

--- a/ui/apps/vue-mri-ui-lib/src/store/modules/bookmark.ts
+++ b/ui/apps/vue-mri-ui-lib/src/store/modules/bookmark.ts
@@ -587,6 +587,7 @@ const mutations = {
     modulestate.bookmarks = []
     modulestate.materializedCohorts = []
     modulestate.atlasCohortDefinitions = []
+    modulestate.activeBookmark = null
   },
   [types.RESET_DATASET_CACHE](modulestate) {
     modulestate.canDatasetMaterializeCohorts = false


### PR DESCRIPTION
Follow up to #2056

## Summary
- Switch Patient Analytics to an explicit mount/unmount lifecycle so the Vue app can re-enter cleanly in portal without relying on script re-execution.
- Keep PA assets loaded across navigation and start prewarming the real runtime assets earlier to improve repeated loads and reduce first-entry wait.
- Fix portal-specific UI/state issues seen during remounts, including the React/Vue host conflict on first load and stale bookmark state persisting across PA navigation.
## What Changed
### Portal integration
- Added an explicit PA runtime lifecycle on the Vue side with `window.mountPA` / `window.unmountPA`.
- Updated portal PA loading to mount Vue into a dedicated empty host instead of a React-managed node with children.
- Reworked the PA loader into a centered full-overlay loader that does not compete with Vue for DOM ownership.
### Asset loading
- Removed reliance on cache-busting as the remount mechanism.
- Kept repeated-load improvements by reusing loaded PA assets instead of forcing reloads.
- Added early prewarming of actual PA runtime assets on module import:
  - `mri/assets.json`
  - `sap-ui-core.js`
  - PA CSS
  - PA JS modules
### State cleanup
- Clear `activeBookmark` on bookmark reset.
- Clear `activeBookmark` again during PA unmount to prevent stale bookmark state flashing briefly on re-entry in portal.
## Why
Previously, PA only mounted because the JS module re-executed. That made repeated navigation fragile and led to cache-busting as a workaround. Moving to an explicit mount/unmount lifecycle makes remounts reliable, allows assets to stay cached, and fixes portal-specific teardown/re-entry bugs.
A few user-visible issues also came from portal/Vue integration details:
- React and Vue were mutating the same mount node during first load
- stale bookmark state survived between PA entries
- first-load prefetch was only warming the manifest, not the real runtime assets
This PR addresses those problems directly.
## Testing
- Built `ui/apps/vue-mri-ui-lib`
- Built `ui/apps/portal`
- Added targeted unit coverage for:
  - clearing `activeBookmark` on bookmark reset
  - clearing `activeBookmark` on `unmountPA`
- Manually verified key portal flows during development:
  - first PA entry
  - navigate away and back
  - repeated remount behavior
  - loader overlay behavior
  - stale bookmark cleanup on re-entry
## Notes
- Repeated PA entry is now the main improved case.
- First-load performance should improve only if the PA module is imported early enough for prewarming to get a head start; this PR adds that prewarm path, but the exact benefit depends on portal import timing.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)