### PR TITLE
Fix selection border behavior on data characterization treemap chart

### DIFF
--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.scss
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.scss
@@ -11,6 +11,23 @@
   }
 }
 
+.treemap-chart-wrapper {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+
+.treemap-chart-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(255, 255, 255, 0.5);
+  z-index: 1;
+  cursor: not-allowed;
+}
+
 .legend-box-size {
   text-align: center;
   padding-top: 8px;

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from "react";
+import React, { FC, useState, useEffect, useRef, useCallback } from "react";
 import type { EChartsOption } from "echarts";
 
 import ReactECharts from "echarts-for-react";
@@ -17,6 +17,8 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const { getText, i18nKeys } = useTranslation();
   const [selectedItemKey, setSelectedItemKey] = useState<string | null>(null);
   const [chartData, setChartData] = useState<any[]>([]);
+  const visualMapRangeRef = useRef<[number, number] | null>(null);
+  const chartRef = useRef<ReactECharts | null>(null);
   const theme = useTheme();
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
 
@@ -34,32 +36,44 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const minRecordsPerPerson = Math.min(...recordsPerPersonValues);
   const maxRecordsPerPerson = Math.max(...recordsPerPersonValues);
 
+  // Build styled data array based on selection and visualMap range
+  const buildStyledData = useCallback(
+    (currentRange: [number, number] | null) => {
+      const solidColor = theme.palette.custom.treeMapLegendColor[1];
+
+      return data.map((item) => {
+        const itemKey = getItemKey(item);
+        const itemStyle: any = {};
+
+        // Apply selection styling (only if item is within visualMap range)
+        if (itemKey && itemKey === selectedItemKey) {
+          const recordsPerPersonVal = item.value?.[1];
+          const isInRange =
+            !currentRange || (recordsPerPersonVal >= currentRange[0] && recordsPerPersonVal <= currentRange[1]);
+          if (isInRange) {
+            itemStyle.borderColor = borderSelectedColor;
+            itemStyle.borderWidth = 3;
+          }
+        }
+
+        // For simple format data, apply solid color
+        if (!hasRecordsPerPerson) {
+          itemStyle.color = solidColor;
+        }
+
+        return {
+          ...item,
+          ...(Object.keys(itemStyle).length > 0 && { itemStyle }),
+        };
+      });
+    },
+    [data, selectedItemKey, hasRecordsPerPerson, theme.palette.custom.treeMapLegendColor, borderSelectedColor]
+  );
+
   // Initialize chart data with itemStyle for each item
   useEffect(() => {
-    const solidColor = theme.palette.custom.treeMapLegendColor[1];
-
-    const dataWithStyles = data.map((item) => {
-      const itemKey = getItemKey(item);
-      const itemStyle: any = {};
-
-      // Apply selection styling
-      if (itemKey && itemKey === selectedItemKey) {
-        itemStyle.borderColor = borderSelectedColor;
-        itemStyle.borderWidth = 3;
-      }
-
-      // For simple format data, apply solid color
-      if (!hasRecordsPerPerson) {
-        itemStyle.color = solidColor;
-      }
-
-      return {
-        ...item,
-        ...(Object.keys(itemStyle).length > 0 && { itemStyle }),
-      };
-    });
-    setChartData(dataWithStyles);
-  }, [data, selectedItemKey, hasRecordsPerPerson, theme.palette.custom.treeMapLegendColor, borderSelectedColor]);
+    setChartData(buildStyledData(visualMapRangeRef.current));
+  }, [buildStyledData]);
 
   // Build the base option object
   const baseOption: EChartsOption = {
@@ -170,11 +184,23 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
       // e.value[3] = conceptId, e.value[4] = conceptPath (if available), e.name = display name
       return handleNodeClick(e.value[3], e.value[4] || e.name, e.name);
     },
+    datarangeselected: (e: any) => {
+      if (e.selected != null) {
+        visualMapRangeRef.current = e.selected;
+        // Imperatively update series data to toggle border styling without React re-render
+        const instance = chartRef.current?.getEchartsInstance();
+        if (instance) {
+          const styledData = buildStyledData(e.selected);
+          instance.setOption({ series: [{ data: styledData }] }, false, true);
+        }
+      }
+    },
   };
 
   return (
     <>
       <ReactECharts
+        ref={chartRef}
         style={{
           height: "100%",
           minHeight: 500,

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect, useRef, useCallback } from "react";
+import { FC, useState, useEffect, useRef, useCallback } from "react";
 import type { EChartsOption } from "echarts";
 
 import ReactECharts from "echarts-for-react";
@@ -17,7 +17,6 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const { getText, i18nKeys } = useTranslation();
   const [selectedItemKey, setSelectedItemKey] = useState<string | null>(null);
   const [chartData, setChartData] = useState<any[]>([]);
-  const visualMapRangeRef = useRef<[number, number] | null>(null);
   const chartRef = useRef<ReactECharts | null>(null);
   const theme = useTheme();
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
@@ -70,10 +69,20 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
     [data, selectedItemKey, hasRecordsPerPerson, theme.palette.custom.treeMapLegendColor, borderSelectedColor]
   );
 
+  // Read the current visualMap range from the ECharts instance
+  const getVisualMapRange = useCallback((): [number, number] | null => {
+    const instance = chartRef.current?.getEchartsInstance();
+    if (instance) {
+      const opt = instance.getOption() as any;
+      return opt?.visualMap?.[0]?.range ?? null;
+    }
+    return null;
+  }, []);
+
   // Initialize chart data with itemStyle for each item
   useEffect(() => {
-    setChartData(buildStyledData(visualMapRangeRef.current));
-  }, [buildStyledData]);
+    setChartData(buildStyledData(getVisualMapRange()));
+  }, [buildStyledData, getVisualMapRange]);
 
   // Build the base option object
   const baseOption: EChartsOption = {
@@ -186,7 +195,6 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
     },
     datarangeselected: (e: any) => {
       if (e.selected != null) {
-        visualMapRangeRef.current = e.selected;
         // Imperatively update series data to toggle border styling without React re-render
         const instance = chartRef.current?.getEchartsInstance();
         if (instance) {

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -11,9 +11,10 @@ interface TreeMapChartProps {
   title: string;
   setSelectedConcept: (value: { id: string; name: string } | null) => void;
   extraChartConfigs?: any;
+  loading?: boolean;
 }
 
-const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, extraChartConfigs }) => {
+const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, extraChartConfigs, loading }) => {
   const { getText, i18nKeys } = useTranslation();
   const [selectedItemKey, setSelectedItemKey] = useState<string | null>(null);
   const chartRef = useRef<ReactECharts | null>(null);
@@ -203,11 +204,11 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   };
 
   return (
-    <>
+    <div className="treemap-chart-wrapper">
+      {loading && <div className="treemap-chart-overlay" />}
       <ReactECharts
         ref={chartRef}
         style={{
-          height: "100%",
           minHeight: 500,
           width: "100%",
         }}
@@ -217,7 +218,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
         lazyUpdate={true}
       />
       <div className="legend-box-size">{getText(i18nKeys.TREE_MAP_CHART__CHART_LEGEND)}</div>
-    </>
+    </div>
   );
 };
 

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -71,6 +71,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   // Compute chart data on each render, reading the current visualMap range from the ECharts instance.
   // During drag, the imperative update in datarangeselected handles styling without triggering re-renders.
   const getVisualMapRange = (): [number, number] | null => {
+    if (!hasRecordsPerPerson) return null;
     const instance = chartRef.current?.getEchartsInstance();
     if (instance) {
       const opt = instance.getOption() as any;

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useEffect, useRef, useCallback } from "react";
+import { FC, useState, useRef, useCallback } from "react";
 import type { EChartsOption } from "echarts";
 
 import ReactECharts from "echarts-for-react";
@@ -16,7 +16,6 @@ interface TreeMapChartProps {
 const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, extraChartConfigs }) => {
   const { getText, i18nKeys } = useTranslation();
   const [selectedItemKey, setSelectedItemKey] = useState<string | null>(null);
-  const [chartData, setChartData] = useState<any[]>([]);
   const chartRef = useRef<ReactECharts | null>(null);
   const theme = useTheme();
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
@@ -69,20 +68,17 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
     [data, selectedItemKey, hasRecordsPerPerson, theme.palette.custom.treeMapLegendColor, borderSelectedColor]
   );
 
-  // Read the current visualMap range from the ECharts instance
-  const getVisualMapRange = useCallback((): [number, number] | null => {
+  // Compute chart data on each render, reading the current visualMap range from the ECharts instance.
+  // During drag, the imperative update in datarangeselected handles styling without triggering re-renders.
+  const getVisualMapRange = (): [number, number] | null => {
     const instance = chartRef.current?.getEchartsInstance();
     if (instance) {
       const opt = instance.getOption() as any;
       return opt?.visualMap?.[0]?.range ?? null;
     }
     return null;
-  }, []);
-
-  // Initialize chart data with itemStyle for each item
-  useEffect(() => {
-    setChartData(buildStyledData(getVisualMapRange()));
-  }, [buildStyledData, getVisualMapRange]);
+  };
+  const chartData = buildStyledData(getVisualMapRange());
 
   // Build the base option object
   const baseOption: EChartsOption = {
@@ -195,7 +191,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
     },
     datarangeselected: (e: any) => {
       if (e.selected != null) {
-        // Imperatively update series data to toggle border styling without React re-render
+        // Imperatively update series data for immediate responsiveness during drag
         const instance = chartRef.current?.getEchartsInstance();
         if (instance) {
           const styledData = buildStyledData(e.selected);

--- a/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
+++ b/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
@@ -11,6 +11,7 @@ interface TreeMapChartTableProps {
   title: string;
   data: any;
   setSelectedConcept: (value: { id: string; name: string } | null) => void;
+  loading?: boolean;
 }
 
 enum TreeMapChartTab {
@@ -24,7 +25,7 @@ const hasSimpleFormatData = (data: any[]) => {
   return "COUNTVALUE" in data[0] && "CONCEPTNAME" in data[0];
 };
 
-const TreeMapChartTable: FC<TreeMapChartTableProps> = ({ title, data, setSelectedConcept }) => {
+const TreeMapChartTable: FC<TreeMapChartTableProps> = ({ title, data, setSelectedConcept, loading }) => {
   const { getText, i18nKeys } = useTranslation();
   const [treeMapChartData, setTreeMapChartData] = useState<any[]>([]);
   const [treeMapTableData, setTreeMapTableData] = useState<any[]>([]);
@@ -106,7 +107,7 @@ const TreeMapChartTable: FC<TreeMapChartTableProps> = ({ title, data, setSelecte
         <Tab label={getText(i18nKeys.TREE_MAP_CHART_TABLE__LABEL_TABLE)}></Tab>
       </Tabs>
       {tabValue === TreeMapChartTab.TreeMap && (
-        <TreeMapChart data={treeMapChartData} title={title} setSelectedConcept={setSelectedConcept} />
+        <TreeMapChart data={treeMapChartData} title={title} setSelectedConcept={setSelectedConcept} loading={loading} />
       )}
       {tabValue === TreeMapChartTab.Table && (
         <TreeMapTable data={treeMapTableData} setSelectedConcept={setSelectedConcept} isSimpleFormat={isSimple} />

--- a/ui/apps/portal/src/components/Charts/Reports/Drilldown/SharedDrilldown.tsx
+++ b/ui/apps/portal/src/components/Charts/Reports/Drilldown/SharedDrilldown.tsx
@@ -183,7 +183,12 @@ const SharedDrilldown: FC<SharedDrilldownProps> = ({ flowRunId, sourceKey, datas
               <Loader text={getText(i18nKeys.SHARED_DRILLDOWN__LOADER, [sourceKey, selectedConcept?.id || ""])} />
             </div>
           )}
-          <TreeMapChartTable title={title ?? sourceKey} data={data} setSelectedConcept={setSelectedConcept} />
+          <TreeMapChartTable
+            title={title ?? sourceKey}
+            data={data}
+            setSelectedConcept={setSelectedConcept}
+            loading={isloadingDrilldownData}
+          />
         </div>
       )}
 


### PR DESCRIPTION
- Make selection border in data characterization treemap respect visual map range changes, so that the border is only applied when the item's `recordsPerPerson` falls within the current visualMap range and selection border is restored when item's in range again.
- Add overlay above the treemap chart when loading reports to prevent user interaction while loading.


https://github.com/user-attachments/assets/e4f3cf35-1df8-46fe-bc61-24ef3f72494f




### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)