### PR TITLE
[Integrate-2310] default sslmode to "allow" when db_extra has ca but no sslmode

### DIFF
--- a/plugins/ui/apps/portal/src/plugins/Setup/Db/EditDbDetailsDialog/EditDbDetailsDialog.tsx
+++ b/plugins/ui/apps/portal/src/plugins/Setup/Db/EditDbDetailsDialog/EditDbDetailsDialog.tsx
@@ -133,6 +133,7 @@ export const EditDbDetailsDialog: FC<EditDbDialogProps> = ({ open, onClose, db }
             typeof extraHashmap.Internal === "string" ? JSON.parse(extraHashmap.Internal) : extraHashmap.Internal;
           sslmode = internalObj.sslmode || "";
           ca = internalObj.ca || "";
+          if (ca && !sslmode) sslmode = "allow";
           // Remove TLS fields so they don't appear in the Extra textarea
           delete internalObj.sslmode;
           delete internalObj.ca;


### PR DESCRIPTION
### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)