### PR TITLE
Make stackCategory optional in PA chartOptions

### DIFF
--- a/plugins/functions/mri-pa-config/spec/config/mri/config/formatter_test.ts
+++ b/plugins/functions/mri-pa-config/spec/config/mri/config/formatter_test.ts
@@ -2,6 +2,7 @@ import * as mFormatter from "../../../src/mri/config/formatter";
 import { MockHdb } from "../../testutils/mockHdb";
 import * as qeFormatter from "../../../src/mri/config/qe-formatter";
 import { CONFIG_FORMATTER_SETTINGS } from "../../../src/mri/config/config";
+import * as customRules from "../../../../src/config/customRules";
 
 let fakeConnection;
 let formatter;
@@ -185,6 +186,41 @@ describe("Check the Admin Formatter functionality", () => {
         });
 
         expect(formattedConfig.patient.attributes.smoker.name).toEqual("Smoker");
+    });
+
+    describe("chartOptions.initialAttributes.stackCategory is optional", () => {
+        let mriConfigWithoutStackCategory;
+
+        beforeEach(() => {
+            mriConfigWithoutStackCategory = JSON.parse(JSON.stringify(fp2Config));
+            delete mriConfigWithoutStackCategory.chartOptions.initialAttributes.stackCategory;
+        });
+
+        it("validation rules pass when stackCategory is omitted", () => {
+            const attrRule = new customRules.InitialAttributesRule();
+            expect(attrRule.selectObjects(mriConfigWithoutStackCategory)).toEqual([true]);
+
+            const visibleRule = new customRules.InitialChartCategoriesVisibleRule(cdwConfig);
+            expect(visibleRule.selectObjects(mriConfigWithoutStackCategory)).toEqual([true]);
+        });
+
+        it("formatAdminConfig preserves the absence of stackCategory in initialAttributes", () => {
+            const result = formatter.formatAdminConfig({
+                mriConfig: mriConfigWithoutStackCategory,
+                dmConfig: JSON.parse(JSON.stringify(cdwConfig)),
+                lang: "en",
+            });
+            expect(result.chartOptions.initialAttributes.hasOwnProperty("stackCategory")).toBe(false);
+        });
+
+        it("formatFrontendConfig preserves the absence of stackCategory in initialAttributes", () => {
+            const result = formatter.formatFrontendConfig({
+                mriConfig: mriConfigWithoutStackCategory,
+                dmConfig: JSON.parse(JSON.stringify(cdwConfig)),
+                lang: "en",
+            });
+            expect(result.chartOptions.initialAttributes.hasOwnProperty("stackCategory")).toBe(false);
+        });
     });
 
 });

--- a/plugins/functions/mri-pa-config/src/config/configDefinition.ts
+++ b/plugins/functions/mri-pa-config/src/config/configDefinition.ts
@@ -583,6 +583,7 @@ function _getValidDefinition(cdwConfig) {
                         name: "stackCategory",
                         type: "array",
                         strict: true,
+                        mandatory: false,
                         children: [
                             {
                                 name: "source",

--- a/plugins/functions/mri-pa-config/src/config/customRules.ts
+++ b/plugins/functions/mri-pa-config/src/config/customRules.ts
@@ -9,8 +9,10 @@ export class InitialAttributesRule extends RuleValidatorBase {
   }
 
   public selectObjects(config) {
-    const initialAttributes = config.chartOptions.initialAttributes.measures
-      .concat(config.chartOptions.initialAttributes.categories)
+    const initialAttributes = (
+      config.chartOptions.initialAttributes.measures ?? []
+    )
+      .concat(config.chartOptions.initialAttributes.categories ?? [])
       .concat(config.chartOptions.initialAttributes.stackCategory ?? []);
     const initialFiltercards = config.filtercards
       .filter((e) => {
@@ -23,7 +25,7 @@ export class InitialAttributesRule extends RuleValidatorBase {
     let match;
     initialAttributes.forEach((obj) => {
       match = obj.match(/^(.+)\.attributes\..+$/);
-      if (!(match.length === 2)) {
+      if (!match || match.length !== 2) {
         throw new Error(
           "MRI_PA_CFG_VALIDATION_ERROR_INVALID_SOURCE_OF_ATTRIBUTE",
         );
@@ -72,10 +74,9 @@ export class InitialChartCategoriesVisibleRule extends RuleValidatorBase {
   }
 
   public selectObjects(config) {
-    const initialChartCategories =
-      config.chartOptions.initialAttributes.categories.concat(
-        config.chartOptions.initialAttributes.stackCategory ?? [],
-      );
+    const initialChartCategories = (
+      config.chartOptions.initialAttributes.categories ?? []
+    ).concat(config.chartOptions.initialAttributes.stackCategory ?? []);
     const filtercards = config.filtercards;
 
     const res = initialChartCategories.every((category) => {
@@ -118,7 +119,7 @@ export class InitialYAxisRule extends RuleValidatorBase {
 
   public selectObjects(config) {
     let valid = true;
-    const yAttributes = config.chartOptions.initialAttributes.measures;
+    const yAttributes = config.chartOptions.initialAttributes.measures ?? [];
     if (Object.keys(yAttributes).length === 0) {
       valid = false;
     }

--- a/plugins/functions/mri-pa-config/src/config/customRules.ts
+++ b/plugins/functions/mri-pa-config/src/config/customRules.ts
@@ -4,248 +4,265 @@ import { ruleValidator } from "@alp/alp-config-utils";
 const RuleValidatorBase = ruleValidator.RuleValidatorBase;
 
 export class InitialAttributesRule extends RuleValidatorBase {
-    constructor(dataSource?) {
-        super(dataSource);
-    }
+  constructor(dataSource?) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        const initialAttributes =
-            config.chartOptions.initialAttributes.measures.concat(
-                config.chartOptions.initialAttributes.categories).concat(
-                config.chartOptions.initialAttributes.stackCategory);
-        const initialFiltercards = config.filtercards.filter( (e) => {
-            return e.initial;
-        }).map( (e) => {
-            return e.source;
-        });
-        let valid = true;
-        let match;
-        initialAttributes.forEach( (obj) => {
-            match = obj.match(/^(.+)\.attributes\..+$/);
-            if (!(match.length === 2)) {
-                throw new Error("MRI_PA_CFG_VALIDATION_ERROR_INVALID_SOURCE_OF_ATTRIBUTE");
-            }
-            if (initialFiltercards.indexOf(match[1]) === -1) {
-                valid = false;
-            }
-        });
-        return [valid];
-    }
+  public selectObjects(config) {
+    const initialAttributes = config.chartOptions.initialAttributes.measures
+      .concat(config.chartOptions.initialAttributes.categories)
+      .concat(config.chartOptions.initialAttributes.stackCategory ?? []);
+    const initialFiltercards = config.filtercards
+      .filter((e) => {
+        return e.initial;
+      })
+      .map((e) => {
+        return e.source;
+      });
+    let valid = true;
+    let match;
+    initialAttributes.forEach((obj) => {
+      match = obj.match(/^(.+)\.attributes\..+$/);
+      if (!(match.length === 2)) {
+        throw new Error(
+          "MRI_PA_CFG_VALIDATION_ERROR_INVALID_SOURCE_OF_ATTRIBUTE",
+        );
+      }
+      if (initialFiltercards.indexOf(match[1]) === -1) {
+        valid = false;
+      }
+    });
+    return [valid];
+  }
 }
 
 export class InitialAttributesVisibilityRule extends RuleValidatorBase {
-    constructor(dataSource?) {
-        super(dataSource);
+  constructor(dataSource?) {
+    super(dataSource);
+  }
+
+  public selectObjects(config) {
+    if (config.hasOwnProperty("visible") && config.hasOwnProperty("initial")) {
+      return [!(!config.visible && config.initial)];
     }
 
-    public selectObjects(config) {
-        if (config.hasOwnProperty("visible") && config.hasOwnProperty("initial")) {
-            return [!(!config.visible && config.initial)];
-        }
-
-        return [true];
-    }
-
+    return [true];
+  }
 }
 
 export class XAxisVisibilityRule extends RuleValidatorBase {
-    constructor(dataSource?) {
-        super(dataSource);
-    }
+  constructor(dataSource?) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        if (config.hasOwnProperty("category") && config.hasOwnProperty("filtercard")) {
-            return [!config.category || config.filtercard.visible];
-        }
-        return [true];
+  public selectObjects(config) {
+    if (
+      config.hasOwnProperty("category") &&
+      config.hasOwnProperty("filtercard")
+    ) {
+      return [!config.category || config.filtercard.visible];
     }
+    return [true];
+  }
 }
 
 export class InitialChartCategoriesVisibleRule extends RuleValidatorBase {
-    constructor(dataSource) {
-        super(dataSource);
-    }
+  constructor(dataSource) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        const initialChartCategories = config.chartOptions.initialAttributes.categories.concat(
-            config.chartOptions.initialAttributes.stackCategory);
-        const filtercards = config.filtercards;
+  public selectObjects(config) {
+    const initialChartCategories =
+      config.chartOptions.initialAttributes.categories.concat(
+        config.chartOptions.initialAttributes.stackCategory ?? [],
+      );
+    const filtercards = config.filtercards;
 
-        const res = initialChartCategories.every( (category) => {
-            const categoryAttributeBaseName = category.match(/^(.+)\.attributes\..*$/)[1];
-            const filtercardForCategory = filtercards.find((filtercard) =>
-                filtercard.source === categoryAttributeBaseName,
-            );
+    const res = initialChartCategories.every((category) => {
+      const categoryAttributeBaseName = category.match(
+        /^(.+)\.attributes\..*$/,
+      )[1];
+      const filtercardForCategory = filtercards.find(
+        (filtercard) => filtercard.source === categoryAttributeBaseName,
+      );
 
-            if (!filtercardForCategory) {
-                return false;
-            }
+      if (!filtercardForCategory) {
+        return false;
+      }
 
-            const attributeForCategory = filtercardForCategory.attributes.find((attribute) =>
-                category === attribute.source,
-            );
+      const attributeForCategory = filtercardForCategory.attributes.find(
+        (attribute) => category === attribute.source,
+      );
 
-            if (!attributeForCategory) {
-                return false;
-            }
+      if (!attributeForCategory) {
+        return false;
+      }
 
-            const filtercardIsVisibleAndInitial = filtercardForCategory.initial && filtercardForCategory.visible;
-            const attributeIsVisibleAndInitial = attributeForCategory.filtercard.initial && attributeForCategory.filtercard.visible;
+      const filtercardIsVisibleAndInitial =
+        filtercardForCategory.initial && filtercardForCategory.visible;
+      const attributeIsVisibleAndInitial =
+        attributeForCategory.filtercard.initial &&
+        attributeForCategory.filtercard.visible;
 
-            return filtercardIsVisibleAndInitial && attributeIsVisibleAndInitial;
-        });
+      return filtercardIsVisibleAndInitial && attributeIsVisibleAndInitial;
+    });
 
-        return [res];
-    }
+    return [res];
+  }
 }
 
 export class InitialYAxisRule extends RuleValidatorBase {
-    constructor(dataSource?) {
-        super(dataSource);
-    }
+  constructor(dataSource?) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        let valid = true;
-        const yAttributes = config.chartOptions.initialAttributes.measures;
-        if (Object.keys(yAttributes).length === 0) {
-            valid = false;
-        }
-        return [valid];
+  public selectObjects(config) {
+    let valid = true;
+    const yAttributes = config.chartOptions.initialAttributes.measures;
+    if (Object.keys(yAttributes).length === 0) {
+      valid = false;
     }
-
+    return [valid];
+  }
 }
 
 export class AtLeastOneChartVisibleRule extends RuleValidatorBase {
-    constructor(dataSource?) {
-        super(dataSource);
-    }
+  constructor(dataSource?) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        let valid = false;
+  public selectObjects(config) {
+    let valid = false;
 
-        for (const item of Object.keys(config.chartOptions)) {
-            if (config.chartOptions[item].hasOwnProperty("visible")) {
-                valid = valid || config.chartOptions[item].visible;
-            }
-        }
-        return [valid];
+    for (const item of Object.keys(config.chartOptions)) {
+      if (config.chartOptions[item].hasOwnProperty("visible")) {
+        valid = valid || config.chartOptions[item].visible;
+      }
     }
+    return [valid];
+  }
 }
 
 export class PathExistsInConfig extends RuleValidatorBase {
-    constructor(dataSource?) {
-        super(dataSource);
+  constructor(dataSource?) {
+    super(dataSource);
+  }
+
+  public selectObjects(config) {
+    const cdwConfig = this.dataSource;
+    const pathParts = config.split(".");
+    let valid = true;
+
+    let obj = JSON.parse(JSON.stringify(cdwConfig));
+    for (let i = 0; i < pathParts.length; i++) {
+      if (obj.hasOwnProperty(pathParts[i])) {
+        obj = obj[pathParts[i]];
+      } else {
+        valid = false;
+        break;
+      }
     }
-
-    public selectObjects(config) {
-        const cdwConfig = this.dataSource;
-        const pathParts = config.split(".");
-        let valid = true;
-
-        let obj = JSON.parse(JSON.stringify(cdwConfig));
-        for (let i = 0; i < pathParts.length; i++) {
-            if (obj.hasOwnProperty(pathParts[i])) {
-                obj = obj[pathParts[i]];
-            } else {
-                valid = false;
-                break;
-            }
-        }
-        return [valid];
-    }
-
+    return [valid];
+  }
 }
 
 export class DefaultBinSizeRule extends RuleValidatorBase {
-    constructor(dataSource) {
-        super(dataSource);
-    }
+  constructor(dataSource) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        const cdwConfig = this.dataSource;
+  public selectObjects(config) {
+    const cdwConfig = this.dataSource;
 
-        if (config.hasOwnProperty("defaultBinSize") && config.defaultBinSize) {
-            const source = config.source;
-            const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
-            return [sourceAttribute.type === "num"];
-        }
-        return [true];
+    if (config.hasOwnProperty("defaultBinSize") && config.defaultBinSize) {
+      const source = config.source;
+      const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
+      return [sourceAttribute.type === "num"];
     }
+    return [true];
+  }
 }
 
 export class NoAggregatedCategory extends RuleValidatorBase {
-    constructor(dataSource) {
-        super(dataSource);
-    }
+  constructor(dataSource) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        const cdwConfig = this.dataSource;
+  public selectObjects(config) {
+    const cdwConfig = this.dataSource;
 
-        if (config.hasOwnProperty("category") && config.category) {
-            const source = config.source;
-            const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
-            return [!sourceAttribute.measureExpression];
-        }
-        return [true];
+    if (config.hasOwnProperty("category") && config.category) {
+      const source = config.source;
+      const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
+      return [!sourceAttribute.measureExpression];
     }
+    return [true];
+  }
 }
 
 export class NoAggregatedFiltercardAttribute extends RuleValidatorBase {
-    constructor(dataSource) {
-        super(dataSource);
-    }
+  constructor(dataSource) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        const cdwConfig = this.dataSource;
+  public selectObjects(config) {
+    const cdwConfig = this.dataSource;
 
-        if (config.hasOwnProperty("filtercard") && config.filtercard.hasOwnProperty("visible") && config.filtercard.visible) {
-            const source = config.source;
-            const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
-            return [!sourceAttribute.measureExpression];
-        }
-        return [true];
+    if (
+      config.hasOwnProperty("filtercard") &&
+      config.filtercard.hasOwnProperty("visible") &&
+      config.filtercard.visible
+    ) {
+      const source = config.source;
+      const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
+      return [!sourceAttribute.measureExpression];
     }
+    return [true];
+  }
 }
 
 export class UseRefTextRule extends RuleValidatorBase {
-    constructor(dataSource) {
-        super(dataSource);
-    }
+  constructor(dataSource) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        const cdwConfig = this.dataSource;
+  public selectObjects(config) {
+    const cdwConfig = this.dataSource;
 
-        if (config.hasOwnProperty("useRefText") && config.useRefText) {
-            const source = config.source;
-            const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
-            if (sourceAttribute.type != "conceptSet") {
-                return [sourceAttribute.hasOwnProperty("referenceFilter") && sourceAttribute.referenceFilter !== ""];
-            }
-        }
-        return [true];
+    if (config.hasOwnProperty("useRefText") && config.useRefText) {
+      const source = config.source;
+      const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
+      if (sourceAttribute.type != "conceptSet") {
+        return [
+          sourceAttribute.hasOwnProperty("referenceFilter") &&
+            sourceAttribute.referenceFilter !== "",
+        ];
+      }
     }
+    return [true];
+  }
 }
 
 export class UseRefValueRule extends RuleValidatorBase {
-    constructor(dataSource) {
-        super(dataSource);
-    }
+  constructor(dataSource) {
+    super(dataSource);
+  }
 
-    public selectObjects(config) {
-        const cdwConfig = this.dataSource;
+  public selectObjects(config) {
+    const cdwConfig = this.dataSource;
 
-        if (config.hasOwnProperty("useRefValue") && config.useRefValue) {
-            const source = config.source;
-            const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
-            if (sourceAttribute.type != "conceptSet") {
-                return [
-                    sourceAttribute.hasOwnProperty("referenceExpression")
-                    && sourceAttribute.referenceExpression !== ""
-                    && sourceAttribute.hasOwnProperty("referenceFilter")
-                    && sourceAttribute.referenceFilter !== "",
-                ];
-            }
-        }
-        return [true];
+    if (config.hasOwnProperty("useRefValue") && config.useRefValue) {
+      const source = config.source;
+      const sourceAttribute = utils.getObjectByPath(cdwConfig, source);
+      if (sourceAttribute.type != "conceptSet") {
+        return [
+          sourceAttribute.hasOwnProperty("referenceExpression") &&
+            sourceAttribute.referenceExpression !== "" &&
+            sourceAttribute.hasOwnProperty("referenceFilter") &&
+            sourceAttribute.referenceFilter !== "",
+        ];
+      }
     }
+    return [true];
+  }
 }


### PR DESCRIPTION
Make `chartOptions.initialAttributes.stackCategory` optional in PA Config so that it's backward compatible with older config records.

Note:
In `[plugins/functions/mri-pa-config/src/config/customRules.ts`, the actual changes are in lines 12-16 and line 28. The rest are formatting changes.
### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)