### PR TITLE
fix(shiny-dashboard): resolve /d2e iframe path for service worker (#2516)

### DIFF
--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ShinyDashboardIframe.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ShinyDashboardIframe.vue
@@ -26,6 +26,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useStore } from 'vuex'
 import { getPortalAPI } from '@/utils/PortalUtils'
+import { buildShinyLiveDashboardUrl } from '@/utils/shinyLiveUrl'
 
 const props = defineProps<{
   datasetId: string
@@ -53,7 +54,7 @@ const iframeUrl = computed(() => {
   }
 
   const resourceId = `${props.datasetId}_cohort_${props.wizardConfig.dashboardType}_python`
-  const url = `/gateway/api/dataset/shiny-live/${resourceId}/`
+  const url = buildShinyLiveDashboardUrl(resourceId)
   return url
 })
 

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/__tests__/ShinyDashboardIframe.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/__tests__/ShinyDashboardIframe.test.ts
@@ -1,0 +1,86 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ShinyDashboardIframe from '../ShinyDashboardIframe.vue'
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    getters: {
+      getText: (key: string) => key,
+    },
+  }),
+}))
+
+vi.mock('@/utils/PortalUtils', () => ({
+  getPortalAPI: () => ({
+    getToken: vi.fn().mockResolvedValue('test-token'),
+  }),
+}))
+
+vi.mock('@/utils/shinyLiveUrl', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/shinyLiveUrl')>('@/utils/shinyLiveUrl')
+  return actual
+})
+
+describe('ShinyDashboardIframe', () => {
+  const originalPathname = window.location.pathname
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...window.location,
+        pathname: '/d2e/portal',
+      },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...window.location,
+        pathname: originalPathname,
+      },
+      configurable: true,
+    })
+  })
+
+  it('uses the /d2e gateway prefix when the app is mounted under /d2e', () => {
+    const wrapper = mount(ShinyDashboardIframe, {
+      props: {
+        datasetId: 'dataset-1',
+        cohortId: 'cohort-1',
+        wizardConfig: {
+          dashboardType: 'calculate-incidence',
+        },
+      },
+    })
+
+    expect(wrapper.find('iframe').attributes('src')).toBe(
+      '/d2e/gateway/api/dataset/shiny-live/dataset-1_cohort_calculate-incidence_python/'
+    )
+  })
+
+  it('uses the /gateway prefix when the app is not mounted under /d2e', () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...window.location,
+        pathname: '/portal',
+      },
+      configurable: true,
+    })
+
+    const wrapper = mount(ShinyDashboardIframe, {
+      props: {
+        datasetId: 'dataset-1',
+        cohortId: 'cohort-1',
+        wizardConfig: {
+          dashboardType: 'calculate-incidence',
+        },
+      },
+    })
+
+    expect(wrapper.find('iframe').attributes('src')).toBe(
+      '/gateway/api/dataset/shiny-live/dataset-1_cohort_calculate-incidence_python/'
+    )
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/shinyLiveUrl.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/shinyLiveUrl.ts
@@ -1,0 +1,7 @@
+export function buildShinyLiveDashboardUrl(
+  resourceId: string,
+  pathname = window.location.pathname
+): string {
+  const gatewayBase = pathname.startsWith('/d2e/') ? '/d2e/gateway' : '/gateway'
+  return `${gatewayBase}/api/dataset/shiny-live/${resourceId}/`
+}


### PR DESCRIPTION
## Summary

Fixes #2516 - ShinyLive dashboard service worker fails to load on `develop.d2e.sg` due to hardcoded iframe URL path.

## Problem

`ShinyDashboardIframe.vue` was using a hardcoded `/gateway/api/dataset/shiny-live/...` URL, which breaks on deployments where the portal is served under `/d2e/` (e.g., `develop.d2e.sg`). The service worker scope and relative asset resolution depend on the correct base path.

## Solution

- Added `buildShinyLiveDashboardUrl()` utility that detects `/d2e/` deployments via `window.location.pathname`
- Uses `/d2e/gateway/api/...` when under `/d2e/`, falls back to `/gateway/api/...` otherwise
- Updated `ShinyDashboardIframe.vue` to use the new utility
- Added unit tests covering both deployment scenarios

## Files Changed

- `plugins/ui/apps/vue-mri-ui-lib/src/utils/shinyLiveUrl.ts` (new)
- `plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ShinyDashboardIframe.vue`
- `plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/__tests__/ShinyDashboardIframe.test.ts` (new)

## Testing

Unit tests added for:
- `/d2e/` path prefix (returns `/d2e/gateway/api/...`)
- Non-`/d2e/` path prefix (returns `/gateway/api/...`)

## Related

This is a reimplementation of the fix from branch `khairul-syazwan/fix-open-dashboard` (commit `672ba9e17`), which was never merged to develop.