### PR TITLE
Fix node selection and name parsing in data characterisation treemaptable

### DIFF
--- a/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -22,10 +22,9 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const theme = useTheme();
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
 
-  // Create a unique key for each item using conceptId (value[3]) to avoid
-  // false matches when multiple nodes share the same conceptName (value[4])
+  // Create a unique key for each item using conceptId (value[3])
   const getItemKey = (item: any) => {
-    return item.value?.[3] ?? item.name;
+    return item.value?.[3];
   };
 
   // Detect if records per person data is meaningful (not just placeholder values)

--- a/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -23,8 +23,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
 
   // Create a composite key from conceptId (value[3]) and conceptPath (value[4]).
-  // Neither field alone is unique: two nodes can share a conceptId with different paths,
-  // or share a name with different conceptIds. The combination is always unique.
+  // Two nodes can share a conceptId with different paths or share a name with different conceptIds.
   const getItemKey = (item: any): string => {
     const conceptId = item.value?.[3];
     const conceptPath = item.value?.[4] ?? item.name ?? "";
@@ -191,9 +190,11 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
     // Build the same composite key that getItemKey produces so buildStyledData
     // can match it and apply the border highlight to exactly the right node.
     const itemKey = `${conceptId ?? ""}-${conceptPath}`;
-    const normalizedId = conceptId != null ? String(conceptId) : conceptName;
-    setSelectedConcept({ id: normalizedId, name: conceptName });
     setSelectedItemKey(itemKey);
+    // Only trigger the drilldown fetch when conceptId is present.
+    if (conceptId != null) {
+      setSelectedConcept({ id: String(conceptId), name: conceptName });
+    }
   };
 
   const onEvents = {

--- a/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -22,11 +22,13 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const theme = useTheme();
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
 
-  // Create a normalized string key for each item using conceptId (value[3]),
-  // falling back to item.name when conceptId is missing/falsy.
+  // Create a composite key from conceptId (value[3]) and conceptPath (value[4]).
+  // Neither field alone is unique: two nodes can share a conceptId with different paths,
+  // or share a name with different conceptIds. The combination is always unique.
   const getItemKey = (item: any): string => {
     const conceptId = item.value?.[3];
-    return conceptId != null ? String(conceptId) : item.name ?? "";
+    const conceptPath = item.value?.[4] ?? item.name ?? "";
+    return `${conceptId ?? ""}-${conceptPath}`;
   };
 
   // Detect if records per person data is meaningful (not just placeholder values)
@@ -185,17 +187,20 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   // Merge with extra configs if provided
   const option = extraChartConfigs ? { ...baseOption, ...extraChartConfigs } : baseOption;
 
-  const handleNodeClick = (conceptId: any, conceptName: string) => {
+  const handleNodeClick = (conceptId: any, conceptName: string, conceptPath: string) => {
+    // Build the same composite key that getItemKey produces so buildStyledData
+    // can match it and apply the border highlight to exactly the right node.
+    const itemKey = `${conceptId ?? ""}-${conceptPath}`;
     const normalizedId = conceptId != null ? String(conceptId) : conceptName;
     setSelectedConcept({ id: normalizedId, name: conceptName });
-    // Use normalizedId as the unique key — must match what getItemKey produces
-    setSelectedItemKey(normalizedId);
+    setSelectedItemKey(itemKey);
   };
 
   const onEvents = {
     click: (e: any) => {
       // e.value[3] = conceptId, e.value[4] = conceptPath (if available), e.name = display name
-      return handleNodeClick(e.value[3], e.value[4] || e.name);
+      const conceptPath = e.value?.[4] ?? e.name ?? "";
+      return handleNodeClick(e.value[3], e.value[4] || e.name, conceptPath);
     },
     datarangeselected: (e: any) => {
       if (e.selected != null) {

--- a/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -22,9 +22,10 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const theme = useTheme();
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
 
-  // Create a unique key for each item
+  // Create a unique key for each item using conceptId (value[3]) to avoid
+  // false matches when multiple nodes share the same conceptName (value[4])
   const getItemKey = (item: any) => {
-    return item.value?.[4] || item.name;
+    return item.value?.[3] ?? item.name;
   };
 
   // Detect if records per person data is meaningful (not just placeholder values)
@@ -67,7 +68,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
         };
       });
     },
-    [data, selectedItemKey, hasRecordsPerPerson, theme.palette.custom.treeMapLegendColor, borderSelectedColor],
+    [data, selectedItemKey, hasRecordsPerPerson, theme.palette.custom.treeMapLegendColor, borderSelectedColor]
   );
 
   // Compute chart data on each render, reading the current visualMap range from the ECharts instance.
@@ -96,6 +97,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
         // Parse conceptPath string, replace || with breaklines with growing indentation
         const parsedConceptPath = conceptPath
           .split("||")
+          .filter((s: string) => s.trim() !== "")
           .map((e: string, index: number) => {
             return `<div style="padding-left: ${index * 10}px">${e.trim()}</div>`;
           })
@@ -111,7 +113,7 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
         // Only show records per person if the data has meaningful values
         if (hasRecordsPerPerson) {
           tooltipLines.push(
-            `${getText(i18nKeys.TREE_MAP_CHART__RECORDS_PER_PERSON)}: ${formatNumber(recordsPerPerson)}`,
+            `${getText(i18nKeys.TREE_MAP_CHART__RECORDS_PER_PERSON)}: ${formatNumber(recordsPerPerson)}`
           );
         }
 
@@ -182,17 +184,17 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   // Merge with extra configs if provided
   const option = extraChartConfigs ? { ...baseOption, ...extraChartConfigs } : baseOption;
 
-  const handleNodeClick = (conceptId: string, conceptName: string, itemName: string) => {
+  const handleNodeClick = (conceptId: string, conceptName: string) => {
     setSelectedConcept({ id: conceptId, name: conceptName });
-    // Use conceptName or itemName as the unique key
-    const itemKey = conceptName || itemName;
+    // Use conceptId as the unique key so nodes with the same name are treated as distinct
+    const itemKey = conceptId;
     setSelectedItemKey(itemKey);
   };
 
   const onEvents = {
     click: (e: any) => {
       // e.value[3] = conceptId, e.value[4] = conceptPath (if available), e.name = display name
-      return handleNodeClick(e.value[3], e.value[4] || e.name, e.name);
+      return handleNodeClick(e.value[3], e.value[4] || e.name);
     },
     datarangeselected: (e: any) => {
       if (e.selected != null) {

--- a/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChart.tsx
@@ -22,9 +22,11 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   const theme = useTheme();
   const borderSelectedColor = theme.palette.custom.selectedRowBorder;
 
-  // Create a unique key for each item using conceptId (value[3])
-  const getItemKey = (item: any) => {
-    return item.value?.[3];
+  // Create a normalized string key for each item using conceptId (value[3]),
+  // falling back to item.name when conceptId is missing/falsy.
+  const getItemKey = (item: any): string => {
+    const conceptId = item.value?.[3];
+    return conceptId != null ? String(conceptId) : item.name ?? "";
   };
 
   // Detect if records per person data is meaningful (not just placeholder values)
@@ -183,11 +185,11 @@ const TreeMapChart: FC<TreeMapChartProps> = ({ data, title, setSelectedConcept, 
   // Merge with extra configs if provided
   const option = extraChartConfigs ? { ...baseOption, ...extraChartConfigs } : baseOption;
 
-  const handleNodeClick = (conceptId: string, conceptName: string) => {
-    setSelectedConcept({ id: conceptId, name: conceptName });
-    // Use conceptId as the unique key so nodes with the same name are treated as distinct
-    const itemKey = conceptId;
-    setSelectedItemKey(itemKey);
+  const handleNodeClick = (conceptId: any, conceptName: string) => {
+    const normalizedId = conceptId != null ? String(conceptId) : conceptName;
+    setSelectedConcept({ id: normalizedId, name: conceptName });
+    // Use normalizedId as the unique key — must match what getItemKey produces
+    setSelectedItemKey(normalizedId);
   };
 
   const onEvents = {

--- a/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
@@ -76,7 +76,7 @@ const TreeMapChartTable: FC<TreeMapChartTableProps> = ({ title, data, setSelecte
       // Parse existing format for treemap chart
       const mappedData = treeMapTableData.map((obj: any) => ({
         name:
-          obj["CONCEPTPATH"]
+          (obj["CONCEPTPATH"] ?? "")
             ?.split("||")
             .filter((s: string) => s.trim() !== "")
             .pop()

--- a/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/TreeMap/TreeMapChartTable.tsx
@@ -75,7 +75,12 @@ const TreeMapChartTable: FC<TreeMapChartTableProps> = ({ title, data, setSelecte
     } else {
       // Parse existing format for treemap chart
       const mappedData = treeMapTableData.map((obj: any) => ({
-        name: obj["CONCEPTPATH"]?.split("||").pop()?.trim() || obj["CONCEPTPATH"],
+        name:
+          obj["CONCEPTPATH"]
+            ?.split("||")
+            .filter((s: string) => s.trim() !== "")
+            .pop()
+            ?.trim() || obj["CONCEPTPATH"],
         value: [
           obj["NUMPERSONS"],
           obj["RECORDSPERPERSON"] ? obj["RECORDSPERPERSON"] : obj["LENGTHOFERA"],

--- a/plugins/ui/apps/portal/src/components/Charts/Reports/Drilldown/SharedDrilldown.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Reports/Drilldown/SharedDrilldown.tsx
@@ -81,7 +81,12 @@ const SharedDrilldown: FC<SharedDrilldownProps> = ({ flowRunId, sourceKey, datas
   }, [getDrilldownData]);
 
   useEffect(() => {
-    setLeafConceptName(selectedConcept?.name.split("||").pop() || "");
+    setLeafConceptName(
+      selectedConcept?.name
+        .split("||")
+        .filter((s: string) => s.trim() !== "")
+        .pop() || ""
+    );
   }, [selectedConcept]);
 
   const renderDrilldownCharts = () => {

--- a/plugins/ui/apps/portal/src/components/Charts/Reports/Drilldown/SharedDrilldown.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Reports/Drilldown/SharedDrilldown.tsx
@@ -82,7 +82,7 @@ const SharedDrilldown: FC<SharedDrilldownProps> = ({ flowRunId, sourceKey, datas
 
   useEffect(() => {
     setLeafConceptName(
-      selectedConcept?.name
+      (selectedConcept?.name ?? "")
         .split("||")
         .filter((s: string) => s.trim() !== "")
         .pop() || ""


### PR DESCRIPTION
1. Filter out empty || segments in concept name path before setting the leaf concept name for treemap node name, tooltip and drilldown chart titles.
2. Use `conceptId`-`conceptNamePath` as composite selection key in treemap

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)