### PR TITLE
Updated code to set default result viewer template for new studies 

### DIFF
--- a/plugins/ui/apps/portal/src/plugins/SystemAdmin/StudyPage/StudyPage.tsx
+++ b/plugins/ui/apps/portal/src/plugins/SystemAdmin/StudyPage/StudyPage.tsx
@@ -82,8 +82,7 @@ export const StudyPage: FC<StudyPageProps> = () => {
           name: study.notebookName || study.studyId,
           strategus_json: study.analysisSpec,
           type: StrategusStudyType.LOCAL,
-          viewerCode: study.viewerCode ?? RESULT_VIEWER_TEMPLATE,
-          tokenDatasetCode: study.tokenStudyCode ?? undefined,
+          viewerCode: study.viewerCode?.trim() || RESULT_VIEWER_TEMPLATE,
         }));
         setStrategusStudies(convertedStudies);
       } catch (error) {

--- a/plugins/ui/apps/portal/src/plugins/SystemAdmin/StudyPage/StudyPage.tsx
+++ b/plugins/ui/apps/portal/src/plugins/SystemAdmin/StudyPage/StudyPage.tsx
@@ -83,6 +83,7 @@ export const StudyPage: FC<StudyPageProps> = () => {
           strategus_json: study.analysisSpec,
           type: StrategusStudyType.LOCAL,
           viewerCode: study.viewerCode?.trim() || RESULT_VIEWER_TEMPLATE,
+          tokenDatasetCode: study.tokenStudyCode ?? undefined,
         }));
         setStrategusStudies(convertedStudies);
       } catch (error) {


### PR DESCRIPTION
This change sets the default result viewer template for a new study - previously it was empty.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)