### PR TITLE
Improve cohort definition query performance

### DIFF
--- a/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
@@ -187,21 +187,36 @@ export class CohortEndpoint {
         excludePatientIds?: boolean
     ) {
         const baseQueryString = `
-            SELECT 
-                cd.COHORT_DEFINITION_ID AS "COHORT_DEFINITION_ID",
-                cd.COHORT_DEFINITION_NAME AS "COHORT_DEFINITION_NAME",
-                TO_NVARCHAR(cd.COHORT_DEFINITION_DESCRIPTION) AS "COHORT_DEFINITION_DESCRIPTION",
-                cd.COHORT_INITIATION_DATE AS "COHORT_INITIATION_DATE",
-                TO_NVARCHAR(cd.COHORT_DEFINITION_SYNTAX) AS "COHORT_DEFINITION_SYNTAX",
-                COALESCE(c.count, 0) AS "count"
-            FROM ${this.schemaName}.COHORT_DEFINITION cd
-            LEFT JOIN (
+            WITH filtered_cd AS (
                 SELECT
                     COHORT_DEFINITION_ID,
-                    COUNT(DISTINCT SUBJECT_ID) AS count
-                FROM ${this.schemaName}.COHORT
-                GROUP BY COHORT_DEFINITION_ID
-            ) c
+                    COHORT_DEFINITION_NAME,
+                    TO_NVARCHAR(COHORT_DEFINITION_DESCRIPTION) AS COHORT_DEFINITION_DESCRIPTION,
+                    COHORT_INITIATION_DATE,
+                    TO_NVARCHAR(COHORT_DEFINITION_SYNTAX) AS COHORT_DEFINITION_SYNTAX
+                FROM ${this.schemaName}.COHORT_DEFINITION cd
+        `;
+
+        const countsAndSelectQueryString = `
+            ),
+            counts AS (
+                SELECT
+                    c.COHORT_DEFINITION_ID,
+                    COUNT(DISTINCT c.SUBJECT_ID) AS count
+                FROM ${this.schemaName}.COHORT c
+                INNER JOIN filtered_cd cd
+                    ON cd.COHORT_DEFINITION_ID = c.COHORT_DEFINITION_ID
+                GROUP BY c.COHORT_DEFINITION_ID
+            )
+            SELECT
+                cd.COHORT_DEFINITION_ID AS "COHORT_DEFINITION_ID",
+                cd.COHORT_DEFINITION_NAME AS "COHORT_DEFINITION_NAME",
+                cd.COHORT_DEFINITION_DESCRIPTION AS "COHORT_DEFINITION_DESCRIPTION",
+                cd.COHORT_INITIATION_DATE AS "COHORT_INITIATION_DATE",
+                cd.COHORT_DEFINITION_SYNTAX AS "COHORT_DEFINITION_SYNTAX",
+                COALESCE(c.count, 0) AS "count"
+            FROM filtered_cd cd
+            LEFT JOIN counts c
                 ON cd.COHORT_DEFINITION_ID = c.COHORT_DEFINITION_ID
         `;
 
@@ -212,6 +227,7 @@ export class CohortEndpoint {
                 baseQueryString,
                 queryParams
             );
+            selectQueryString += countsAndSelectQueryString;
 
             // Add limit and/or offset keyword if is it included
             if (limit) {

--- a/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
@@ -193,9 +193,15 @@ export class CohortEndpoint {
                 TO_NVARCHAR(cd.COHORT_DEFINITION_DESCRIPTION) AS "COHORT_DEFINITION_DESCRIPTION",
                 cd.COHORT_INITIATION_DATE AS "COHORT_INITIATION_DATE",
                 TO_NVARCHAR(cd.COHORT_DEFINITION_SYNTAX) AS "COHORT_DEFINITION_SYNTAX",
-                COUNT(DISTINCT c.SUBJECT_ID) AS "count"
+                COALESCE(c.count, 0) AS "count"
             FROM ${this.schemaName}.COHORT_DEFINITION cd
-            LEFT JOIN ${this.schemaName}.COHORT c 
+            LEFT JOIN (
+                SELECT
+                    COHORT_DEFINITION_ID,
+                    COUNT(DISTINCT SUBJECT_ID) AS count
+                FROM ${this.schemaName}.COHORT
+                GROUP BY COHORT_DEFINITION_ID
+            ) c
                 ON cd.COHORT_DEFINITION_ID = c.COHORT_DEFINITION_ID
         `;
 
@@ -206,14 +212,6 @@ export class CohortEndpoint {
                 baseQueryString,
                 queryParams
             );
-            selectQueryString += `
-            GROUP BY 
-                cd.COHORT_DEFINITION_ID,
-                cd.COHORT_DEFINITION_NAME,
-                TO_NVARCHAR(cd.COHORT_DEFINITION_DESCRIPTION),
-                cd.COHORT_INITIATION_DATE,
-                TO_NVARCHAR(cd.COHORT_DEFINITION_SYNTAX)
-                `;
 
             // Add limit and/or offset keyword if is it included
             if (limit) {


### PR DESCRIPTION
The cohort save/materialization succeeds; the failure happens after that, when the UI reloads cohort definitions via `d2e-webapi -> analytics-svc`. That analytics query can run close to Trex’s hardcoded 30s timeout, so the UI intermittently ends up without `cohortDefinitionId`.

Original query problem: it joined `COHORT_DEFINITION` to the large `COHORT` table, then did `COUNT(DISTINCT SUBJECT_ID)` over the joined result.

Non-chosen solution: pre-aggregate all of `COHORT` first, then join counts back to filtered cohort definitions. This was fastest in Germany k8s:

```text
Pre-aggregated rewrite: 0.684s, plan cost 0.0608
```

Chosen solution: filter cohort definitions first, count distinct subjects only for those filtered definitions, then join counts back. It was slightly slower in one runtime test, but had the best HANA plan cost:

```text
Original:              2.153s, plan cost 0.4091
Pre-aggregated option: 0.684s, plan cost 0.0608
Chosen final fix:      0.813s, plan cost 0.0135
```

Reason for choosing final fix: it still keeps runtime far below the 30s timeout, while giving HANA the lowest-cost query shape and better expected scalability as data grows.