### PR TITLE
Update hugging face model version

### DIFF
--- a/plugins/flows/data_transformation/Dockerfile
+++ b/plugins/flows/data_transformation/Dockerfile
@@ -125,7 +125,7 @@ RUN uv pip install --upgrade "pip<24" \
     && uv pip install spacy-transformers==1.3.9 \
     && uv pip install --no-deps https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_ner_bc5cdr_md-0.5.4.tar.gz \
     && uv pip install git+https://github.com/nmslib/nmslib.git@2ae5378#subdirectory=python_bindings \
-    && /app/.venv/bin/pip install --no-deps "en-core-med7-trf @ https://huggingface.co/kormilitzin/en_core_med7_trf/resolve/main/en_core_med7_trf-1.0.0-py3-none-any.whl" \
+    && /app/.venv/bin/pip install --no-deps "en-core-med7-trf @ https://huggingface.co/kormilitzin/en_core_med7_trf/resolve/a24b622/en_core_med7_trf-1.1.0-py3-none-any.whl" \
     # For PyNer
     && pip install git+https://github.com/data2evidence/py_name_entity_recognition@release-v1.0.8 \
     && pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl


### PR DESCRIPTION
This PR fixes the gha fail when building datatransformation image- https://github.com/OHDSI/Data2Evidence/issues/2704
The root cause is that the URL uses /resolve/main/ — a moving pointer to the latest commit on main. When the author pushes a new wheel, the old filename disappears and the URL breaks.
The URL now points to commit a24b622 ("Release en_core_med7_trf v1.1.0") instead of main. Even if the author pushes a new version and removes the old wheel again, this URL will continue to resolve to the 1.1.0 wheel.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)