### PR TITLE
Backend change for Concept Set Support in Table 1

### DIFF
--- a/plugins/functions/parquet-export/index.ts
+++ b/plugins/functions/parquet-export/index.ts
@@ -81,6 +81,11 @@ function isValidWildcardFlag(val: string): boolean {
   return Number(val) === 1 || Number(val) === 0;
 }
 
+function isValidConceptIdArray(arr: unknown): arr is number[] {
+  if (!Array.isArray(arr)) return false;
+  return arr.every((item) => typeof item === "number" && Number.isInteger(item) && item > 0);
+}
+
 function sanitizeParamValue(value: string): string {
   return value.replace(/'/g, "''");
 }
@@ -107,6 +112,7 @@ const RESERVED_PLACEHOLDERS = new Set([
   "WILDCARD_FLAG3",
   "WILDCARD_FLAG4",
   "WILDCARD_FLAG5",
+  "CONCEPT_IDS",
 ]);
 
 function substituteTemplateParams(
@@ -214,6 +220,10 @@ function substituteTemplateParams(
     .replace(
       /\{\{WILDCARD_FLAG5\}\}/g,
       additionalParams["WILDCARD_FLAG5"] || "",
+    )
+    .replace(
+      /\{\{CONCEPT_IDS\}\}/g,
+      additionalParams["CONCEPT_IDS"] || "",
     );
 
   const remainingPlaceholders = extractPlaceholders(result);
@@ -468,6 +478,14 @@ router.post("/", async (req: Request, res: Response) => {
       });
     }
 
+    const conceptIds = req.body.conceptIds as unknown | undefined;
+    if (conceptIds !== undefined && !isValidConceptIdArray(conceptIds)) {
+      return res.status(400).json({
+        error: "Invalid parameter",
+        message: "conceptIds must be an array of positive integers",
+      });
+    }
+
     const reservedBodyParams = new Set([
       "datasetId",
       "cohortId",
@@ -477,6 +495,7 @@ router.post("/", async (req: Request, res: Response) => {
       "type",
       "yearRange",
       "conditions",
+      "conceptIds",
     ]);
 
     const additionalParams: Record<string, string> = {};
@@ -502,6 +521,11 @@ router.post("/", async (req: Request, res: Response) => {
           });
         }
       });
+    }
+
+    // Handle conceptIds array
+    if (conceptIds && Array.isArray(conceptIds) && conceptIds.length > 0) {
+      additionalParams["CONCEPT_IDS"] = conceptIds.join(",");
     }
 
     let substitutedSql: string;

--- a/plugins/functions/parquet-export/index.ts
+++ b/plugins/functions/parquet-export/index.ts
@@ -82,8 +82,8 @@ function isValidWildcardFlag(val: string): boolean {
 }
 
 function isValidConceptIdArray(arr: unknown): arr is number[] {
-  if (!Array.isArray(arr)) return false;
-  return arr.every((item) => typeof item === "number" && Number.isInteger(item) && item > 0);
+  if (!Array.isArray(arr) || arr.length === 0) return false;
+  return arr.every((item) => typeof item === "number" && Number.isInteger(item) && item >= 0);
 }
 
 function sanitizeParamValue(value: string): string {
@@ -124,6 +124,7 @@ function substituteTemplateParams(
     resultsSchema: string;
   },
   additionalParams: Record<string, string>,
+  conceptIds: number[],
 ): string {
   if (!isValidCohortId(params.cohortId)) {
     throw new Error("Invalid cohortId");
@@ -223,7 +224,7 @@ function substituteTemplateParams(
     )
     .replace(
       /\{\{CONCEPT_IDS\}\}/g,
-      additionalParams["CONCEPT_IDS"] || "",
+      conceptIds.join(","),
     );
 
   const remainingPlaceholders = extractPlaceholders(result);
@@ -479,7 +480,7 @@ router.post("/", async (req: Request, res: Response) => {
     }
 
     const conceptIds = req.body.conceptIds as unknown | undefined;
-    if (conceptIds !== undefined && !isValidConceptIdArray(conceptIds)) {
+    if (!isValidConceptIdArray(conceptIds)) {
       return res.status(400).json({
         error: "Invalid parameter",
         message: "conceptIds must be an array of positive integers",
@@ -523,11 +524,6 @@ router.post("/", async (req: Request, res: Response) => {
       });
     }
 
-    // Handle conceptIds array
-    if (conceptIds && Array.isArray(conceptIds) && conceptIds.length > 0) {
-      additionalParams["CONCEPT_IDS"] = conceptIds.join(",");
-    }
-
     let substitutedSql: string;
     try {
       substitutedSql = substituteTemplateParams(
@@ -539,6 +535,7 @@ router.post("/", async (req: Request, res: Response) => {
           resultsSchema: dataset.resultsSchemaName,
         },
         additionalParams,
+        conceptIds,
       );
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Ticket - [https://github.com/OHDSI/Data2Evidence/issues/2656]

Changes - 
Added support for concept Ids in parquet-export endpoint. Now, an api call to this endpoint can include a list of concept ids - to be used for table1. 
