### PR TITLE
Update legend for overlapping charts

### DIFF
--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
@@ -325,7 +325,7 @@ export default {
       return Object.values(Constants.ChartColorway)
     },
     legendBarOpacity() {
-      // Overlapping histogram draws transluscent bars
+      // Overlapping histogram draws translucent bars
       const effectiveMode = getEffectiveBarChartMode(this.getBarChartType, this.getMriFrontendConfig)
       return effectiveMode === 'overlay' ? OVERLAY_BAR_OPACITY : 1
     },

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChart.vue
@@ -3,7 +3,15 @@
     <div class="stackbar-chart-area">
       <div class="stackbar-container" id="stacked-chart"></div>
     </div>
-    <StackBarChartLegend v-if="legendTraces.length > 1" :traces="legendTraces" :colorway="legendColorway" />
+    <StackBarChartLegend
+      v-if="legendTraces.length > 1"
+      :traces="legendTraces"
+      :colorway="legendColorway"
+      :bar-opacity="legendBarOpacity"
+      :show-distribution-curve="showDistributionCurveLegend"
+      :area-fill="legendAreaFill"
+      :fill-alpha="legendFillAlpha"
+    />
   </div>
 </template>
 
@@ -16,7 +24,7 @@ import processCSV from '../utils/ProcessCSV'
 import { generateDownloadFileName } from '../utils/generateDownloadFileName'
 import { postProcessBarChartData } from './helpers/postProcessBarChartData'
 import StackBarChartLegend from './StackBarChartLegend.vue'
-import { applyById, getEffectiveBarChartMode } from './StackBarModes/modes'
+import { applyById, getEffectiveBarChartMode, OVERLAY_BAR_OPACITY, KDE_FILL_ALPHA } from './StackBarModes/modes'
 
 const DEFAULT_BAR_GAP = 0.3
 
@@ -315,6 +323,28 @@ export default {
         return this.chartData.colorLegend.map(item => item.color)
       }
       return Object.values(Constants.ChartColorway)
+    },
+    legendBarOpacity() {
+      // Overlapping histogram draws transluscent bars
+      const effectiveMode = getEffectiveBarChartMode(this.getBarChartType, this.getMriFrontendConfig)
+      return effectiveMode === 'overlay' ? OVERLAY_BAR_OPACITY : 1
+    },
+    showDistributionCurveLegend() {
+      const effectiveMode = getEffectiveBarChartMode(this.getBarChartType, this.getMriFrontendConfig)
+      const supportsDistributionCurve = effectiveMode === 'overlay' || effectiveMode === 'partialOverlaySolid'
+      if (!supportsDistributionCurve || !this.getShowDistributionOverlay) return false
+      const firstTrace = this.chartData?.traces?.[0]
+      return (firstTrace?.y?.length || 0) > 1
+    },
+    legendAreaFill() {
+      // for kdp, fill color background with the solid curve color as the border.
+      const effectiveMode = getEffectiveBarChartMode(this.getBarChartType, this.getMriFrontendConfig)
+      if (effectiveMode !== 'distribution') return false
+      const firstTrace = this.chartData?.traces?.[0]
+      return (firstTrace?.y?.length || 0) > 1
+    },
+    legendFillAlpha() {
+      return KDE_FILL_ALPHA
     },
   },
   beforeUnmount() {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChartLegend.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChartLegend.vue
@@ -38,10 +38,9 @@ interface Props {
   colorway: string[]
   barOpacity?: number
   showDistributionCurve?: boolean
-  // When true, bar swatches render as an area-fill square (translucent fill + solid border)
-  // to match the kernel-density-plot rendering instead of a solid filled square.
+  // When true, bar swatches render as area-fill square (translucent fill + solid border)
   areaFill?: boolean
-  // Hex alpha suffix used for the translucent fill when areaFill is true.
+  // Hex alpha suffix used for the translucent fill
   fillAlpha?: string
 }
 
@@ -109,8 +108,7 @@ const legendItems = computed(() => {
       kind,
       displayName,
       fullName,
-      // Bar and curve entries share the same text, so disambiguate for screen
-      // readers by appending the kind to the curve's aria-label.
+      // append distribution to relevant aria-label for screen reader clarity
       ariaLabel: kind === 'curve' ? `${fullName} distribution` : fullName,
       isTruncated: fullName !== displayName,
       color: props.colorway.length > 0 ? props.colorway[originalIndex % props.colorway.length] : '#cccccc',

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChartLegend.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChartLegend.vue
@@ -6,7 +6,7 @@
         :key="index"
         class="stackbar-legend-entry"
         tabindex="0"
-        :aria-label="item.fullName"
+        :aria-label="item.ariaLabel"
         @mouseenter="item.isTruncated && showTooltip($event, item.fullName)"
         @mouseleave="hideTooltip"
         @focus="item.isTruncated && showTooltip($event, item.fullName)"
@@ -109,6 +109,9 @@ const legendItems = computed(() => {
       kind,
       displayName,
       fullName,
+      // Bar and curve entries share the same text, so disambiguate for screen
+      // readers by appending the kind to the curve's aria-label.
+      ariaLabel: kind === 'curve' ? `${fullName} distribution` : fullName,
       isTruncated: fullName !== displayName,
       color: props.colorway.length > 0 ? props.colorway[originalIndex % props.colorway.length] : '#cccccc',
     }

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChartLegend.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarChartLegend.vue
@@ -12,7 +12,8 @@
         @focus="item.isTruncated && showTooltip($event, item.fullName)"
         @blur="hideTooltip"
       >
-        <span class="stackbar-legend-entry-box" :style="{ 'background-color': item.color }"></span>
+        <span v-if="item.kind === 'bar'" class="stackbar-legend-entry-box" :style="barSwatchStyle(item.color)"></span>
+        <span v-else class="stackbar-legend-entry-line" :style="{ 'background-color': item.color }"></span>
         <span class="stackbar-legend-entry-text">{{ item.displayName }}</span>
       </li>
     </ul>
@@ -35,12 +36,36 @@ interface Trace {
 interface Props {
   traces: Trace[]
   colorway: string[]
+  barOpacity?: number
+  showDistributionCurve?: boolean
+  // When true, bar swatches render as an area-fill square (translucent fill + solid border)
+  // to match the kernel-density-plot rendering instead of a solid filled square.
+  areaFill?: boolean
+  // Hex alpha suffix used for the translucent fill when areaFill is true.
+  fillAlpha?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   traces: () => [],
   colorway: () => [],
+  barOpacity: 1,
+  showDistributionCurve: false,
+  areaFill: false,
+  fillAlpha: '30',
 })
+
+const barSwatchStyle = (color: string) => {
+  if (props.areaFill) {
+    return {
+      'background-color': color + props.fillAlpha,
+      border: `1px solid ${color}`,
+    }
+  }
+  return {
+    'background-color': color,
+    opacity: props.barOpacity,
+  }
+}
 
 const tooltipVisible = ref(false)
 const tooltipText = ref('')
@@ -74,17 +99,28 @@ const hideTooltip = () => {
 const legendItems = computed(() => {
   const totalTraces = props.traces.length
   // Reverse to match stacking order (top of stack shown first in legend)
-  return [...props.traces].reverse().map((trace, index) => {
+  const reversed = [...props.traces].reverse()
+
+  const makeItem = (kind: 'bar' | 'curve', trace: Trace, index: number) => {
     const originalIndex = totalTraces - 1 - index
     const fullName = trace.meta?.fullName || trace.name
     const displayName = trace.name
     return {
+      kind,
       displayName,
       fullName,
       isTruncated: fullName !== displayName,
       color: props.colorway.length > 0 ? props.colorway[originalIndex % props.colorway.length] : '#cccccc',
     }
-  })
+  }
+
+  const barItems = reversed.map((trace, index) => makeItem('bar', trace, index))
+
+  if (!props.showDistributionCurve) return barItems
+
+  // Distribution curve legend items share the same labels and colors as the bars
+  const curveItems = reversed.map((trace, index) => makeItem('curve', trace, index))
+  return [...barItems, ...curveItems]
 })
 </script>
 
@@ -123,6 +159,14 @@ const legendItems = computed(() => {
   min-width: 12px;
   margin-right: 8px;
   border-radius: 2px;
+  box-sizing: border-box;
+}
+.stackbar-legend-entry-line {
+  width: 12px;
+  height: 2px;
+  min-width: 12px;
+  margin-right: 8px;
+  border-radius: 1px;
 }
 .stackbar-legend-entry-text {
   font-size: 12px;

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/KernelDensityPlotMode.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/KernelDensityPlotMode.vue
@@ -15,8 +15,7 @@ export const meta = {
   configFlag: 'kernelDensityPlotEnabled',
 }
 
-// Hex alpha suffix appended to the curve color to produce the translucent area fill under each
-// kernel-density curve. Exported so the legend can render swatches with the same fill color.
+// Hex alpha suffix appended to the curve color to produce the translucent area fill
 export const KDE_FILL_ALPHA = '30'
 
 type Ctx = {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/KernelDensityPlotMode.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/KernelDensityPlotMode.vue
@@ -15,6 +15,10 @@ export const meta = {
   configFlag: 'kernelDensityPlotEnabled',
 }
 
+// Hex alpha suffix appended to the curve color to produce the translucent area fill under each
+// kernel-density curve. Exported so the legend can render swatches with the same fill color.
+export const KDE_FILL_ALPHA = '30'
+
 type Ctx = {
   showDistributionOverlay: boolean
   barGap: number
@@ -149,7 +153,7 @@ export function apply(traces: any[], layout: any, ctx: Ctx): { traces: any[]; la
         meta: trace.meta,
         line: { color: ctx.colorway[i % ctx.colorway.length], width: 2 },
         fill: 'tozeroy',
-        fillcolor: ctx.colorway[i % ctx.colorway.length] + '30',
+        fillcolor: ctx.colorway[i % ctx.colorway.length] + KDE_FILL_ALPHA,
         showlegend: trace.showlegend,
         customdata: perPointCustomdata,
         hovertemplate: hoverTemplate,

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/OverlayMode.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/OverlayMode.vue
@@ -25,6 +25,10 @@ export const meta = {
   configFlag: 'overlappingHistogramEnabled',
 }
 
+// Opacity applied to the overlapping bars so stacked groups remain visible through one another.
+// Exported so the legend can render swatches with the same color the bars actually use.
+export const OVERLAY_BAR_OPACITY = 0.3
+
 type Ctx = {
   showDistributionOverlay: boolean
   barGap: number
@@ -37,7 +41,7 @@ export function apply(traces: any[], layout: any, ctx: Ctx): { traces: any[]; la
   // Create new trace objects so the canonical chartData.traces are never mutated.
   const newTraces = traces.map(trace => ({
     ...trace,
-    marker: { ...trace.marker, opacity: 0.3 },
+    marker: { ...trace.marker, opacity: OVERLAY_BAR_OPACITY },
   }))
   if (ctx.showDistributionOverlay) {
     // appendDistributionOverlay pushes to newTraces (safe — it's a fresh array) and

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/OverlayMode.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/OverlayMode.vue
@@ -25,8 +25,6 @@ export const meta = {
   configFlag: 'overlappingHistogramEnabled',
 }
 
-// Opacity applied to the overlapping bars so stacked groups remain visible through one another.
-// Exported so the legend can render swatches with the same color the bars actually use.
 export const OVERLAY_BAR_OPACITY = 0.3
 
 type Ctx = {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/modes.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/StackBarModes/modes.ts
@@ -1,7 +1,11 @@
 import { meta as StackedMeta, apply as applyStacked } from './StackedMode.vue'
-import { meta as OverlayMeta, apply as applyOverlay } from './OverlayMode.vue'
+import { meta as OverlayMeta, apply as applyOverlay, OVERLAY_BAR_OPACITY } from './OverlayMode.vue'
 import { meta as PartialOverlaySolidMeta, apply as applyPartialOverlaySolid } from './PartialOverlaySolidMode.vue'
-import { meta as DistributionCurvesMeta, apply as applyDistributionCurves } from './KernelDensityPlotMode.vue'
+import {
+  meta as DistributionCurvesMeta,
+  apply as applyDistributionCurves,
+  KDE_FILL_ALPHA,
+} from './KernelDensityPlotMode.vue'
 
 export type ModeMeta = {
   id: string
@@ -18,6 +22,8 @@ export type ModeApplyCtx = {
 }
 
 export type ModeApply = (traces: any[], layout: any, ctx: ModeApplyCtx) => { traces: any[]; layout: any }
+
+export { OVERLAY_BAR_OPACITY, KDE_FILL_ALPHA }
 
 export const modeOrder: ModeMeta[] = [StackedMeta, OverlayMeta, PartialOverlaySolidMeta, DistributionCurvesMeta]
 


### PR DESCRIPTION
For the new overlapping chart types (overlapping histograms, overlapping bar chart, KDP overlay and KDP), the legend now displays the exact color assigned to each series/layer in that chart.

Demo:

https://github.com/user-attachments/assets/276120c7-e05c-439f-88bd-4b40db9f178c


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [x] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [x] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)