### PR TITLE
Update attrition plot vuetify dialog behaviour

### DIFF
--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
@@ -159,12 +159,15 @@
     <VDialog
       :model-value="showInclusionReportModal"
       @update:modelValue="showInclusionReportModal = $event"
+      @keydown.esc="closeInclusionReportModal"
       max-width="90%"
       persistent
     >
       <div class="inclusion-report-dialog" data-testid="pa-inclusion-report-dialog">
         <div class="inclusion-report-dialog__title">
-          <div class="inclusion-report-dialog__title-text" data-testid="pa-inclusion-report-dialog-title">Attrition Plot</div>
+          <div class="inclusion-report-dialog__title-text" data-testid="pa-inclusion-report-dialog-title">
+            Attrition Plot
+          </div>
           <button
             class="inclusion-report-dialog__close-btn"
             @click="closeInclusionReportModal"

--- a/plugins/ui/apps/vue-mri-ui-lib/src/plugins/vuetify.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/plugins/vuetify.ts
@@ -185,6 +185,7 @@ export default createVuetify({
     VDialog: {
       maxWidth: 600,
       rounded: 'sm',
+      noClickAnimation: true, // no bouncing animation when clicking outside of persistent dialog
     },
 
     // Data table defaults

--- a/plugins/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/query-filter/components/InclusionReport/index.vue
@@ -487,6 +487,7 @@ h4 {
     height: fit-content;
     border: 1px solid var(--color-ui-light-border, #ddd);
     border-radius: 4px;
+    margin-bottom: 2em;
   }
 
   .treemap-chart {


### PR DESCRIPTION
1. Close attrition plot dialog on `ESC` key press
2. Disable bouncing animation when clicking outside of vuetify dialog

Please note: it is desired behavior for the attrition plot dialog to not close when clicking on the overlay.

Demo:

https://github.com/user-attachments/assets/f1663f07-d1d9-4f68-b1b3-5ad031dfd581



### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)