### PR TITLE
Bug Fix - Parquet Export endpoint for Table 1

### DIFF
--- a/plugins/functions/parquet-export/index.ts
+++ b/plugins/functions/parquet-export/index.ts
@@ -124,7 +124,7 @@ function substituteTemplateParams(
     resultsSchema: string;
   },
   additionalParams: Record<string, string>,
-  conceptIds: number[],
+  conceptIds?: number[],
 ): string {
   if (!isValidCohortId(params.cohortId)) {
     throw new Error("Invalid cohortId");
@@ -224,7 +224,7 @@ function substituteTemplateParams(
     )
     .replace(
       /\{\{CONCEPT_IDS\}\}/g,
-      conceptIds.join(","),
+      conceptIds ? conceptIds.join(",") : "",
     );
 
   const remainingPlaceholders = extractPlaceholders(result);
@@ -480,11 +480,14 @@ router.post("/", async (req: Request, res: Response) => {
     }
 
     const conceptIds = req.body.conceptIds as unknown | undefined;
-    if (!isValidConceptIdArray(conceptIds)) {
-      return res.status(400).json({
-        error: "Invalid parameter",
-        message: "conceptIds must be an array of positive integers",
-      });
+    // Check if template requires CONCEPT_IDS
+    if (template.sqlText.includes("{{CONCEPT_IDS}}")) {
+      if (!isValidConceptIdArray(conceptIds)) {
+        return res.status(400).json({
+          error: "Missing or invalid parameter",
+          message: "conceptIds must be a non-empty array of positive integers",
+        });
+      }
     }
 
     const reservedBodyParams = new Set([
@@ -628,3 +631,4 @@ router.post("/", async (req: Request, res: Response) => {
 
 app.use("/parquet-export", router);
 app.listen(8000);
+  


### PR DESCRIPTION
Update to parquet-export to achieve following -
1. Make the concept ids optional for all templates except the one which has concept_ids as a variable
2. For table 1 template (has concept_ids variable in SQL template), if concept_ids are not passed, it returns a 400 error.


Issue - [https://github.com/OHDSI/Data2Evidence/issues/2817]


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)