### PR TITLE
Increase packet size limit for hdb client to support large SQL statements

### DIFF
--- a/plugins/functions/_shared/alp-base-utils/src/DBConnectionUtil.ts
+++ b/plugins/functions/_shared/alp-base-utils/src/DBConnectionUtil.ts
@@ -58,7 +58,13 @@ export class DBConnectionUtil {
                 if (cb) { cb(null, DBConnectionUtil.pool); }
                 return resolve(DBConnectionUtil.pool);
             }
-            const client = hdb.createClient(credentials);
+            const client = hdb.createClient({
+                ...credentials,
+                // Allows node-hdb to send large prepared SQL statements without
+                // hitting its 128 KiB default request packet size. node-hdb
+                // derives packetSizeLimit from packetSize when it is unset.
+                packetSize: Math.pow(2, 30) - 1,
+            });
             if (cb) { cb(null, client); }
             client.on("error", (err) => {
                 logger.error(err);


### PR DESCRIPTION
## Summary

This PR fixes `MRIDBError: Packet size limit exceeded` when analytics-svc sends very large prepared SQL statements through `node-hdb`.

The change configures the HANA client with a larger `packetSize`:

    const client = hdb.createClient({
        ...credentials,
        // Allows node-hdb to send large prepared SQL statements without
        // hitting its 128 KiB default request packet size. node-hdb
        // derives packetSizeLimit from packetSize when it is unset.
        packetSize: Math.pow(2, 30) - 1,
    });

`packetSizeLimit` is not set separately because `node-hdb` derives it from `packetSize` when `packetSizeLimit` is unset.

## Root Cause

For concept-set filters, query-gen expands the IFR concept-set marker into individual concept constraints before SQL generation.

The relevant expansion path is in:

    plugins/functions/query-gen-svc/src/utils/formatter/ConceptSetToConceptConverter.ts

Concept-set attributes are expanded roughly as:

    IFR conceptSet attribute
    -> terminology-svc included concepts
    -> resolved concept ids
    -> generateConceptConstraints(conceptIds)
    -> large OR tree of "=" constraints
    -> large prepared SQL statement

For broad/root concept sets, this can produce a very large `OR` list in the generated SQL. When analytics-svc prepares that SQL against HANA through `node-hdb`, the default `node-hdb` request packet size is too small for the prepared statement payload.

This causes:

    MRIDBError: Packet size limit exceeded

The packet-size error occurs in the analytics HANA execution path, not in terminology-svc itself.

## Validation

I reproduced the issue using a synthetic terminology-side concept expansion that returns contiguous concept ids. The request flowed through:

    terminology-svc -> query-gen-svc -> analytics-svc -> HANA via node-hdb

Endpoint shape used for validation:

    GET /d2e/analytics-svc/api/services/patient?mriquery=<compressed>&datasetId=<dataset-id>

Filtered logs were used to distinguish real HANA execution from analytics-svc empty fallback responses.

## Results

| Mode | Largest verified working count | First tested failure | Failure |
| --- | ---: | ---: | --- |
| Without `packetSize` fix | 2,500 concepts | 2,750 concepts | `MRIDBError: Packet size limit exceeded` |
| With `packetSize` fix | 65,000 concepts | 65,500 concepts | query-gen/analytics fallback before useful HANA execution |

With the fix, the observed packet-size failure no longer occurs at the previous threshold. The next practical limiter in this synthetic path is query generation / analytics fallback behavior, not `node-hdb` packet size.

## Expected Packet Capacity

With `packetSize = Math.pow(2, 30) - 1`, the configured packet boundary is approximately:

    1,073,741,823 bytes

In the isolated analytics-side packet repro, the generated SQL shape was approximately:

    sqlChars = 6 * conceptCount + 289,081

Using that SQL shape, the theoretical packet-size ceiling is:

    (1,073,741,823 - 289,081) / 6 = ~178,908,790 concepts

So, if query-gen did not fail earlier and HANA accepted the generated SQL shape, the packet-size setting itself should allow roughly `178M` synthetic concepts for that compact analytics-side SQL shape.

In practice, the terminology-side/query-gen path fails much earlier because the IFR is expanded into a very large recursive `OR` tree before analytics reaches HANA. In this validation, the observed post-fix terminology-to-analytics ceiling was only around `65k` concepts because query-gen/analytics fallback became the next limiter.

## Representative Log Evidence

Without the fix:

    [codex-debug terminology-synthetic-concepts] included_concepts size=2750
    defaultLogger: Error: Packet size limit exceeded
    DBError [MRIDBError]: Packet size limit exceeded
    analytics-log: MRIDBError: Packet size limit exceeded

With the fix:

    [codex-debug terminology-synthetic-concepts] included_concepts size=65000
    patient rows returned

At larger sizes after the fix:

    [codex-debug terminology-synthetic-concepts] included_concepts size=65500
    {"sql":"","data":[],"totalPatientCount":0}

That response indicates query-gen/analytics fallback before useful HANA execution, not a packet-size error.

## Clone Investigation

I also tested whether replacing query-gen cloning from:

    JSON.parse(JSON.stringify(...))

to:

    structuredClone(...)

would resolve the large concept-set failure.

The experiment verified that:

- `structuredClone` is available in the Deno runtime.
- query-gen smoke checks still worked after replacing the clone calls.
- direct query generation still succeeded at `100,000` and `110,000` synthetic concepts.
- direct query generation still failed at `112,000` concepts.

The failure at `112,000` was:

    RangeError: Maximum call stack size exceeded
    at QueryObject.join (.../_shared/alp-base-utils/src/QueryObject.ts)
    at Operator.getSQL (.../query-gen-svc/src/qe/sql_generator2/Operator.ts)

So replacing `JSON.parse(JSON.stringify(...))` alone was not enough. The clone method may affect JSON serialization pressure in some paths, but the direct failing mechanism was recursive SQL generation over a very large expanded IFR `OR` tree.

In other words, the durable query-gen-side issue is not only cloning. It is that concept-set semantics are eagerly flattened into many individual concept constraints before SQL generation.

Issue for cloning: https://github.com/OHDSI/Data2Evidence/issues/2837

## Scope

The production code change in this PR is limited to HANA client creation in:

    plugins/functions/_shared/alp-base-utils/src/DBConnectionUtil.ts

No query-gen behavior is changed in this PR.
