### PR TITLE
Fix dataset info card height + required-filters typeahead search & dropdown

### DIFF
--- a/plugins/ui/apps/portal/src/containers/researcher/Information/Information.scss
+++ b/plugins/ui/apps/portal/src/containers/researcher/Information/Information.scss
@@ -1,5 +1,5 @@
 .information__container {
-  height: calc(100% - 4rem);
+  min-height: calc(100% - 4rem);
   margin: 2rem;
 
   .alp-card__header {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ConceptSetTypeaheadField.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ConceptSetTypeaheadField.vue
@@ -127,6 +127,10 @@ const isOpen = ref(false)
 const isCustomValue = ref(false)
 const loading = ref(false)
 const options = ref<Option[]>([])
+// Cached unfiltered value list (from the empty-query fetch). The domain store
+// caches per attribute path and can hand back a previous search's results for an
+// empty query, so we keep our own copy and serve it for empty/cleared input.
+const fullOptions = ref<Option[]>([])
 const suggestionsListRef = ref<HTMLUListElement | null>(null)
 const wrapperRef = ref<HTMLDivElement | null>(null)
 const inputRef = ref<HTMLInputElement | null>(null)
@@ -154,6 +158,13 @@ async function fetchOptions(query: string) {
   if (query === lastQuery.value) return
   lastQuery.value = query
 
+  // Empty query means "the full list". Serve our cached copy instead of the store
+  // response, which may be a prior search's stale results for this path (#2908).
+  if (!query && fullOptions.value.length) {
+    options.value = fullOptions.value
+    return
+  }
+
   loading.value = true
   try {
     const data = await store.dispatch('loadValuesForAttributePath', {
@@ -161,12 +172,23 @@ async function fetchOptions(query: string) {
       searchQuery: query,
       attributeType: 'text',
     })
-    options.value = (data || []).map(domainValueToOption)
+    const mapped = (data || []).map(domainValueToOption)
+    options.value = mapped
+    if (!query) fullOptions.value = mapped
   } catch {
     options.value = []
   } finally {
     loading.value = false
   }
+}
+
+// Restore the full value list immediately (no server round-trip) when the input
+// is emptied, so clearing never shows the previous search's stale results.
+function restoreFullList() {
+  if (fullOptions.value.length) {
+    options.value = fullOptions.value
+  }
+  lastQuery.value = ''
 }
 
 function debouncedFetch(query: string) {
@@ -185,13 +207,29 @@ function updateDropdownPosition() {
   if (!input) return
 
   const rect = input.getBoundingClientRect()
-  dropdownStyle.value = {
+  const MAX_HEIGHT = 200 // keep in sync with .concept-typeahead-dropdown max-height
+  const GAP = 8
+  const spaceBelow = window.innerHeight - rect.bottom
+  const spaceAbove = rect.top
+
+  // Flip above the field when there isn't room below (e.g. fields low in the
+  // modal), so the dropdown never spills past the viewport / behind the footer.
+  const openUp = spaceBelow < Math.min(MAX_HEIGHT, 160) && spaceAbove > spaceBelow
+
+  const style: Record<string, string> = {
     position: 'fixed',
-    top: `${rect.bottom}px`,
     left: `${rect.left}px`,
     width: `${rect.width}px`,
     'z-index': '10002',
   }
+  if (openUp) {
+    style.bottom = `${window.innerHeight - rect.top}px`
+    style['max-height'] = `${Math.max(0, Math.min(MAX_HEIGHT, spaceAbove - GAP))}px`
+  } else {
+    style.top = `${rect.bottom}px`
+    style['max-height'] = `${Math.max(0, Math.min(MAX_HEIGHT, spaceBelow - GAP))}px`
+  }
+  dropdownStyle.value = style
 }
 
 function handleInput() {
@@ -204,6 +242,10 @@ function handleInput() {
   isOpen.value = true
   highlightedIndex.value = -1
   updateDropdownPosition()
+  if (!searchText.value) {
+    restoreFullList()
+    return
+  }
   debouncedFetch(searchText.value)
 }
 
@@ -279,6 +321,7 @@ function clearSelection() {
   selectedItem.value = null
   isCustomValue.value = false
   searchText.value = ''
+  restoreFullList()
   emit('update:modelValue', null)
   emit('update:displayValue', null)
 }


### PR DESCRIPTION

<img width="1966" height="1712" alt="Screen Recording 2026-07-23 at 12 59 20 PM" src="https://github.com/user-attachments/assets/db3dbd75-8097-44be-b037-72a4fa63db76" />

<img width="1966" height="1712" alt="Screen Recording 2026-07-23 at 1 06 24 PM" src="https://github.com/user-attachments/assets/dc94908d-24e4-4eec-9293-9fed99cbf8db" />


### Summary

Patch for the researcher portal / Patient Analytics **required-filters** flow, fixing three UI issues with minimal, targeted changes (net diff is two files).

**Dataset information card (`Information.scss`)** — the researcher information card used `height: calc(100% - 4rem)`. After #2816 gave the researcher `<main>` a definite height (`min-height: 0`), that clamped the card to a viewport-bound box, so tall dataset metadata spilled *below* the white card background. Switched to `min-height: calc(100% - 4rem)` so the card fills the viewport when metadata is short and **grows with content** when it's tall.

**Required-filters typeahead search (`ConceptSetTypeaheadField.vue`)** — an empty query returned nothing, and clearing the input showed the *previous search's* results. Root cause: `domainService` caches domain values per attribute path and returns a prior search's results for an empty (full-list) query. Fixed **in the component** by caching the full value list from the initial empty fetch and serving it for empty/cleared input — no change to the shared store. Now: empty → full list, typing → filtered results, clear → full list again (no stale data).

**Required-filters typeahead dropdown (`ConceptSetTypeaheadField.vue`)** — the dropdown could spill past the viewport / behind the modal's fixed footer for fields low in the modal. It now **flips above** the field (and caps its height to the available space) when there isn't room below.

> Note: an earlier Vuetify `VAutocomplete`/`VCombobox` rewrite of this component (plus a `domainService` `isFullList` change) was intentionally **reverted** — too large for a patch. These fixes are deliberately minimal and component-only, keeping the original hand-rolled component.

### Affected modules

- `plugins/ui/apps/portal` — researcher dataset information page (`Information.scss`)
- `plugins/ui/apps/vue-mri-ui-lib` — required-filters modal typeahead (`ConceptSetTypeaheadField.vue`)

### Validation performed

- `vue-mri` unit tests pass (14/14): `ConceptSetTypeaheadField` + `domainService`.
- `portal` and `vue-mri` built cleanly and hot-deployed to the local trex; verified in-browser: info card grows with metadata; typeahead empty→all, type→filter, clear→all; dropdown flips above low fields.
- Component behavior additionally verified in an isolated Playwright harness (real component + a mock store replicating the real stale-cache behavior).

### Merge Checklist

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in code review doc

Resolves #2906, #2908, #2924
