### PR TITLE
[Analyze 2862] Add validity filter mapping to WebAPI requests

### DIFF
--- a/plugins/ui/apps/concept-sets/src/axios/concept-search-filter.ts
+++ b/plugins/ui/apps/concept-sets/src/axios/concept-search-filter.ts
@@ -1,0 +1,10 @@
+/**
+ * Maps D2E's multi-select validity facet to WebAPI's scalar INVALID_REASON.
+ * Selecting both exhaustive values is equivalent to no validity restriction,
+ * so omit the field instead of making the result depend on selection order.
+ */
+export const getInvalidReasonFilter = (
+  validity: string[],
+): string | undefined => {
+  return validity.length === 1 ? validity[0] : undefined;
+};

--- a/plugins/ui/apps/concept-sets/src/axios/d2e-webapi.ts
+++ b/plugins/ui/apps/concept-sets/src/axios/d2e-webapi.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/terminology";
 import { api } from "./api";
 import { getPortalAPI } from "../utils/PortalUtils";
+import { getInvalidReasonFilter } from "./concept-search-filter";
 
 const D2E_WEBAPI_BASE_URL = "d2e-webapi";
 
@@ -27,13 +28,14 @@ export class D2eWebapi {
     sortBy?: string,
     sortOrder?: string,
   ): Promise<IWebapiConcept[]> {
+    const invalidReason = getInvalidReasonFilter(validity);
     const data = {
       QUERY: searchText,
       CONCEPT_CLASS_ID: conceptClassId,
       DOMAIN_ID: domainId,
       VOCABULARY_ID: vocabularyId,
       STANDARD_CONCEPT: standardConcept[0],
-      INVALID_REASON: validity[0],
+      ...(invalidReason && { INVALID_REASON: invalidReason }),
     };
     const params = new URLSearchParams();
     params.append("page", String(page));

--- a/plugins/ui/apps/concept-sets/src/axios/public-webapi-proxy.ts
+++ b/plugins/ui/apps/concept-sets/src/axios/public-webapi-proxy.ts
@@ -8,6 +8,7 @@ import {
   IWebapiConceptSetExpression,
 } from "../Terminology/utils/types";
 import { getPortalAPI } from "../utils/PortalUtils";
+import { getInvalidReasonFilter } from "./concept-search-filter";
 
 export class PublicWebapiProxyAPI {
   private readonly baseURL: string;
@@ -114,13 +115,14 @@ export class PublicWebapiProxyAPI {
     }
 
     try {
+      const invalidReason = getInvalidReasonFilter(validity);
       const data = {
         QUERY: searchText,
         CONCEPT_CLASS_ID: conceptClassId,
         DOMAIN_ID: domainId,
         VOCABULARY_ID: vocabularyId,
         STANDARD_CONCEPT: standardConcept[0],
-        INVALID_REASON: validity[0],
+        ...(invalidReason && { INVALID_REASON: invalidReason }),
       };
 
       const result = await request({


### PR DESCRIPTION
## Summary

Fixes #2862.

Concept validity is a multi-select filter in D2E, while the OHDSI WebAPI-compatible `INVALID_REASON` field accepts only a scalar value.

Previously, the Concept Sets request adapters sent `validity[0]`. When both `Valid` and `Invalid` were selected, the result depended on selection order and could return no rows even though valid concepts existed.

This change applies the following normalization:

- One value selected: send it as `INVALID_REASON`.
- No values selected: omit `INVALID_REASON`.
- Both `Valid` and `Invalid` selected: omit `INVALID_REASON`, because both exhaustive values are equivalent to no validity restriction.

The same logic is used by the normal D2E WebAPI and public WebAPI-proxy request adapters.

## Why not send an array?

The equivalent OHDSI WebAPI search contract defines `INVALID_REASON` as a scalar. Omitting the field when both values are selected preserves that contract while providing the expected OR semantics.