### PR TITLE
Add deterministic cohort patch function to PA

### DIFF
--- a/plugins/functions/analytics-svc/src/mri/endpoint/StackedBarchartEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/StackedBarchartEndpoint.ts
@@ -40,6 +40,37 @@ export class StackedBarchartEndpoint extends BaseQueryEngineEndpoint {
         return false;
     }
 
+    /**
+     * True when the request selects at least one axis attribute.
+     *
+     * With every axis on "n/a" there is no measure and no category, so the
+     * generated MeasurePopulation CTE comes out as `SELECT  FROM PatientRequest0`
+     * and the database rejects the whole statement with "Parser Error: SELECT
+     * clause without selection list" — a 500 whose message says nothing about the
+     * actual problem. Callers that clear the axes programmatically (the AI
+     * assistant's cohort patches) then see only a "--" count. Detect it here and
+     * answer with the empty result instead.
+     */
+    private hasAxisSelection(bookmarkInputStr: string): boolean {
+        let axisSelection: any;
+        try {
+            axisSelection = JSON.parse(bookmarkInputStr)?.axisSelection;
+        } catch (e) {
+            // Not our call to reject a malformed body — let the normal path report it.
+            return true;
+        }
+        if (!Array.isArray(axisSelection)) {
+            return true;
+        }
+        return axisSelection.some(
+            (axis) =>
+                axis &&
+                typeof axis.attributeId === "string" &&
+                axis.attributeId !== "" &&
+                axis.attributeId !== "n/a"
+        );
+    }
+
     public processRequest(
         req,
         configId,
@@ -68,6 +99,11 @@ export class StackedBarchartEndpoint extends BaseQueryEngineEndpoint {
                     },
                 };
                 if (bookmarkInputStr === "{}") {
+                    return resolve(emptyResult);
+                }
+                if (!this.hasAxisSelection(bookmarkInputStr)) {
+                    emptyResult.noDataReason =
+                        "MRI_PA_CHART_NO_AXIS_SELECTED";
                     return resolve(emptyResult);
                 }
                 let queryResponse: QuerySvcResultType = await generateQuery(

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
@@ -1,0 +1,319 @@
+import { vi } from 'vitest'
+import { applyCohortPatch, type PatchOp } from '../cohortPatch'
+
+// A store stand-in that models just enough of the query module for the applier:
+// filter cards, constraints, and the actions/getters it calls. Cards and
+// constraints are held in plain maps so tests can assert the resulting state.
+const makeStore = ({ existingCards = [] as string[], axes = [] as any[] } = {}) => {
+  const cards: Record<string, { props: { excludeFilter: boolean } }> = {}
+  for (const id of existingCards) cards[id] = { props: { excludeFilter: false } }
+  const constraints: Record<string, any> = {}
+  // Instance numbers continue past whatever is already on the cohort, as they do live.
+  let cardSeq = existingCards.filter(id => id !== 'patient').length
+  let conSeq = 0
+
+  const store: any = {
+    getters: {
+      getFilterCards: () => cards,
+      getAllAxes: axes,
+      getConstraintForAttribute: ({ filterCardId, key }: { filterCardId: string; key: string }) =>
+        Object.values(constraints).find((c: any) => c.parent === filterCardId && c.props.attrKey === key) ?? null,
+    },
+    dispatch: vi.fn(),
+  }
+
+  store.dispatch.mockImplementation((type: string, payload: any) => {
+    switch (type) {
+      case 'holdFireRequest':
+      case 'releaseFireRequest':
+      case 'setFireRequest':
+      case 'refreshPatientCount':
+      case 'resetAxes':
+        return Promise.resolve(undefined)
+      case 'setAxisValue': {
+        if (axes[payload.id]) axes[payload.id].props = { ...axes[payload.id].props, ...payload.props }
+        return Promise.resolve(undefined)
+      }
+      case 'addFilterCard': {
+        // Mirror BoolFilterContainer.createFilterCard: the Basic Data card keeps its
+        // config path as its instance id, interaction cards get an index suffix.
+        const id = payload.configPath === 'patient' ? 'patient' : `${payload.configPath}.${++cardSeq}`
+        cards[id] = { props: { excludeFilter: payload.isExclusion ?? false } }
+        return Promise.resolve(id)
+      }
+      case 'addFilterCardConstraint': {
+        const id = `con${++conSeq}`
+        // type derived from key for test purposes: age -> num, else conceptSet/text
+        const type = payload.key === 'age' ? 'num' : payload.key === 'condition' ? 'conceptSet' : 'text'
+        constraints[id] = { id, parent: payload.filterCardId, props: { attrKey: payload.key, type, value: undefined } }
+        return Promise.resolve(id)
+      }
+      case 'updateConstraintValue': {
+        constraints[payload.constraintId].props.value = payload.value
+        return Promise.resolve(undefined)
+      }
+      case 'deleteFilterCardConstraint': {
+        delete constraints[payload.constraintId]
+        return Promise.resolve(undefined)
+      }
+      case 'deleteFilterCard': {
+        delete cards[payload.filterCardId]
+        // Mirror the real query-module action: deleting a card clears every axis
+        // bound to that card id.
+        for (const axis of axes) {
+          if (axis?.props?.filterCardId === payload.filterCardId) {
+            axis.props = { ...axis.props, attributeId: '', filterCardId: '', key: '' }
+          }
+        }
+        return Promise.resolve(undefined)
+      }
+      default:
+        return Promise.resolve(undefined)
+    }
+  })
+
+  return { store, cards, constraints }
+}
+
+describe('applyCohortPatch', () => {
+  it('rejects an empty patch', async () => {
+    const { store } = makeStore()
+    await expect(applyCohortPatch(store, [] as PatchOp[])).rejects.toThrow(/non-empty/)
+  })
+
+  it('holds fire-request, then releases + refreshes after success', async () => {
+    const { store } = makeStore()
+    await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.interactions.priDiag' }])
+
+    expect(store.dispatch).toHaveBeenCalledWith('holdFireRequest', undefined)
+    expect(store.dispatch).toHaveBeenCalledWith('releaseFireRequest', undefined)
+    expect(store.dispatch).toHaveBeenCalledWith('setFireRequest', undefined)
+    expect(store.dispatch).toHaveBeenCalledWith('refreshPatientCount', undefined)
+  })
+
+  it('applies a basic numeric filter (age >= 65) via the shared normalizer', async () => {
+    const { store, constraints } = makeStore()
+    const res = await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient', ref: 'basic' },
+      { op: 'add_constraint', card: 'basic', attributePath: 'patient.attributes.age', value: '>=65' },
+    ])
+
+    expect(res.applied).toBe(true)
+    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'age') as any
+    expect(con.props.value).toEqual([{ op: '>=', value: 65 }])
+  })
+
+  it('applies a concept-set filter with the picker value shape (conceptSetId + includeDescendants)', async () => {
+    const { store, constraints } = makeStore()
+    await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient.interactions.priDiag', ref: 'dx' },
+      {
+        op: 'add_constraint',
+        card: 'dx',
+        attributePath: 'patient.interactions.priDiag.attributes.condition',
+        value: { conceptSetId: 'cs_42', includeDescendants: true, displayValue: 'Viral sinusitis' },
+      },
+    ])
+
+    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'condition') as any
+    expect(con.props.value).toEqual([
+      { value: 'cs_42', text: 'Viral sinusitis', display_value: 'Viral sinusitis', includeDescendants: true },
+    ])
+  })
+
+  it('accepts a NUMERIC conceptSetId (d2e-mcp create_concept_set) — no "[object Object]"', async () => {
+    const { store, constraints } = makeStore()
+    await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+      {
+        op: 'add_constraint',
+        card: 'dx',
+        attributePath: 'patient.interactions.conditionoccurrence.attributes.condition',
+        // conceptSetId as a number, exactly as create_concept_set returns it
+        value: { conceptSetId: 29, includeDescendants: true, displayValue: 'Sinusitis' },
+      },
+    ])
+
+    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'condition') as any
+    // value must be the stringified concept-set id (the filter Expression reads .value),
+    // NOT the object stringified to "[object Object]".
+    expect(con.props.value).toEqual([
+      { value: '29', text: 'Sinusitis', display_value: 'Sinusitis', includeDescendants: true },
+    ])
+  })
+
+  it('reports the constraint values that actually landed, read back from the store', async () => {
+    const { store } = makeStore()
+    const res = await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+      {
+        op: 'add_constraint',
+        card: 'dx',
+        attributePath: 'patient.interactions.conditionoccurrence.attributes.condition',
+        value: { conceptSetId: 37, displayValue: "Alzheimer's disease" },
+      },
+    ])
+
+    expect(res.appliedConstraints).toEqual([
+      {
+        card: 'patient.interactions.conditionoccurrence.1',
+        attributePath: 'patient.interactions.conditionoccurrence.attributes.condition',
+        value: [
+          {
+            value: '37',
+            text: "Alzheimer's disease",
+            display_value: "Alzheimer's disease",
+            includeDescendants: false,
+          },
+        ],
+      },
+    ])
+  })
+
+  it('rejects an add_constraint with no value instead of silently clearing the filter', async () => {
+    const { store, cards } = makeStore()
+    await expect(
+      applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+        {
+          op: 'add_constraint',
+          card: 'dx',
+          attributePath: 'patient.interactions.conditionoccurrence.attributes.conditionconceptset',
+        } as any,
+      ])
+    ).rejects.toThrow(/has no value/)
+
+    // The half-built card must not survive as an unfiltered Condition Occurrence.
+    expect(Object.keys(cards)).toHaveLength(0)
+  })
+
+  it('names the mistake when the concept-set id sits beside `value` instead of inside it', async () => {
+    const { store } = makeStore()
+    await expect(
+      applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+        {
+          op: 'add_constraint',
+          card: 'dx',
+          attributePath: 'patient.interactions.conditionoccurrence.attributes.conditionconceptset',
+          conceptSetId: 37,
+        } as any,
+      ])
+    ).rejects.toThrow(/conceptSetId at the top level of the op — it belongs inside `value`/)
+  })
+
+  it('rejects an empty-string / empty-array value on a text attribute', async () => {
+    for (const value of ['', [], {}, null]) {
+      const { store } = makeStore()
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'add_card', cardConfigPath: 'patient.interactions.priDiag', ref: 'dx' },
+          {
+            op: 'add_constraint',
+            card: 'dx',
+            attributePath: 'patient.interactions.priDiag.attributes.icd',
+            value,
+          } as any,
+        ])
+      ).rejects.toThrow(/has no value/)
+    }
+  })
+
+  it('rejects an unknown cardConfigPath with a recoverable message when config is loaded', async () => {
+    const { store } = makeStore()
+    store.getters.getMriFrontendConfig = {
+      getFilterCards: () => [{ getConfigPath: () => 'patient' }],
+    }
+    await expect(
+      applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.bogus' }])
+    ).rejects.toThrow(/Unknown cardConfigPath/)
+  })
+
+  it('creates an exclusion card when exclude is set', async () => {
+    const { store, cards } = makeStore()
+    await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.interactions.priDiag', exclude: true }])
+    expect(store.dispatch).toHaveBeenCalledWith('addFilterCard', {
+      configPath: 'patient.interactions.priDiag',
+      isExclusion: true,
+    })
+    expect(Object.values(cards)[0].props.excludeFilter).toBe(true)
+  })
+
+  it('resolves a ref across a multi-op patch and reports created cards', async () => {
+    const { store } = makeStore()
+    const res = await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient', ref: 'p' },
+      { op: 'add_constraint', card: 'p', attributePath: 'patient.attributes.age', value: 65 },
+    ])
+    expect(res.createdCards).toHaveLength(1)
+  })
+
+  it('reuses the Basic Data card instead of adding a second copy of it', async () => {
+    // The model has no way to know Basic Data is always present, so it adds it
+    // before constraining Age/Gender. The store would create a SECOND card under
+    // the same instance id ('patient'), which duplicates every constraint on it in
+    // the generated SQL and clears the chart axes as soon as either copy is deleted.
+    const { store, cards } = makeStore({ existingCards: ['patient'] })
+    const res = await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient', ref: 'basic' },
+      { op: 'add_constraint', card: 'basic', attributePath: 'patient.attributes.age', value: '<100' },
+    ])
+
+    expect(store.dispatch).not.toHaveBeenCalledWith('addFilterCard', expect.objectContaining({ configPath: 'patient' }))
+    expect(Object.keys(cards)).toEqual(['patient'])
+    // The ref still resolves, so the constraint lands on the card that is there.
+    expect(res.applied).toBe(true)
+    expect(res.createdCards).toEqual([])
+  })
+
+  it('still creates a second instance of an indexed (interaction) card', async () => {
+    const { store, cards } = makeStore({ existingCards: ['patient.interactions.conditionoccurrence.1'] })
+    await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence' },
+    ])
+    expect(Object.keys(cards)).toHaveLength(2)
+  })
+
+  it('restores the axis selection when a rolled-back card deletion clears it', async () => {
+    const axes = [
+      { props: { attributeId: 'patient.attributes.Gender', filterCardId: 'patient', key: 'Gender' } },
+      { props: { attributeId: 'patient.attributes.Age', filterCardId: 'patient', key: 'Age', binsize: 10 } },
+    ]
+    const { store } = makeStore({ axes })
+
+    await expect(
+      applyCohortPatch(store, [
+        // 'patient' is absent here, so this genuinely creates the card...
+        { op: 'add_card', cardConfigPath: 'patient', ref: 'p' },
+        // ...and this fails, so the rollback deletes it again — taking both axes with it.
+        { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+      ])
+    ).rejects.toThrow(/Unknown card/)
+
+    expect(axes[0].props).toMatchObject({
+      attributeId: 'patient.attributes.Gender',
+      filterCardId: 'patient',
+      key: 'Gender',
+    })
+    expect(axes[1].props).toMatchObject({ attributeId: 'patient.attributes.Age', filterCardId: 'patient', binsize: 10 })
+  })
+
+  it('rolls back created cards/constraints when a later op fails (atomic)', async () => {
+    const { store, cards, constraints } = makeStore()
+    await expect(
+      applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: 'patient', ref: 'p' },
+        { op: 'add_constraint', card: 'p', attributePath: 'patient.attributes.age', value: 65 },
+        // Unknown card ref -> resolveCard throws mid-patch.
+        { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+      ])
+    ).rejects.toThrow(/Unknown card/)
+
+    // Everything created during the patch is undone.
+    expect(Object.keys(cards)).toHaveLength(0)
+    expect(Object.keys(constraints)).toHaveLength(0)
+    expect(store.dispatch).toHaveBeenCalledWith('releaseFireRequest', undefined)
+    // No live refresh on failure.
+    expect(store.dispatch).not.toHaveBeenCalledWith('refreshPatientCount', undefined)
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
@@ -2,22 +2,57 @@ import { vi } from 'vitest'
 import { applyCohortPatch, type PatchOp } from '../cohortPatch'
 
 // A store stand-in that models just enough of the query module for the applier:
-// filter cards, constraints, and the actions/getters it calls. Cards and
-// constraints are held in plain maps so tests can assert the resulting state.
-const makeStore = ({ existingCards = [] as string[], axes = [] as any[] } = {}) => {
-  const cards: Record<string, { props: { excludeFilter: boolean } }> = {}
-  for (const id of existingCards) cards[id] = { props: { excludeFilter: false } }
+// filter cards, constraints, the bool-container tree that carries the AND/OR
+// structure, and the actions/getters it calls. Cards and constraints are held in
+// plain maps so tests can assert the resulting state.
+//
+// `existingCards` is a flat list (one card per group, i.e. all AND-ed) unless
+// `existingGroups` is passed, which spells the grouping out: each inner array is
+// one bool-filter container, so cards listed together are OR-ed.
+const makeStore = ({
+  existingCards = [] as string[],
+  existingGroups,
+  axes = [] as any[],
+  // attributePath -> config `domainFilter`, the OMOP domain a conceptSet
+  // attribute's concepts must come from. Only set in the tests that exercise it.
+  domains,
+}: {
+  existingCards?: string[]
+  existingGroups?: string[][]
+  axes?: any[]
+  domains?: Record<string, string>
+} = {}) => {
+  const cards: Record<string, { props: { excludeFilter: boolean; name?: string } }> = {}
+  const groups: string[][] = existingGroups ?? existingCards.map(id => [id])
+  for (const id of groups.flat()) cards[id] = { props: { excludeFilter: false } }
   const constraints: Record<string, any> = {}
   // Instance numbers continue past whatever is already on the cohort, as they do live.
-  let cardSeq = existingCards.filter(id => id !== 'patient').length
+  let cardSeq = Object.keys(cards).filter(id => id !== 'patient').length
   let conSeq = 0
+
+  // Bool containers are addressed by id in the store, so index them the way the
+  // real entity map does: group N is container "bfc<N>", stable across splices.
+  const containerIds = () => groups.map((_, i) => `bfc${i}`)
+  const groupOf = (containerId: string) => groups[Number(containerId.replace('bfc', ''))]
 
   const store: any = {
     getters: {
       getFilterCards: () => cards,
+      getFilterCard: (id: string) => cards[id],
+      getFilterCardConstraints: (cardId: string) => Object.values(constraints).filter((c: any) => c.parent === cardId),
       getAllAxes: axes,
+      getBoolContainerRoot: () => 'root',
+      getBoolContainer: (id: string) => (id === 'root' ? { props: { boolfiltercontainers: containerIds() } } : null),
+      getBoolFilterContainer: (id: string) => ({ props: { filterCards: groupOf(id) ?? [] } }),
       getConstraintForAttribute: ({ filterCardId, key }: { filterCardId: string; key: string }) =>
         Object.values(constraints).find((c: any) => c.parent === filterCardId && c.props.attrKey === key) ?? null,
+      ...(domains
+        ? {
+            getMriFrontendConfig: {
+              getAttributeByPath: (path: string) => ({ getDomainFilter: () => domains[path] ?? '' }),
+            },
+          }
+        : {}),
     },
     dispatch: vi.fn(),
   }
@@ -39,13 +74,47 @@ const makeStore = ({ existingCards = [] as string[], axes = [] as any[] } = {}) 
         // config path as its instance id, interaction cards get an index suffix.
         const id = payload.configPath === 'patient' ? 'patient' : `${payload.configPath}.${++cardSeq}`
         cards[id] = { props: { excludeFilter: payload.isExclusion ?? false } }
+        // No container id → a NEW group (AND). With one → join that group (OR).
+        const target = payload.boolFilterContainerId ? groupOf(payload.boolFilterContainerId) : undefined
+        if (target) {
+          target.push(id)
+        } else {
+          groups.push([id])
+        }
         return Promise.resolve(id)
+      }
+      // AND → OR: fold this container into the nearest preceding one.
+      case 'toggleFilterContainerBooleanCondition': {
+        const index = Number(payload.filterContainerId.replace('bfc', ''))
+        groups[index - 1].push(...groups[index])
+        groups.splice(index, 1)
+        return Promise.resolve(undefined)
+      }
+      // OR → AND: split the card (and everything after it) into its own container.
+      case 'toggleFilterBooleanCondition': {
+        const index = Number(payload.parentId.replace('bfc', ''))
+        const group = groups[index]
+        const moved = group.splice(group.indexOf(payload.filterCardId))
+        groups.splice(index + 1, 0, moved)
+        return Promise.resolve(undefined)
       }
       case 'addFilterCardConstraint': {
         const id = `con${++conSeq}`
         // type derived from key for test purposes: age -> num, else conceptSet/text
-        const type = payload.key === 'age' ? 'num' : payload.key === 'condition' ? 'conceptSet' : 'text'
-        constraints[id] = { id, parent: payload.filterCardId, props: { attrKey: payload.key, type, value: undefined } }
+        const type =
+          payload.key === 'age'
+            ? 'num'
+            : payload.key === 'condition' || /conceptset$/i.test(payload.key)
+              ? 'conceptSet'
+              : 'text'
+        // The real constraint carries the attribute's config path; the card's
+        // instance id is its config path plus an index suffix.
+        const attributePath = `${payload.filterCardId.replace(/\.\d+$/, '')}.attributes.${payload.key}`
+        constraints[id] = {
+          id,
+          parent: payload.filterCardId,
+          props: { attrKey: payload.key, attributePath, type, value: undefined },
+        }
         return Promise.resolve(id)
       }
       case 'updateConstraintValue': {
@@ -58,6 +127,13 @@ const makeStore = ({ existingCards = [] as string[], axes = [] as any[] } = {}) 
       }
       case 'deleteFilterCard': {
         delete cards[payload.filterCardId]
+        // Mirror FILTERCARD_DELETE: the card leaves its container, and a container
+        // left empty is dropped from the tree.
+        for (let i = groups.length - 1; i >= 0; i -= 1) {
+          const at = groups[i].indexOf(payload.filterCardId)
+          if (at > -1) groups[i].splice(at, 1)
+          if (groups[i].length === 0) groups.splice(i, 1)
+        }
         // Mirror the real query-module action: deleting a card clears every axis
         // bound to that card id.
         for (const axis of axes) {
@@ -72,7 +148,7 @@ const makeStore = ({ existingCards = [] as string[], axes = [] as any[] } = {}) 
     }
   })
 
-  return { store, cards, constraints }
+  return { store, cards, constraints, groups }
 }
 
 describe('applyCohortPatch', () => {
@@ -296,6 +372,242 @@ describe('applyCohortPatch', () => {
       key: 'Gender',
     })
     expect(axes[1].props).toMatchObject({ attributeId: 'patient.attributes.Age', filterCardId: 'patient', binsize: 10 })
+  })
+
+  describe('AND / OR grouping', () => {
+    const DX = 'patient.interactions.conditionoccurrence'
+
+    it('AND-s a new card by default (each card in its own group)', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      const res = await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX }])
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`], [`${DX}.2`]])
+      expect(res.cardGroups).toHaveLength(3)
+    })
+
+    it('ORs a new card with an existing one via orWith — "Alzheimer\'s OR sinusitis"', async () => {
+      // The reported bug: asked to widen an Alzheimer's cohort to "Alzheimer's OR
+      // sinusitis", the assistant could only add a second AND-ed card, which reads
+      // as "had both". The second condition has to land in the FIRST card's group.
+      const { store, groups, constraints } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      const res = await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: DX, ref: 'dx2', orWith: `${DX}.1` },
+        {
+          op: 'add_constraint',
+          card: 'dx2',
+          attributePath: `${DX}.attributes.conditionconceptset`,
+          value: { conceptSetId: 42, displayValue: 'Sinusitis' },
+        },
+      ])
+
+      expect(store.dispatch).toHaveBeenCalledWith('addFilterCard', {
+        configPath: DX,
+        isExclusion: false,
+        boolFilterContainerId: 'bfc1',
+      })
+      // One group holding both condition cards = Or(A, B) in the IFR.
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+      expect(res.cardGroups).toEqual([
+        { cards: [{ filterCardId: 'patient', name: 'patient' }] },
+        {
+          cards: [
+            { filterCardId: `${DX}.1`, name: `${DX}.1` },
+            { filterCardId: `${DX}.2`, name: `${DX}.2` },
+          ],
+        },
+      ])
+      // ...and the sinusitis filter is on the NEW card only — the first card's
+      // concept set is not restated, which would have made it "both conditions".
+      const con = Object.values(constraints).find((c: any) => c.parent === `${DX}.2`) as any
+      expect(con.props.value).toEqual([
+        { value: '42', text: 'Sinusitis', display_value: 'Sinusitis', includeDescendants: false },
+      ])
+      expect(Object.values(constraints)).toHaveLength(1)
+    })
+
+    it('resolves orWith against a ref created earlier in the same patch', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient'] })
+      await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: DX, ref: 'a' },
+        { op: 'add_card', cardConfigPath: DX, ref: 'b', orWith: 'a' },
+      ])
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+    })
+
+    it('refuses to OR a card with Basic Data (it would match every patient)', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient'] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX, orWith: 'patient' }])
+      ).rejects.toThrow(/Basic Data/)
+      expect(groups).toEqual([['patient']])
+    })
+
+    it('refuses to OR an exclusion card with an inclusion one', async () => {
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX, exclude: true, orWith: `${DX}.1` }])
+      ).rejects.toThrow(/exclusion/)
+    })
+
+    it('set_card_join OR merges a card already on the cohort into the preceding group', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`, `${DX}.2`] })
+      const res = await applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'OR' }])
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+      expect(res.cardGroups?.[1].cards.map(c => c.filterCardId)).toEqual([`${DX}.1`, `${DX}.2`])
+    })
+
+    it('set_card_join AND splits an OR-ed card back into its own group', async () => {
+      const { store, groups } = makeStore({ existingGroups: [['patient'], [`${DX}.1`, `${DX}.2`]] })
+      await applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'AND' }])
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`], [`${DX}.2`]])
+    })
+
+    it('is a no-op when the requested join is already in place', async () => {
+      const { store, groups } = makeStore({ existingGroups: [['patient'], [`${DX}.1`, `${DX}.2`]] })
+      await applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'OR' }])
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+      expect(store.dispatch).not.toHaveBeenCalledWith('toggleFilterContainerBooleanCondition', expect.anything())
+    })
+
+    it('refuses to OR the first filter card with Basic Data before it', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.1`, join: 'OR' }])
+      ).rejects.toThrow(/Basic Data/)
+      expect(groups).toEqual([['patient'], [`${DX}.1`]])
+    })
+
+    it('rejects an invalid join value', async () => {
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`, `${DX}.2`] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'XOR' } as any])
+      ).rejects.toThrow(/must be "AND" or "OR"/)
+    })
+
+    it('undoes a grouping change when a later op fails (atomic)', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`, `${DX}.2`] })
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'set_card_join', card: `${DX}.2`, join: 'OR' },
+          { op: 'add_constraint', card: 'ghost', attributePath: `${DX}.attributes.condition`, value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`], [`${DX}.2`]])
+    })
+
+    it('keeps the chart axes when OR-ing clears them (resetAxes fires on grouped cards)', async () => {
+      // resetAxes clears every axis bound to a card in a container that now holds
+      // more than one card. Left cleared, the chart query goes out with an empty
+      // axisSelection and the patient count renders "--".
+      const axes = [{ props: { attributeId: `${DX}.attributes.startdate`, filterCardId: `${DX}.1`, key: 'startdate' } }]
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`], axes })
+      // The real resetAxes runs inside addFilterCard; the mock triggers it here.
+      store.dispatch.mockImplementation(
+        (
+          (inner: any) => (type: string, payload: any) => {
+            const res = inner(type, payload)
+            if (type === 'addFilterCard' && payload.boolFilterContainerId) {
+              axes[0].props = { attributeId: '', filterCardId: '', key: '' }
+            }
+            return res
+          }
+        )(store.dispatch.getMockImplementation())
+      )
+
+      await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX, orWith: `${DX}.1` }])
+
+      expect(axes[0].props).toMatchObject({
+        attributeId: `${DX}.attributes.startdate`,
+        filterCardId: `${DX}.1`,
+      })
+    })
+  })
+
+  describe('concept-set domain', () => {
+    const DX = 'patient.interactions.conditionoccurrence'
+    const VISIT = 'patient.interactions.visit'
+    const DX_SET = `${DX}.attributes.conditionconceptset`
+    const VISIT_SET = `${VISIT}.attributes.visitconceptset`
+    const domains = { [DX_SET]: 'Condition', [VISIT_SET]: 'Visit' }
+
+    // "Alzheimer's OR an ER visit": the model OR-ed the Visit card correctly and
+    // then filled its concept set with the Alzheimer's set it already had in
+    // context, never resolving "ER visit". The cohort computes, so nothing looks
+    // wrong — it just answers a different question.
+    const carriedOverPatch: PatchOp[] = [
+      { op: 'add_card', cardConfigPath: VISIT, ref: 'v', orWith: `${DX}.1` },
+      { op: 'add_constraint', card: 'v', attributePath: VISIT_SET, value: { conceptSetId: 41 } },
+    ]
+
+    const withAlzheimers = async () => {
+      const made = makeStore({ existingCards: ['patient', `${DX}.1`], domains })
+      await applyCohortPatch(made.store, [
+        {
+          op: 'add_constraint',
+          card: `${DX}.1`,
+          attributePath: DX_SET,
+          value: { conceptSetId: 41, displayValue: "Alzheimer's disease" },
+        },
+      ])
+      return made
+    }
+
+    it("rejects carrying a Condition concept set onto a Visit card's concept set", async () => {
+      const { store, constraints } = await withAlzheimers()
+
+      await expect(applyCohortPatch(store, carriedOverPatch)).rejects.toThrow(
+        /Concept set 41 is already filtered on .*conditionconceptset.*Condition-domain.*Visit-domain/s
+      )
+      // Atomic: the half-built Visit card is gone, and the Alzheimer's filter stands.
+      const visitConstraint = Object.values(constraints).find((c: any) => c.parent.startsWith(VISIT))
+      expect(visitConstraint).toBeUndefined()
+      expect(Object.values(constraints)).toHaveLength(1)
+    })
+
+    it('rolls the OR-ed card back out of the group when its value is rejected', async () => {
+      const { store, groups } = await withAlzheimers()
+      await expect(applyCohortPatch(store, carriedOverPatch)).rejects.toThrow(/Concept set 41/)
+      expect(groups).toEqual([['patient'], [`${DX}.1`]])
+    })
+
+    it('allows the same concept set on two cards of the SAME domain (primary + secondary diagnosis)', async () => {
+      const { store } = await withAlzheimers()
+      const res = await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: DX, ref: 'dx2', orWith: `${DX}.1` },
+        { op: 'add_constraint', card: 'dx2', attributePath: DX_SET, value: { conceptSetId: 41 } },
+      ])
+      expect(res.applied).toBe(true)
+    })
+
+    it('allows a different concept set on the Visit card — the correct fix', async () => {
+      const { store, constraints } = await withAlzheimers()
+      const res = await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: VISIT, ref: 'v', orWith: `${DX}.1` },
+        {
+          op: 'add_constraint',
+          card: 'v',
+          attributePath: VISIT_SET,
+          value: { conceptSetId: 88, displayValue: 'Emergency Room Visit' },
+        },
+      ])
+      expect(res.applied).toBe(true)
+      const visitConstraint = Object.values(constraints).find((c: any) => c.parent.startsWith(VISIT)) as any
+      expect(visitConstraint.props.value[0]).toMatchObject({ value: '88', text: 'Emergency Room Visit' })
+    })
+
+    it('skips the check when the config exposes no domain for the attribute', async () => {
+      // domainFilter is empty on plenty of attributes (and absent on non-OMOP
+      // configs); an unknown domain must not block a legitimate patch.
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await applyCohortPatch(store, [
+        { op: 'add_constraint', card: `${DX}.1`, attributePath: DX_SET, value: { conceptSetId: 41 } },
+      ])
+      const res = await applyCohortPatch(store, carriedOverPatch)
+      expect(res.applied).toBe(true)
+    })
   })
 
   it('rolls back created cards/constraints when a later op fails (atomic)', async () => {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
@@ -99,6 +99,12 @@ const makeStore = ({
         return Promise.resolve(undefined)
       }
       case 'addFilterCardConstraint': {
+        const existing = Object.values(constraints).find(
+          (c: any) => c.parent === payload.filterCardId && c.props.attrKey === payload.key
+        ) as any
+        if (existing) {
+          return Promise.resolve(existing.id)
+        }
         const id = `con${++conSeq}`
         // type derived from key for test purposes: age -> num, *date -> time,
         // else conceptSet/text
@@ -295,9 +301,9 @@ describe('applyCohortPatch', () => {
     store.getters.getMriFrontendConfig = {
       getFilterCards: () => [{ getConfigPath: () => 'patient' }],
     }
-    await expect(
-      applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.bogus' }])
-    ).rejects.toThrow(/Unknown cardConfigPath/)
+    await expect(applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.bogus' }])).rejects.toThrow(
+      /Unknown cardConfigPath/
+    )
   })
 
   it('creates an exclusion card when exclude is set', async () => {
@@ -330,9 +336,7 @@ describe('applyCohortPatch', () => {
 
   it('still creates a second instance of an indexed (interaction) card', async () => {
     const { store, cards } = makeStore({ existingCards: ['patient.interactions.conditionoccurrence.1'] })
-    await applyCohortPatch(store, [
-      { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence' },
-    ])
+    await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence' }])
     expect(Object.keys(cards)).toHaveLength(2)
   })
 
@@ -459,17 +463,17 @@ describe('applyCohortPatch', () => {
 
     it('refuses to OR the first filter card with Basic Data before it', async () => {
       const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
-      await expect(
-        applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.1`, join: 'OR' }])
-      ).rejects.toThrow(/Basic Data/)
+      await expect(applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.1`, join: 'OR' }])).rejects.toThrow(
+        /Basic Data/
+      )
       expect(groups).toEqual([['patient'], [`${DX}.1`]])
     })
 
     it('refuses to change the join on the Basic Data card itself', async () => {
       const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
-      await expect(
-        applyCohortPatch(store, [{ op: 'set_card_join', card: 'patient', join: 'OR' }])
-      ).rejects.toThrow(/Basic Data card is always AND-ed/)
+      await expect(applyCohortPatch(store, [{ op: 'set_card_join', card: 'patient', join: 'OR' }])).rejects.toThrow(
+        /Basic Data card is always AND-ed/
+      )
       expect(groups).toEqual([['patient'], [`${DX}.1`]])
     })
 
@@ -500,15 +504,13 @@ describe('applyCohortPatch', () => {
       const { store } = makeStore({ existingCards: ['patient', `${DX}.1`], axes })
       // The real resetAxes runs inside addFilterCard; the mock triggers it here.
       store.dispatch.mockImplementation(
-        (
-          (inner: any) => (type: string, payload: any) => {
-            const res = inner(type, payload)
-            if (type === 'addFilterCard' && payload.boolFilterContainerId) {
-              axes[0].props = { attributeId: '', filterCardId: '', key: '' }
-            }
-            return res
+        ((inner: any) => (type: string, payload: any) => {
+          const res = inner(type, payload)
+          if (type === 'addFilterCard' && payload.boolFilterContainerId) {
+            axes[0].props = { attributeId: '', filterCardId: '', key: '' }
           }
-        )(store.dispatch.getMockImplementation())
+          return res
+        })(store.dispatch.getMockImplementation())
       )
 
       await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX, orWith: `${DX}.1` }])
@@ -673,7 +675,7 @@ describe('applyCohortPatch', () => {
       return made
     }
 
-    it('removes one constraint and leaves the card\'s other filters alone', async () => {
+    it("removes one constraint and leaves the card's other filters alone", async () => {
       const { store, constraints } = await withAlzheimers()
       const res = await applyCohortPatch(store, [{ op: 'remove_constraint', card: `${DX}.1`, attributePath: DX_SET }])
 
@@ -711,6 +713,29 @@ describe('applyCohortPatch', () => {
       ])
     })
 
+    it('puts the ORIGINAL value back when the patch replaced the same constraint and then failed', async () => {
+      const { store, constraints } = await withAlzheimers()
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_constraint', card: `${DX}.1`, attributePath: DX_SET },
+          {
+            op: 'add_constraint',
+            card: `${DX}.1`,
+            attributePath: DX_SET,
+            value: { conceptSetId: 99, displayValue: 'Something else' },
+          },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      const cons = Object.values(constraints).filter((c: any) => c.props.attrKey === 'conditionconceptset')
+      expect(cons).toHaveLength(1)
+      expect((cons[0] as any).props.value).toEqual([
+        { value: '41', text: "Alzheimer's disease", display_value: "Alzheimer's disease", includeDescendants: false },
+      ])
+    })
+
     it('removes a card — and leaves it removed when a later op fails', async () => {
       // The one op revert cannot undo: re-adding the card would mint a new instance
       // id and lose the constraints that hung off it. Pinned here so the limitation
@@ -729,9 +754,7 @@ describe('applyCohortPatch', () => {
     })
 
     it('does not re-point the chart axes at a card the patch removed', async () => {
-      const axes = [
-        { props: { attributeId: `${DX}.attributes.startdate`, filterCardId: `${DX}.1`, key: 'startdate' } },
-      ]
+      const axes = [{ props: { attributeId: `${DX}.attributes.startdate`, filterCardId: `${DX}.1`, key: 'startdate' } }]
       const { store } = makeStore({ existingCards: ['patient', `${DX}.1`], axes })
 
       await expect(

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
@@ -100,25 +100,43 @@ const makeStore = ({
       }
       case 'addFilterCardConstraint': {
         const id = `con${++conSeq}`
-        // type derived from key for test purposes: age -> num, else conceptSet/text
+        // type derived from key for test purposes: age -> num, *date -> time,
+        // else conceptSet/text
         const type =
           payload.key === 'age'
             ? 'num'
-            : payload.key === 'condition' || /conceptset$/i.test(payload.key)
-              ? 'conceptSet'
-              : 'text'
+            : /date$/i.test(payload.key)
+              ? 'time'
+              : payload.key === 'condition' || /conceptset$/i.test(payload.key)
+                ? 'conceptSet'
+                : 'text'
         // The real constraint carries the attribute's config path; the card's
         // instance id is its config path plus an index suffix.
         const attributePath = `${payload.filterCardId.replace(/\.\d+$/, '')}.attributes.${payload.key}`
         constraints[id] = {
           id,
           parent: payload.filterCardId,
-          props: { attrKey: payload.key, attributePath, type, value: undefined },
+          props: {
+            attrKey: payload.key,
+            attributePath,
+            type,
+            value: undefined,
+            // Mirror DateConstraintModel: a date constraint keeps NO value of its
+            // own — its state is fromDate/toDate, initialized to ''.
+            ...(type === 'time' ? { fromDate: { value: '' }, toDate: { value: '' } } : {}),
+          },
         }
         return Promise.resolve(id)
       }
       case 'updateConstraintValue': {
         constraints[payload.constraintId].props.value = payload.value
+        return Promise.resolve(undefined)
+      }
+      // Mirrors CONSTRAINTS_DATETIME_SET_VALUE — a slot entirely separate from
+      // props.value, which props.value-only bookkeeping cannot restore.
+      case 'updateDateConstraintValue': {
+        constraints[payload.constraintId].props.fromDate.value = payload.fromDateValue
+        constraints[payload.constraintId].props.toDate.value = payload.toDateValue
         return Promise.resolve(undefined)
       }
       case 'deleteFilterCardConstraint': {
@@ -607,6 +625,57 @@ describe('applyCohortPatch', () => {
       ])
       const res = await applyCohortPatch(store, carriedOverPatch)
       expect(res.applied).toBe(true)
+    })
+  })
+
+  it('restores a date range when a later op fails — the state lives in fromDate/toDate', async () => {
+    // Date/time constraints are written by updateDateConstraintValue into
+    // props.fromDate.value / props.toDate.value and have no props.value at all, so
+    // rollback bookkeeping that snapshots only `value` recorded undefined and
+    // restored nothing: the patch threw, and the widened window stayed on the
+    // cohort. The user is told nothing was applied, and a later save persists a
+    // date range nobody asked for.
+    const DX = 'patient.interactions.conditionoccurrence'
+    const STARTDATE = `${DX}.attributes.startdate`
+    const { store, constraints } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+
+    // Patch 1 commits the window the cohort arrives with (as opening a saved
+    // cohort would) — the constraint therefore pre-exists patch 2.
+    await applyCohortPatch(store, [
+      {
+        op: 'add_constraint',
+        card: `${DX}.1`,
+        attributePath: STARTDATE,
+        value: { from: '2019-01-01', to: '2019-12-31' },
+      },
+    ])
+    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'startdate') as any
+    const before = { from: con.props.fromDate.value, to: con.props.toDate.value }
+    expect(before.from).toBeInstanceOf(Date)
+    expect(con.props.value).toBeUndefined()
+
+    // Patch 2 widens the window, then fails on the next op.
+    await expect(
+      applyCohortPatch(store, [
+        {
+          op: 'add_constraint',
+          card: `${DX}.1`,
+          attributePath: STARTDATE,
+          value: { from: '2015-01-01', to: '2020-12-31' },
+        },
+        { op: 'add_constraint', card: 'ghost', attributePath: `${DX}.attributes.condition`, value: 1 },
+      ])
+    ).rejects.toThrow(/Unknown card/)
+
+    expect(con.props.fromDate.value).toEqual(before.from)
+    expect(con.props.toDate.value).toEqual(before.to)
+    // isUTC:true is the pass-through branch; isUTC:false shifts by the timezone
+    // offset on every call, so a revert using it would move the restored range.
+    expect(store.dispatch).toHaveBeenCalledWith('updateDateConstraintValue', {
+      constraintId: con.id,
+      fromDateValue: before.from,
+      toDateValue: before.to,
+      isUTC: true,
     })
   })
 

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
@@ -193,6 +193,9 @@ describe('applyCohortPatch', () => {
     ])
 
     expect(res.applied).toBe(true)
+    // The `ref` resolved across ops, so the constraint landed on the card the
+    // preceding add_card created.
+    expect(res.createdCards).toHaveLength(1)
     const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'age') as any
     expect(con.props.value).toEqual([{ op: '>=', value: 65 }])
   })
@@ -215,27 +218,6 @@ describe('applyCohortPatch', () => {
     ])
   })
 
-  it('accepts a NUMERIC conceptSetId (d2e-mcp create_concept_set) — no "[object Object]"', async () => {
-    const { store, constraints } = makeStore()
-    await applyCohortPatch(store, [
-      { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
-      {
-        op: 'add_constraint',
-        card: 'dx',
-        attributePath: 'patient.interactions.conditionoccurrence.attributes.condition',
-        // conceptSetId as a number, exactly as create_concept_set returns it
-        value: { conceptSetId: 29, includeDescendants: true, displayValue: 'Sinusitis' },
-      },
-    ])
-
-    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'condition') as any
-    // value must be the stringified concept-set id (the filter Expression reads .value),
-    // NOT the object stringified to "[object Object]".
-    expect(con.props.value).toEqual([
-      { value: '29', text: 'Sinusitis', display_value: 'Sinusitis', includeDescendants: true },
-    ])
-  })
-
   it('reports the constraint values that actually landed, read back from the store', async () => {
     const { store } = makeStore()
     const res = await applyCohortPatch(store, [
@@ -244,6 +226,10 @@ describe('applyCohortPatch', () => {
         op: 'add_constraint',
         card: 'dx',
         attributePath: 'patient.interactions.conditionoccurrence.attributes.condition',
+        // conceptSetId as a NUMBER, exactly as d2e-mcp create_concept_set returns it:
+        // it has to land as the stringified id (the filter Expression reads .value),
+        // never as the object stringified to "[object Object]" — a broken filter that
+        // renders an empty chart and a patient count of "--".
         value: { conceptSetId: 37, displayValue: "Alzheimer's disease" },
       },
     ])
@@ -264,22 +250,30 @@ describe('applyCohortPatch', () => {
     ])
   })
 
-  it('rejects an add_constraint with no value instead of silently clearing the filter', async () => {
-    const { store, cards } = makeStore()
-    await expect(
-      applyCohortPatch(store, [
-        { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
-        {
-          op: 'add_constraint',
-          card: 'dx',
-          attributePath: 'patient.interactions.conditionoccurrence.attributes.conditionconceptset',
-        } as any,
-      ])
-    ).rejects.toThrow(/has no value/)
+  // Every empty shape is caught by the same input check, before anything is
+  // mutated: applyConstraintValue reads an empty value on a text/conceptSet
+  // attribute as "clear this filter", so the patch would report success and leave
+  // a filter card with no constraint on the cohort.
+  it.each([[undefined], [''], [[]], [{}], [null]])(
+    'rejects an add_constraint whose value is %p instead of silently clearing the filter',
+    async value => {
+      const { store, cards } = makeStore()
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+          {
+            op: 'add_constraint',
+            card: 'dx',
+            attributePath: 'patient.interactions.conditionoccurrence.attributes.conditionconceptset',
+            value,
+          } as any,
+        ])
+      ).rejects.toThrow(/has no value/)
 
-    // The half-built card must not survive as an unfiltered Condition Occurrence.
-    expect(Object.keys(cards)).toHaveLength(0)
-  })
+      // The half-built card must not survive as an unfiltered Condition Occurrence.
+      expect(Object.keys(cards)).toHaveLength(0)
+    }
+  )
 
   it('names the mistake when the concept-set id sits beside `value` instead of inside it', async () => {
     const { store } = makeStore()
@@ -294,23 +288,6 @@ describe('applyCohortPatch', () => {
         } as any,
       ])
     ).rejects.toThrow(/conceptSetId at the top level of the op — it belongs inside `value`/)
-  })
-
-  it('rejects an empty-string / empty-array value on a text attribute', async () => {
-    for (const value of ['', [], {}, null]) {
-      const { store } = makeStore()
-      await expect(
-        applyCohortPatch(store, [
-          { op: 'add_card', cardConfigPath: 'patient.interactions.priDiag', ref: 'dx' },
-          {
-            op: 'add_constraint',
-            card: 'dx',
-            attributePath: 'patient.interactions.priDiag.attributes.icd',
-            value,
-          } as any,
-        ])
-      ).rejects.toThrow(/has no value/)
-    }
   })
 
   it('rejects an unknown cardConfigPath with a recoverable message when config is loaded', async () => {
@@ -331,15 +308,6 @@ describe('applyCohortPatch', () => {
       isExclusion: true,
     })
     expect(Object.values(cards)[0].props.excludeFilter).toBe(true)
-  })
-
-  it('resolves a ref across a multi-op patch and reports created cards', async () => {
-    const { store } = makeStore()
-    const res = await applyCohortPatch(store, [
-      { op: 'add_card', cardConfigPath: 'patient', ref: 'p' },
-      { op: 'add_constraint', card: 'p', attributePath: 'patient.attributes.age', value: 65 },
-    ])
-    expect(res.createdCards).toHaveLength(1)
   })
 
   it('reuses the Basic Data card instead of adding a second copy of it', async () => {
@@ -494,6 +462,14 @@ describe('applyCohortPatch', () => {
       await expect(
         applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.1`, join: 'OR' }])
       ).rejects.toThrow(/Basic Data/)
+      expect(groups).toEqual([['patient'], [`${DX}.1`]])
+    })
+
+    it('refuses to change the join on the Basic Data card itself', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'set_card_join', card: 'patient', join: 'OR' }])
+      ).rejects.toThrow(/Basic Data card is always AND-ed/)
       expect(groups).toEqual([['patient'], [`${DX}.1`]])
     })
 
@@ -676,6 +652,98 @@ describe('applyCohortPatch', () => {
       fromDateValue: before.from,
       toDateValue: before.to,
       isUTC: true,
+    })
+  })
+
+  describe('removals', () => {
+    const DX = 'patient.interactions.conditionoccurrence'
+    const DX_SET = `${DX}.attributes.conditionconceptset`
+
+    const withAlzheimers = async () => {
+      const made = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await applyCohortPatch(made.store, [
+        { op: 'add_constraint', card: 'patient', attributePath: 'patient.attributes.age', value: '>=65' },
+        {
+          op: 'add_constraint',
+          card: `${DX}.1`,
+          attributePath: DX_SET,
+          value: { conceptSetId: 41, displayValue: "Alzheimer's disease" },
+        },
+      ])
+      return made
+    }
+
+    it('removes one constraint and leaves the card\'s other filters alone', async () => {
+      const { store, constraints } = await withAlzheimers()
+      const res = await applyCohortPatch(store, [{ op: 'remove_constraint', card: `${DX}.1`, attributePath: DX_SET }])
+
+      expect(res.applied).toBe(true)
+      expect(Object.values(constraints).map((c: any) => c.props.attrKey)).toEqual(['age'])
+    })
+
+    it('is a no-op when the constraint to remove is not on the card', async () => {
+      const { store } = makeStore({ existingCards: ['patient'] })
+      const res = await applyCohortPatch(store, [
+        { op: 'remove_constraint', card: 'patient', attributePath: 'patient.attributes.age' },
+      ])
+
+      expect(res.applied).toBe(true)
+      expect(store.dispatch).not.toHaveBeenCalledWith('deleteFilterCardConstraint', expect.anything())
+    })
+
+    it('puts a removed constraint back — value and all — when a later op fails', async () => {
+      // Atomic has to mean the filter the user had comes back, not merely that
+      // nothing new was added. A patch that widens a cohort by dropping a filter and
+      // then fails would otherwise leave it permanently widened while telling the
+      // user nothing was applied.
+      const { store, constraints } = await withAlzheimers()
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_constraint', card: `${DX}.1`, attributePath: DX_SET },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'conditionconceptset') as any
+      expect(con.props.value).toEqual([
+        { value: '41', text: "Alzheimer's disease", display_value: "Alzheimer's disease", includeDescendants: false },
+      ])
+    })
+
+    it('removes a card — and leaves it removed when a later op fails', async () => {
+      // The one op revert cannot undo: re-adding the card would mint a new instance
+      // id and lose the constraints that hung off it. Pinned here so the limitation
+      // stays a decision (documented on applyCohortPatch) rather than a surprise.
+      const { store, cards, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_card', card: `${DX}.1` },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      expect(Object.keys(cards)).toEqual(['patient'])
+      expect(groups).toEqual([['patient']])
+    })
+
+    it('does not re-point the chart axes at a card the patch removed', async () => {
+      const axes = [
+        { props: { attributeId: `${DX}.attributes.startdate`, filterCardId: `${DX}.1`, key: 'startdate' } },
+      ]
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`], axes })
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_card', card: `${DX}.1` },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      // Restoring the snapshot here would leave the chart querying an axis bound to
+      // a filterCardId the IFR no longer contains.
+      expect(axes[0].props).toMatchObject({ attributeId: '', filterCardId: '', key: '' })
     })
   })
 

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
@@ -3,8 +3,7 @@
 // The LLM emits typed *intent* (PatchOp[]) — never a hand-built bookmark tree —
 // and this applier mutates the IFR already in the Vuex store via the app's own
 // query actions. That reuses the exact validation/normalization the UI uses, so
-// AI-driven edits behave identically to wizard-driven ones. See
-// DESIGN_pa_apply_cohort_patch.md and CLAUDE.md ("Never author bookmark JSON").
+// AI-driven edits behave identically to wizard-driven ones.
 import type { Store } from 'vuex'
 import { getFieldAttrKey } from '../utils/dashboardFlowUtils'
 import { applyConstraintValue } from '../utils/applyConstraintValue'

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
@@ -17,10 +17,16 @@ export type ConstraintValue =
   | { conceptSetId: string | number; includeDescendants?: boolean; displayValue?: string }
 
 export type PatchOp =
-  | { op: 'add_card'; cardConfigPath: string; exclude?: boolean; ref?: string }
+  | { op: 'add_card'; cardConfigPath: string; exclude?: boolean; ref?: string; orWith?: string }
   | { op: 'add_constraint'; card: string; attributePath: string; value: ConstraintValue; operator?: string }
   | { op: 'remove_card'; card: string }
   | { op: 'remove_constraint'; card: string; attributePath: string }
+  | { op: 'set_card_join'; card: string; join: 'AND' | 'OR' }
+
+/** One OR-group of filter cards. Groups are AND-ed with each other. */
+export interface CardGroup {
+  cards: Array<{ filterCardId: string; name: string; exclude?: boolean }>
+}
 
 export interface ApplyCohortPatchResult {
   applied: boolean
@@ -31,6 +37,8 @@ export interface ApplyCohortPatchResult {
    * committed state to report rather than its own intent.
    */
   appliedConstraints?: Array<{ card: string; attributePath: string; value: any }>
+  /** The resulting AND/OR structure: cards within a group are OR-ed, groups AND-ed. */
+  cardGroups?: CardGroup[]
   error?: string
 }
 
@@ -43,12 +51,20 @@ const isConceptSetValue = (
   !!v && typeof v === 'object' && (typeof v.conceptSetId === 'string' || typeof v.conceptSetId === 'number')
 
 // Rollback bookkeeping: created cards are deleted, prior constraint values and
-// the chart's axis selection restored.
+// the chart's axis selection restored, grouping changes undone.
 interface Rollback {
   createdCardIds: string[]
   priorConstraintValues: Array<{ constraintId: string; value: any }>
   createdConstraints: Array<{ filterCardId: string; constraintId: string }>
   priorAxes: AxisSnapshot[]
+  /**
+   * Grouping (AND/OR) changes, newest last. Undone by applying the inverse
+   * toggle — the same pair of store actions the AND/OR buttons use — because the
+   * container ids change as containers are merged/split, so a recorded id would
+   * be stale by the time revert runs. `card` is the card the toggle acted on;
+   * finding its container again at revert time is what makes the inverse exact.
+   */
+  joinChanges: Array<{ card: string; undo: 'split' | 'merge' }>
 }
 
 interface AxisSnapshot {
@@ -72,6 +88,155 @@ const snapshotAxes = (store: Store<any>): AxisSnapshot[] =>
       ...(typeof axis?.props?.binsize === 'undefined' ? {} : { binsize: axis.props.binsize }),
     },
   }))
+
+// ---------------------------------------------------------------------------
+// AND / OR grouping
+//
+// There is no "operator" field on a filter card. The builder expresses the
+// boolean structure through the SHAPE of the tree (see getIFR in
+// store/modules/query.ts): the cards inside one boolFilterContainer become
+// `BooleanContainers.Or(cards)`, and the containers themselves become
+// `BooleanContainers.And(containers)`. So:
+//
+//   same container   → OR   ("had Alzheimer's OR had sinusitis")
+//   separate containers → AND ("had Alzheimer's AND had sinusitis")
+//
+// `addFilterCard` with no boolFilterContainerId always opens a NEW container,
+// which is why an unqualified add_card is always an AND. To OR two cards they
+// must share a container — that is what add_card's `orWith` and `set_card_join`
+// do, via the same store actions the AND/OR buttons in the UI dispatch.
+// ---------------------------------------------------------------------------
+
+/** The Basic Data card's instance id is its config path (see createFilterCard). */
+const BASIC_DATA_CARD = 'patient'
+
+interface CardLocation {
+  containerId: string
+  /** Position of the container among the root container's children. */
+  containerIndex: number
+  /** Position of the card within its container (0 = first, i.e. no OR before it). */
+  indexInContainer: number
+  cards: string[]
+}
+
+const containerIdsOf = (store: Store<any>): string[] => {
+  const rootId = store.getters.getBoolContainerRoot?.()
+  return store.getters.getBoolContainer?.(rootId)?.props?.boolfiltercontainers ?? []
+}
+
+const cardsInContainer = (store: Store<any>, containerId: string): string[] =>
+  store.getters.getBoolFilterContainer?.(containerId)?.props?.filterCards ?? []
+
+function locateCard(store: Store<any>, filterCardId: string): CardLocation | undefined {
+  const containerIds = containerIdsOf(store)
+  for (let containerIndex = 0; containerIndex < containerIds.length; containerIndex += 1) {
+    const containerId = containerIds[containerIndex]
+    const cards = cardsInContainer(store, containerId)
+    const indexInContainer = cards.indexOf(filterCardId)
+    if (indexInContainer > -1) {
+      return { containerId, containerIndex, indexInContainer, cards }
+    }
+  }
+  return undefined
+}
+
+const isExclusionCard = (store: Store<any>, filterCardId: string): boolean =>
+  !!store.getters.getFilterCard?.(filterCardId)?.props?.excludeFilter
+
+/**
+ * The container a merge would fold into — the store's own rule: the nearest
+ * PRECEDING container of the same inclusion/exclusion kind
+ * (toggleFilterContainerBooleanCondition). Undefined when there is none.
+ */
+function previousContainerFor(store: Store<any>, loc: CardLocation): { id: string; cards: string[] } | undefined {
+  const containerIds = containerIdsOf(store)
+  const wantsExclusion = loc.cards.some(id => isExclusionCard(store, id))
+  for (let i = loc.containerIndex - 1; i >= 0; i -= 1) {
+    const cards = cardsInContainer(store, containerIds[i])
+    if (cards.some(id => isExclusionCard(store, id)) === wantsExclusion) {
+      return { id: containerIds[i], cards }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Guard the one grouping that is always wrong: OR-ing anything with Basic Data.
+ * Basic Data holds the demographics every cohort starts from, so
+ * `Or(patient, conditionOccurrence)` matches every patient the demographics
+ * alone match — the filter silently stops filtering. The UI can't express it
+ * either (BoolFilterContainer hides the 'patient' card from the OR list).
+ */
+function assertNotBasicData(cards: string[], what: string): void {
+  if (cards.includes(BASIC_DATA_CARD)) {
+    throw new Error(
+      `${what} would OR it with the Basic Data card, which matches every patient the demographics match — ` +
+        'the filter would stop filtering. OR interaction cards (Condition Occurrence, Drug Exposure, …) with ' +
+        'each other; demographics stay on Basic Data, which is always AND-ed with the rest.'
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concept-set domain check
+//
+// Every `conceptSet` attribute is configured with the OMOP domain its concepts
+// must come from (`domainFilter`: "Condition", "Visit", "Drug", …) — that is what
+// the UI's concept-set picker filters the vocabulary by. A set built for one
+// domain matches nothing in another, so the same concept-set id cannot be
+// correct on two attributes whose domains differ.
+//
+// The failure this closes: asked to widen a cohort to "Alzheimer's OR an ER
+// visit", the model added the Visit card correctly and then filled its concept
+// set with the ALZHEIMER'S set it already had in context — it never resolved
+// "ER visit" at all. The cohort still computes, so nothing looks broken; it just
+// answers a different question. Same-domain reuse stays legal (the same
+// Condition set on a primary- and a secondary-diagnosis card is a real cohort).
+// ---------------------------------------------------------------------------
+
+function attributeDomain(store: Store<any>, attributePath: string): string {
+  try {
+    return store.getters.getMriFrontendConfig?.getAttributeByPath?.(attributePath)?.getDomainFilter?.() ?? ''
+  } catch {
+    // A path the config doesn't know is add_constraint's problem to report, not
+    // this check's — an unknown domain simply skips the comparison.
+    return ''
+  }
+}
+
+/** Every place this concept-set id is already filtered on, with that attribute's domain. */
+function conceptSetUses(
+  store: Store<any>,
+  conceptSetId: string
+): Array<{ card: string; attributePath: string; domain: string }> {
+  const uses: Array<{ card: string; attributePath: string; domain: string }> = []
+  for (const cardId of Object.keys(store.getters.getFilterCards?.() ?? {})) {
+    const constraints: any[] = store.getters.getFilterCardConstraints?.(cardId) ?? []
+    for (const constraint of constraints) {
+      if (constraint?.props?.type !== 'conceptSet') continue
+      const values: any[] = Array.isArray(constraint.props.value) ? constraint.props.value : []
+      if (!values.some(v => String(v?.value) === conceptSetId)) continue
+      const attributePath = constraint.props.attributePath
+      uses.push({ card: cardId, attributePath, domain: attributeDomain(store, attributePath) })
+    }
+  }
+  return uses
+}
+
+function assertConceptSetDomain(store: Store<any>, op: AddConstraintOp, conceptSetId: string): void {
+  const targetDomain = attributeDomain(store, op.attributePath)
+  if (!targetDomain) return
+  const conflict = conceptSetUses(store, conceptSetId).find(use => use.domain && use.domain !== targetDomain)
+  if (!conflict) return
+  throw new Error(
+    `Concept set ${conceptSetId} is already filtered on "${conflict.attributePath}" (card "${conflict.card}"), ` +
+      `whose concepts are ${conflict.domain}-domain, but "${op.attributePath}" takes ${targetDomain}-domain ` +
+      `concepts — one concept set cannot be both, so this would filter on the wrong term and match nothing. ` +
+      `Resolve what the user asked for on THIS card into its own value: list_concept_sets / search_concepts for ` +
+      `a ${targetDomain} concept set, or pa_search_attribute_values for a catalog attribute on this card. ` +
+      'Never carry a concept-set id over from a different filter.'
+  )
+}
 
 type AddConstraintOp = Extract<PatchOp, { op: 'add_constraint' }>
 
@@ -155,6 +320,7 @@ export async function applyCohortPatch(store: Store<any>, patchOps: PatchOp[]): 
     priorConstraintValues: [],
     createdConstraints: [],
     priorAxes: snapshotAxes(store),
+    joinChanges: [],
   }
 
   const resolveCard = (card: string): string => {
@@ -174,15 +340,67 @@ export async function applyCohortPatch(store: Store<any>, patchOps: PatchOp[]): 
       await applyOne(dispatch, store, rawOp, refMap, rollback, resolveCard, appliedConstraints)
     }
   } catch (err) {
-    await revert(dispatch, rollback)
+    await revert(dispatch, rollback, store)
     await dispatch('releaseFireRequest')
     throw err instanceof Error ? err : new Error(String(err))
   }
 
+  // Grouping cards together runs the store's resetAxes, which clears every axis
+  // bound to a card in a container that now holds more than one card. That is
+  // fine when the user clicks the OR button (they can re-pick), but here it
+  // would leave the cohort with an empty axisSelection — analytics-svc then
+  // emits `SELECT  FROM …` and the DB rejects it, so the count reads "--".
+  // Put back only the axes whose card still exists.
+  await restoreClearedAxes(dispatch, store, rollback.priorAxes)
+
   await dispatch('releaseFireRequest')
   await dispatch('setFireRequest')
   await dispatch('refreshPatientCount')
-  return { applied: true, createdCards: [...rollback.createdCardIds], appliedConstraints }
+  return {
+    applied: true,
+    createdCards: [...rollback.createdCardIds],
+    appliedConstraints,
+    cardGroups: describeCardGroups(store),
+  }
+}
+
+/**
+ * The current AND/OR structure, read back from the store after the patch.
+ *
+ * The caller is an LLM that has to tell the user what the cohort now means, and
+ * "OR" is not visible anywhere in `appliedConstraints` — it lives in how the
+ * cards are grouped. Reporting it here is also what lets a follow-up patch
+ * target the right card without re-reading the whole cohort.
+ */
+export function describeCardGroups(store: Store<any>): CardGroup[] {
+  return containerIdsOf(store)
+    .map(containerId => ({
+      // Cards within a group are OR-ed; the groups themselves are AND-ed.
+      cards: cardsInContainer(store, containerId).map(id => ({
+        filterCardId: id,
+        name: store.getters.getFilterCard?.(id)?.props?.name ?? id,
+        ...(isExclusionCard(store, id) ? { exclude: true } : {}),
+      })),
+    }))
+    .filter(group => group.cards.length > 0)
+}
+
+async function restoreClearedAxes(
+  dispatch: (a: string, p?: unknown) => Promise<any>,
+  store: Store<any>,
+  priorAxes: AxisSnapshot[]
+): Promise<void> {
+  const cards = store.getters.getFilterCards?.() ?? {}
+  const current = snapshotAxes(store)
+  for (const axis of priorAxes) {
+    const stillBound = current[axis.id]?.props?.attributeId
+    if (stillBound || !axis.props.attributeId || !cards[axis.props.filterCardId]) continue
+    try {
+      await dispatch('setAxisValue', { id: axis.id, props: axis.props })
+    } catch (e) {
+      console.error('[cohortPatch] restoring axis after grouping change failed', e)
+    }
+  }
 }
 
 async function applyOne(
@@ -222,16 +440,97 @@ async function applyOne(
         if (op.ref) refMap.set(op.ref, op.cardConfigPath)
         return
       }
+      // `orWith` puts the new card in the SAME bool container as an existing one,
+      // which is how the builder represents OR. Without it the store opens a new
+      // container and the card is AND-ed (the default, and the right one for
+      // "sinusitis AND a drug exposure").
+      let boolFilterContainerId: string | undefined
+      if (op.orWith) {
+        const target = resolveCard(op.orWith)
+        assertNotBasicData([target], `add_card orWith:"${op.orWith}"`)
+        const loc = locateCard(store, target)
+        if (!loc) {
+          throw new Error(
+            `add_card orWith:"${op.orWith}" — card "${target}" is not in the cohort's filter tree, so there is ` +
+              'no group to join. Pass the filterCardId of a card that is on the cohort, or an add_card `ref` ' +
+              'created earlier in this same patch.'
+          )
+        }
+        // Not just the target: joining its GROUP ORs the new card with every card
+        // in it, so Basic Data sharing that group is the same silent widening.
+        assertNotBasicData(loc.cards, `add_card orWith:"${op.orWith}"`)
+        if ((op.exclude ?? false) !== isExclusionCard(store, target)) {
+          throw new Error(
+            `add_card orWith:"${op.orWith}" cannot OR an ${op.exclude ? 'exclusion' : 'inclusion'} card with an ` +
+              `${op.exclude ? 'inclusion' : 'exclusion'} one — they are separate sections of the builder. ` +
+              'OR cards of the same kind.'
+          )
+        }
+        boolFilterContainerId = loc.containerId
+      }
       const filterCardId = (await dispatch('addFilterCard', {
         configPath: op.cardConfigPath,
         isExclusion: op.exclude ?? false,
+        ...(boolFilterContainerId ? { boolFilterContainerId } : {}),
       })) as string
       rollback.createdCardIds.push(filterCardId)
       if (op.ref) refMap.set(op.ref, filterCardId)
       return
     }
+    case 'set_card_join': {
+      // Change how a card ALREADY on the cohort combines with the card before it.
+      // Both branches dispatch exactly what the AND/OR buttons dispatch, so an
+      // AI-driven regroup and a click produce the same tree.
+      const join = String((op as any).join ?? '').toUpperCase()
+      if (join !== 'AND' && join !== 'OR') {
+        throw new Error(`set_card_join: join must be "AND" or "OR" (got ${JSON.stringify((op as any).join)}).`)
+      }
+      const filterCardId = resolveCard(op.card)
+      if (filterCardId === BASIC_DATA_CARD) {
+        throw new Error(
+          'set_card_join: the Basic Data card is always AND-ed with the rest of the cohort — its demographics ' +
+            'apply to every patient the other cards match. Regroup the interaction cards instead.'
+        )
+      }
+      const loc = locateCard(store, filterCardId)
+      if (!loc) {
+        throw new Error(`set_card_join: card "${op.card}" is not in the cohort's filter tree.`)
+      }
+      if (join === 'OR') {
+        // Already OR-ed with the card before it in the same group: nothing to do.
+        if (loc.indexInContainer > 0) return
+        const prev = previousContainerFor(store, loc)
+        if (!prev) {
+          throw new Error(
+            `set_card_join: "${filterCardId}" is the first filter card, so there is nothing before it to OR it ` +
+              'with. Set the join on the LATER card of the pair.'
+          )
+        }
+        assertNotBasicData(prev.cards, `set_card_join OR on "${filterCardId}"`)
+        // Merges this card's container into the previous one → they share a
+        // container → Or(...) in the IFR.
+        await dispatch('toggleFilterContainerBooleanCondition', {
+          filterContainerId: loc.containerId,
+          parentId: store.getters.getBoolContainerRoot?.(),
+        })
+        rollback.joinChanges.push({ card: filterCardId, undo: 'split' })
+        return
+      }
+      // AND: already the first card of its own group → already AND-ed.
+      if (loc.indexInContainer === 0) return
+      // Splits this card (and any card after it in the group) into a new
+      // container → AND with what precedes it.
+      await dispatch('toggleFilterBooleanCondition', { filterCardId, parentId: loc.containerId })
+      rollback.joinChanges.push({ card: filterCardId, undo: 'merge' })
+      return
+    }
     case 'add_constraint': {
       assertHasValue(op)
+      // Before anything is mutated: a concept set that belongs to another
+      // domain is a wrong-cohort bug, not a rendering one.
+      if (isConceptSetValue(op.value)) {
+        assertConceptSetDomain(store, op, String(op.value.conceptSetId))
+      }
       const filterCardId = resolveCard(op.card)
       const key = getFieldAttrKey(op.attributePath)
       let constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
@@ -291,7 +590,30 @@ async function applyOne(
 // created during this patch, and put the chart's axis selection back the way it
 // was. Best-effort — individual failures are swallowed so one bad undo can't
 // mask the original error.
-async function revert(dispatch: (a: string, p?: unknown) => Promise<any>, rollback: Rollback): Promise<void> {
+async function revert(
+  dispatch: (a: string, p?: unknown) => Promise<any>,
+  rollback: Rollback,
+  store: Store<any>
+): Promise<void> {
+  // Grouping first, while the cards this patch created are still present: a
+  // merge/split is expressed in terms of a card's CURRENT container, so undoing
+  // it after the card is gone would have nothing to locate.
+  for (const { card, undo } of rollback.joinChanges.reverse()) {
+    try {
+      const loc = locateCard(store, card)
+      if (!loc) continue
+      if (undo === 'split' && loc.indexInContainer > 0) {
+        await dispatch('toggleFilterBooleanCondition', { filterCardId: card, parentId: loc.containerId })
+      } else if (undo === 'merge' && loc.indexInContainer === 0 && previousContainerFor(store, loc)) {
+        await dispatch('toggleFilterContainerBooleanCondition', {
+          filterContainerId: loc.containerId,
+          parentId: store.getters.getBoolContainerRoot?.(),
+        })
+      }
+    } catch (e) {
+      console.error('[cohortPatch] revert join change failed', e)
+    }
+  }
   for (const { constraintId, value } of rollback.priorConstraintValues.reverse()) {
     if (typeof value !== 'undefined') {
       try {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
@@ -54,7 +54,7 @@ const isConceptSetValue = (
 // the chart's axis selection restored, grouping changes undone.
 interface Rollback {
   createdCardIds: string[]
-  priorConstraintValues: Array<{ constraintId: string; value: any }>
+  priorConstraintValues: Array<{ constraintId: string; value: any; dates?: { from: any; to: any } }>
   createdConstraints: Array<{ filterCardId: string; constraintId: string }>
   priorAxes: AxisSnapshot[]
   /**
@@ -535,7 +535,14 @@ async function applyOne(
       const key = getFieldAttrKey(op.attributePath)
       let constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
       if (constraint) {
-        rollback.priorConstraintValues.push({ constraintId: constraint.id, value: constraint.props?.value })
+        rollback.priorConstraintValues.push({
+          constraintId: constraint.id,
+          value: constraint.props?.value,
+          // Snapshot the date slot too when the constraint has one — see Rollback.
+          ...(constraint.props?.fromDate || constraint.props?.toDate
+            ? { dates: { from: constraint.props?.fromDate?.value, to: constraint.props?.toDate?.value } }
+            : {}),
+        })
       } else {
         const constraintId = (await dispatch('addFilterCardConstraint', { filterCardId, key })) as string
         rollback.createdConstraints.push({ filterCardId, constraintId })
@@ -614,7 +621,24 @@ async function revert(
       console.error('[cohortPatch] revert join change failed', e)
     }
   }
-  for (const { constraintId, value } of rollback.priorConstraintValues.reverse()) {
+  for (const { constraintId, value, dates } of rollback.priorConstraintValues.reverse()) {
+    if (dates) {
+      try {
+        // isUTC:true is the pass-through branch of updateDateConstraintValue: the
+        // snapshot is already normalized, and the only transform it applies there
+        // (toUTCEndOfDay on a 'time' attribute) is idempotent on a Date and returns
+        // '' — an unset constraint — untouched. The isUTC:false branch would shift
+        // the range by the timezone offset every time it ran.
+        await dispatch('updateDateConstraintValue', {
+          constraintId,
+          fromDateValue: dates.from,
+          toDateValue: dates.to,
+          isUTC: true,
+        })
+      } catch (e) {
+        console.error('[cohortPatch] revert updateDateConstraintValue failed', e)
+      }
+    }
     if (typeof value !== 'undefined') {
       try {
         await dispatch('updateConstraintValue', { constraintId, value })

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
@@ -1,0 +1,327 @@
+// Deterministic cohort patch applier for the WebMCP `pa_apply_cohort_patch` tool.
+//
+// The LLM emits typed *intent* (PatchOp[]) — never a hand-built bookmark tree —
+// and this applier mutates the IFR already in the Vuex store via the app's own
+// query actions. That reuses the exact validation/normalization the UI uses, so
+// AI-driven edits behave identically to wizard-driven ones. See
+// DESIGN_pa_apply_cohort_patch.md and CLAUDE.md ("Never author bookmark JSON").
+import type { Store } from 'vuex'
+import { getFieldAttrKey } from '../utils/dashboardFlowUtils'
+import { applyConstraintValue } from '../utils/applyConstraintValue'
+
+export type ConstraintValue =
+  | number
+  | string
+  | { from?: string; to?: string }
+  // conceptSetId may arrive as a number — d2e-mcp create_concept_set returns numeric ids.
+  | { conceptSetId: string | number; includeDescendants?: boolean; displayValue?: string }
+
+export type PatchOp =
+  | { op: 'add_card'; cardConfigPath: string; exclude?: boolean; ref?: string }
+  | { op: 'add_constraint'; card: string; attributePath: string; value: ConstraintValue; operator?: string }
+  | { op: 'remove_card'; card: string }
+  | { op: 'remove_constraint'; card: string; attributePath: string }
+
+export interface ApplyCohortPatchResult {
+  applied: boolean
+  createdCards: string[]
+  /**
+   * What each add_constraint actually put on the cohort, read back from the store.
+   * The caller is an LLM that has to report the filters it applied — give it the
+   * committed state to report rather than its own intent.
+   */
+  appliedConstraints?: Array<{ card: string; attributePath: string; value: any }>
+  error?: string
+}
+
+// A concept-set value is any object carrying a conceptSetId. Accept string OR number:
+// d2e-mcp returns numeric concept-set ids, and a number that slips through to the
+// generic text path gets String()'d into "[object Object]" (a broken filter → count "--").
+const isConceptSetValue = (
+  v: any
+): v is { conceptSetId: string | number; includeDescendants?: boolean; displayValue?: string } =>
+  !!v && typeof v === 'object' && (typeof v.conceptSetId === 'string' || typeof v.conceptSetId === 'number')
+
+// Rollback bookkeeping: created cards are deleted, prior constraint values and
+// the chart's axis selection restored.
+interface Rollback {
+  createdCardIds: string[]
+  priorConstraintValues: Array<{ constraintId: string; value: any }>
+  createdConstraints: Array<{ filterCardId: string; constraintId: string }>
+  priorAxes: AxisSnapshot[]
+}
+
+interface AxisSnapshot {
+  id: number
+  props: { attributeId: string; filterCardId: string; key: string; binsize?: any }
+}
+
+// The store's deleteFilterCard clears every axis bound to the card id it is given,
+// so a rolled-back add_card takes the chart's axis selection with it. An axis-less
+// cohort is not a cosmetic problem: the bar-chart query then goes out with an empty
+// axisSelection and analytics-svc generates `MeasurePopulation AS (SELECT  FROM …)`,
+// which the DB rejects ("SELECT clause without selection list") — the cohort renders
+// "--" for every later edit until the builder is reset. Snapshot before, restore after.
+const snapshotAxes = (store: Store<any>): AxisSnapshot[] =>
+  ((store.getters.getAllAxes as any[]) ?? []).map((axis, id) => ({
+    id,
+    props: {
+      attributeId: axis?.props?.attributeId ?? '',
+      filterCardId: axis?.props?.filterCardId ?? '',
+      key: axis?.props?.key ?? '',
+      ...(typeof axis?.props?.binsize === 'undefined' ? {} : { binsize: axis.props.binsize }),
+    },
+  }))
+
+type AddConstraintOp = Extract<PatchOp, { op: 'add_constraint' }>
+
+// Fields that carry a constraint value but are only meaningful INSIDE `value`.
+// Seeing one at the top level of the op is the tell for the mistake below.
+const MISPLACED_VALUE_KEYS = ['conceptSetId', 'conceptSetIds', 'conceptId', 'conceptIds', 'from', 'to', 'values']
+
+const VALUE_SHAPE_HELP =
+  'Pass value: <number|string> for a basic attribute, { from, to } for a date range, or ' +
+  '{ conceptSetId, includeDescendants? } for a conceptSet attribute. ' +
+  'To clear a filter use remove_constraint, not an empty value.'
+
+/**
+ * Reject an add_constraint that carries nothing to set.
+ *
+ * This is the single most dangerous op shape in the applier: applyConstraintValue
+ * reads an empty value on a text/conceptSet attribute as "clear this filter", so
+ * the patch reports success and leaves a filter card with no constraint — the
+ * cohort then silently keeps every patient the filter was supposed to exclude.
+ * That is a clinical error dressed as a working cohort, so fail loudly instead.
+ */
+function assertHasValue(op: AddConstraintOp): void {
+  const v: any = op.value
+  const isEmpty =
+    typeof v === 'undefined' ||
+    v === null ||
+    (typeof v === 'string' && v.trim() === '') ||
+    (Array.isArray(v) && v.length === 0) ||
+    (typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0)
+  if (!isEmpty) return
+
+  const misplaced = MISPLACED_VALUE_KEYS.filter(k => k in (op as any))
+  throw new Error(
+    `add_constraint for "${op.attributePath}" has no value. ` +
+      (misplaced.length
+        ? `Found ${misplaced.join(', ')} at the top level of the op — ${
+            misplaced.length > 1 ? 'they belong' : 'it belongs'
+          } inside \`value\`. `
+        : '') +
+      VALUE_SHAPE_HELP
+  )
+}
+
+/**
+ * Post-condition for add_constraint: the value is really on the constraint now.
+ *
+ * The input check above catches the shapes we know about; this catches the rest.
+ * Any normalization that quietly resolves to "no value" must fail the patch rather
+ * than leave an empty filter behind and report success.
+ */
+function assertValueLanded(store: Store<any>, filterCardId: string, key: string, op: AddConstraintOp): any {
+  const props = store.getters.getConstraintForAttribute?.({ filterCardId, key })?.props
+  // Date constraints live in fromDate/toDate, everything else in a value array.
+  if (Array.isArray(props?.value) && props.value.length > 0) {
+    return props.value
+  }
+  if (typeof props?.fromDate?.value !== 'undefined' || typeof props?.toDate?.value !== 'undefined') {
+    return { from: props?.fromDate?.value, to: props?.toDate?.value }
+  }
+  throw new Error(
+    `Constraint for "${op.attributePath}" ended up empty after applying ${JSON.stringify(op.value)}. ` +
+      VALUE_SHAPE_HELP
+  )
+}
+
+/**
+ * Apply a list of typed patch ops to the live cohort in `store`. Atomic: if any
+ * op fails the whole patch is rolled back and the error is rethrown.
+ */
+export async function applyCohortPatch(store: Store<any>, patchOps: PatchOp[]): Promise<ApplyCohortPatchResult> {
+  if (!Array.isArray(patchOps) || patchOps.length === 0) {
+    throw new Error('patchOps must be a non-empty array')
+  }
+  const dispatch = (action: string, payload?: unknown) => store.dispatch(action, payload)
+
+  // ref (local handle from add_card) -> real filterCardId, so later ops can
+  // target a card created earlier in the same patch.
+  const refMap = new Map<string, string>()
+  const rollback: Rollback = {
+    createdCardIds: [],
+    priorConstraintValues: [],
+    createdConstraints: [],
+    priorAxes: snapshotAxes(store),
+  }
+
+  const resolveCard = (card: string): string => {
+    const id = refMap.get(card) ?? card
+    const cards = store.getters.getFilterCards?.() ?? {}
+    if (!cards[id]) {
+      throw new Error(`Unknown card "${card}". Create it with add_card or pass a real filterCardId.`)
+    }
+    return id
+  }
+
+  const appliedConstraints: NonNullable<ApplyCohortPatchResult['appliedConstraints']> = []
+
+  await dispatch('holdFireRequest')
+  try {
+    for (const rawOp of patchOps) {
+      await applyOne(dispatch, store, rawOp, refMap, rollback, resolveCard, appliedConstraints)
+    }
+  } catch (err) {
+    await revert(dispatch, rollback)
+    await dispatch('releaseFireRequest')
+    throw err instanceof Error ? err : new Error(String(err))
+  }
+
+  await dispatch('releaseFireRequest')
+  await dispatch('setFireRequest')
+  await dispatch('refreshPatientCount')
+  return { applied: true, createdCards: [...rollback.createdCardIds], appliedConstraints }
+}
+
+async function applyOne(
+  dispatch: (a: string, p?: unknown) => Promise<any>,
+  store: Store<any>,
+  op: PatchOp,
+  refMap: Map<string, string>,
+  rollback: Rollback,
+  resolveCard: (card: string) => string,
+  applied: NonNullable<ApplyCohortPatchResult['appliedConstraints']>
+): Promise<void> {
+  switch (op.op) {
+    case 'add_card': {
+      // Fail fast on a bad path with a recoverable message, instead of a generic
+      // store error (or a silently-malformed card). Skip when config isn't loaded.
+      const config = store.getters.getMriFrontendConfig
+      if (config?.getFilterCards) {
+        const validPaths: string[] = (config.getFilterCards() ?? []).map((c: any) => c.getConfigPath())
+        if (!validPaths.includes(op.cardConfigPath)) {
+          throw new Error(
+            `Unknown cardConfigPath "${op.cardConfigPath}". Use pa_list_filter_options (or the ` +
+              'validFilterOptions returned on this error) for the valid card paths.'
+          )
+        }
+      }
+      // Single-instance cards (Basic Data) must never be added twice. An indexed
+      // card gets an instance id with a trailing number
+      // ("…conditionoccurrence.1"), so a card whose instance id IS the config path
+      // is the singleton — and the store would happily create a SECOND card under
+      // that same id. The IFR then carries "patient" in two bool containers, so
+      // every constraint on it is emitted twice (`age < 100 AND age < 100`) and
+      // deleting either copy clears the chart axes bound to the id that survives.
+      // A model that adds Basic Data before constraining Age/Gender is doing the
+      // reasonable thing; reuse what is already there.
+      const existing = store.getters.getFilterCards?.() ?? {}
+      if (existing[op.cardConfigPath]) {
+        if (op.ref) refMap.set(op.ref, op.cardConfigPath)
+        return
+      }
+      const filterCardId = (await dispatch('addFilterCard', {
+        configPath: op.cardConfigPath,
+        isExclusion: op.exclude ?? false,
+      })) as string
+      rollback.createdCardIds.push(filterCardId)
+      if (op.ref) refMap.set(op.ref, filterCardId)
+      return
+    }
+    case 'add_constraint': {
+      assertHasValue(op)
+      const filterCardId = resolveCard(op.card)
+      const key = getFieldAttrKey(op.attributePath)
+      let constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      if (constraint) {
+        rollback.priorConstraintValues.push({ constraintId: constraint.id, value: constraint.props?.value })
+      } else {
+        const constraintId = (await dispatch('addFilterCardConstraint', { filterCardId, key })) as string
+        rollback.createdConstraints.push({ filterCardId, constraintId })
+        constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      }
+      if (!constraint) {
+        throw new Error(`Could not create constraint for "${op.attributePath}" on card "${op.card}".`)
+      }
+      if (isConceptSetValue(op.value)) {
+        await dispatch('updateConstraintValue', {
+          constraintId: constraint.id,
+          value: [
+            {
+              value: String(op.value.conceptSetId),
+              text: op.value.displayValue ?? String(op.value.conceptSetId),
+              display_value: op.value.displayValue ?? String(op.value.conceptSetId),
+              includeDescendants: op.value.includeDescendants ?? false,
+            },
+          ],
+        })
+      } else {
+        await applyConstraintValue(dispatch, constraint, op.value, op.operator ?? '=')
+      }
+      applied.push({
+        card: filterCardId,
+        attributePath: op.attributePath,
+        value: assertValueLanded(store, filterCardId, key, op),
+      })
+      return
+    }
+    case 'remove_constraint': {
+      const filterCardId = resolveCard(op.card)
+      const key = getFieldAttrKey(op.attributePath)
+      const constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      if (constraint) {
+        await dispatch('deleteFilterCardConstraint', { filterCardId, constraintId: constraint.id })
+      }
+      return
+    }
+    case 'remove_card': {
+      const filterCardId = resolveCard(op.card)
+      await dispatch('deleteFilterCard', { filterCardId })
+      return
+    }
+    default:
+      throw new Error(`Unknown patch op: ${JSON.stringify((op as any).op)}`)
+  }
+}
+
+// Undo a partially-applied patch, mirroring revertFieldChanges in
+// useDashboardFlow: restore prior constraint values, drop constraints and cards
+// created during this patch, and put the chart's axis selection back the way it
+// was. Best-effort — individual failures are swallowed so one bad undo can't
+// mask the original error.
+async function revert(dispatch: (a: string, p?: unknown) => Promise<any>, rollback: Rollback): Promise<void> {
+  for (const { constraintId, value } of rollback.priorConstraintValues.reverse()) {
+    if (typeof value !== 'undefined') {
+      try {
+        await dispatch('updateConstraintValue', { constraintId, value })
+      } catch (e) {
+        console.error('[cohortPatch] revert updateConstraintValue failed', e)
+      }
+    }
+  }
+  for (const { filterCardId, constraintId } of rollback.createdConstraints.reverse()) {
+    try {
+      await dispatch('deleteFilterCardConstraint', { filterCardId, constraintId })
+    } catch (e) {
+      console.error('[cohortPatch] revert deleteFilterCardConstraint failed', e)
+    }
+  }
+  for (const filterCardId of rollback.createdCardIds.reverse()) {
+    try {
+      await dispatch('deleteFilterCard', { filterCardId })
+    } catch (e) {
+      console.error('[cohortPatch] revert deleteFilterCard failed', e)
+    }
+  }
+  // Last: deleteFilterCard above cleared any axis pointing at a card it removed,
+  // so the axis selection is restored after the cards, not before.
+  for (const { id, props } of rollback.priorAxes) {
+    try {
+      await dispatch('setAxisValue', { id, props })
+    } catch (e) {
+      console.error('[cohortPatch] revert setAxisValue failed', e)
+    }
+  }
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
@@ -652,6 +652,14 @@ async function revert(
   for (const snapshot of rollback.priorConstraintValues.reverse()) {
     await restoreConstraintValue(dispatch, snapshot)
   }
+  // Drop what the patch created BEFORE putting back what it removed.
+  for (const { filterCardId, constraintId } of rollback.createdConstraints.reverse()) {
+    try {
+      await dispatch('deleteFilterCardConstraint', { filterCardId, constraintId })
+    } catch (e) {
+      console.error('[cohortPatch] revert deleteFilterCardConstraint failed', e)
+    }
+  }
   // Put back what remove_constraint took. Before the created cards are deleted
   // below, so the card a constraint belongs to is still there to re-add it to.
   for (const { filterCardId, key, snapshot } of rollback.removedConstraints.reverse()) {
@@ -663,13 +671,6 @@ async function revert(
       }
     } catch (e) {
       console.error('[cohortPatch] revert remove_constraint failed', e)
-    }
-  }
-  for (const { filterCardId, constraintId } of rollback.createdConstraints.reverse()) {
-    try {
-      await dispatch('deleteFilterCardConstraint', { filterCardId, constraintId })
-    } catch (e) {
-      console.error('[cohortPatch] revert deleteFilterCardConstraint failed', e)
     }
   }
   for (const filterCardId of rollback.createdCardIds.reverse()) {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
@@ -8,6 +8,11 @@
 import type { Store } from 'vuex'
 import { getFieldAttrKey } from '../utils/dashboardFlowUtils'
 import { applyConstraintValue } from '../utils/applyConstraintValue'
+import {
+  restoreConstraintValue,
+  snapshotConstraintValue,
+  type ConstraintValueSnapshot,
+} from '../utils/constraintValueSnapshot'
 
 export type ConstraintValue =
   | number
@@ -50,12 +55,22 @@ const isConceptSetValue = (
 ): v is { conceptSetId: string | number; includeDescendants?: boolean; displayValue?: string } =>
   !!v && typeof v === 'object' && (typeof v.conceptSetId === 'string' || typeof v.conceptSetId === 'number')
 
-// Rollback bookkeeping: created cards are deleted, prior constraint values and
-// the chart's axis selection restored, grouping changes undone.
+// Rollback bookkeeping: created cards are deleted, removed constraints re-created,
+// prior constraint values and the chart's axis selection restored, grouping changes
+// undone. Cards removed by remove_card are the one thing revert cannot put back —
+// see applyCohortPatch.
 interface Rollback {
   createdCardIds: string[]
-  priorConstraintValues: Array<{ constraintId: string; value: any; dates?: { from: any; to: any } }>
+  priorConstraintValues: ConstraintValueSnapshot[]
   createdConstraints: Array<{ filterCardId: string; constraintId: string }>
+  /**
+   * Constraints this patch DELETED (remove_constraint). Keyed by card + attribute
+   * key rather than by constraint id: the id dies with the constraint, so revert
+   * re-adds it and restores the snapshot onto whatever id the store hands back.
+   */
+  removedConstraints: Array<{ filterCardId: string; key: string; snapshot: ConstraintValueSnapshot }>
+  /** Cards this patch DELETED (remove_card). Not undone; see applyCohortPatch. */
+  removedCardIds: string[]
   priorAxes: AxisSnapshot[]
   /**
    * Grouping (AND/OR) changes, newest last. Undone by applying the inverse
@@ -204,12 +219,16 @@ function attributeDomain(store: Store<any>, attributePath: string): string {
   }
 }
 
-/** Every place this concept-set id is already filtered on, with that attribute's domain. */
-function conceptSetUses(
+/**
+ * The first place this concept-set id is already filtered on under a DIFFERENT
+ * domain, or undefined when there is none. Same-domain reuse is legal, and an
+ * attribute whose domain the config doesn't state can't be judged either way.
+ */
+function findConceptSetDomainConflict(
   store: Store<any>,
-  conceptSetId: string
-): Array<{ card: string; attributePath: string; domain: string }> {
-  const uses: Array<{ card: string; attributePath: string; domain: string }> = []
+  conceptSetId: string,
+  targetDomain: string
+): { card: string; attributePath: string; domain: string } | undefined {
   for (const cardId of Object.keys(store.getters.getFilterCards?.() ?? {})) {
     const constraints: any[] = store.getters.getFilterCardConstraints?.(cardId) ?? []
     for (const constraint of constraints) {
@@ -217,16 +236,17 @@ function conceptSetUses(
       const values: any[] = Array.isArray(constraint.props.value) ? constraint.props.value : []
       if (!values.some(v => String(v?.value) === conceptSetId)) continue
       const attributePath = constraint.props.attributePath
-      uses.push({ card: cardId, attributePath, domain: attributeDomain(store, attributePath) })
+      const domain = attributeDomain(store, attributePath)
+      if (domain && domain !== targetDomain) return { card: cardId, attributePath, domain }
     }
   }
-  return uses
+  return undefined
 }
 
 function assertConceptSetDomain(store: Store<any>, op: AddConstraintOp, conceptSetId: string): void {
   const targetDomain = attributeDomain(store, op.attributePath)
   if (!targetDomain) return
-  const conflict = conceptSetUses(store, conceptSetId).find(use => use.domain && use.domain !== targetDomain)
+  const conflict = findConceptSetDomainConflict(store, conceptSetId, targetDomain)
   if (!conflict) return
   throw new Error(
     `Concept set ${conceptSetId} is already filtered on "${conflict.attributePath}" (card "${conflict.card}"), ` +
@@ -303,8 +323,14 @@ function assertValueLanded(store: Store<any>, filterCardId: string, key: string,
 }
 
 /**
- * Apply a list of typed patch ops to the live cohort in `store`. Atomic: if any
- * op fails the whole patch is rolled back and the error is rethrown.
+ * Apply a list of typed patch ops to the live cohort in `store`.
+ *
+ * Atomic, with one documented exception: if any op fails, everything this patch
+ * added (cards, constraints, values) or regrouped is undone, a constraint it
+ * removed is put back, and the error is rethrown. A card removed by `remove_card`
+ * is NOT restored — re-adding it would mint a new instance id and lose the
+ * constraints that hung off it, and a half-restored card is a worse lie than a
+ * missing one. So put `remove_card` last in a patch, or send it on its own.
  */
 export async function applyCohortPatch(store: Store<any>, patchOps: PatchOp[]): Promise<ApplyCohortPatchResult> {
   if (!Array.isArray(patchOps) || patchOps.length === 0) {
@@ -319,6 +345,8 @@ export async function applyCohortPatch(store: Store<any>, patchOps: PatchOp[]): 
     createdCardIds: [],
     priorConstraintValues: [],
     createdConstraints: [],
+    removedConstraints: [],
+    removedCardIds: [],
     priorAxes: snapshotAxes(store),
     joinChanges: [],
   }
@@ -535,14 +563,8 @@ async function applyOne(
       const key = getFieldAttrKey(op.attributePath)
       let constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
       if (constraint) {
-        rollback.priorConstraintValues.push({
-          constraintId: constraint.id,
-          value: constraint.props?.value,
-          // Snapshot the date slot too when the constraint has one — see Rollback.
-          ...(constraint.props?.fromDate || constraint.props?.toDate
-            ? { dates: { from: constraint.props?.fromDate?.value, to: constraint.props?.toDate?.value } }
-            : {}),
-        })
+        // Snapshots the date slot as well as `value` — see ConstraintValueSnapshot.
+        rollback.priorConstraintValues.push(snapshotConstraintValue(constraint))
       } else {
         const constraintId = (await dispatch('addFilterCardConstraint', { filterCardId, key })) as string
         rollback.createdConstraints.push({ filterCardId, constraintId })
@@ -578,6 +600,11 @@ async function applyOne(
       const key = getFieldAttrKey(op.attributePath)
       const constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
       if (constraint) {
+        // Snapshot before deleting: a later op can still fail the patch, and atomic
+        // has to mean the filter the user had comes back — not merely that nothing
+        // new was added. A dropped filter that survives a failed patch leaves the
+        // cohort permanently wider than the user was told it is.
+        rollback.removedConstraints.push({ filterCardId, key, snapshot: snapshotConstraintValue(constraint) })
         await dispatch('deleteFilterCardConstraint', { filterCardId, constraintId: constraint.id })
       }
       return
@@ -585,6 +612,7 @@ async function applyOne(
     case 'remove_card': {
       const filterCardId = resolveCard(op.card)
       await dispatch('deleteFilterCard', { filterCardId })
+      rollback.removedCardIds.push(filterCardId)
       return
     }
     default:
@@ -621,30 +649,20 @@ async function revert(
       console.error('[cohortPatch] revert join change failed', e)
     }
   }
-  for (const { constraintId, value, dates } of rollback.priorConstraintValues.reverse()) {
-    if (dates) {
-      try {
-        // isUTC:true is the pass-through branch of updateDateConstraintValue: the
-        // snapshot is already normalized, and the only transform it applies there
-        // (toUTCEndOfDay on a 'time' attribute) is idempotent on a Date and returns
-        // '' — an unset constraint — untouched. The isUTC:false branch would shift
-        // the range by the timezone offset every time it ran.
-        await dispatch('updateDateConstraintValue', {
-          constraintId,
-          fromDateValue: dates.from,
-          toDateValue: dates.to,
-          isUTC: true,
-        })
-      } catch (e) {
-        console.error('[cohortPatch] revert updateDateConstraintValue failed', e)
+  for (const snapshot of rollback.priorConstraintValues.reverse()) {
+    await restoreConstraintValue(dispatch, snapshot)
+  }
+  // Put back what remove_constraint took. Before the created cards are deleted
+  // below, so the card a constraint belongs to is still there to re-add it to.
+  for (const { filterCardId, key, snapshot } of rollback.removedConstraints.reverse()) {
+    try {
+      await dispatch('addFilterCardConstraint', { filterCardId, key })
+      const recreated = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      if (recreated) {
+        await restoreConstraintValue(dispatch, { ...snapshot, constraintId: recreated.id })
       }
-    }
-    if (typeof value !== 'undefined') {
-      try {
-        await dispatch('updateConstraintValue', { constraintId, value })
-      } catch (e) {
-        console.error('[cohortPatch] revert updateConstraintValue failed', e)
-      }
+    } catch (e) {
+      console.error('[cohortPatch] revert remove_constraint failed', e)
     }
   }
   for (const { filterCardId, constraintId } of rollback.createdConstraints.reverse()) {
@@ -664,6 +682,10 @@ async function revert(
   // Last: deleteFilterCard above cleared any axis pointing at a card it removed,
   // so the axis selection is restored after the cards, not before.
   for (const { id, props } of rollback.priorAxes) {
+    // Except an axis bound to a card remove_card deleted: that card is gone for
+    // good (see applyCohortPatch), and re-pointing the chart at it would send the
+    // query out with a filterCardId the IFR no longer contains.
+    if (props.filterCardId && rollback.removedCardIds.includes(props.filterCardId)) continue
     try {
       await dispatch('setAxisValue', { id, props })
     } catch (e) {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/lib/i18n.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/lib/i18n.ts
@@ -368,6 +368,8 @@ export const i18n = {
     MRI_PA_DRILL_DOWN: 'Drill Down',
     MRI_PA_CHART_NO_DATA_DEFAULT_MESSAGE:
       'Data cannot be displayed due to an internal error. Please contact your system administrator.',
+    MRI_PA_CHART_NO_AXIS_SELECTED:
+      'No axis is selected, so there is nothing to aggregate. Choose at least one attribute for an axis.',
     MRI_PA_MENUITEM_INTERACTIONS_GENERAL: 'Basic Data',
     MRI_PA_TITLE_FILTER_SUMMARY: 'Filter Summary',
     MRI_PA_TITLE_FILTER_SUMMARY_TOOLTIP: 'View Filter Summary',

--- a/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/query.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/query.ts
@@ -1063,6 +1063,15 @@ const actions = {
             data: {
               data: [],
               totalPatientCount: 0,
+              // Keep WHY it failed. The chart component renders the reason locally, but the
+              // store response loses it — and an empty result with no reason is
+              // indistinguishable from "no matching patients" for anything that reads the
+              // response back.
+              error:
+                error?.response?.data?.errorMessage ||
+                error?.response?.data?.err ||
+                error?.message ||
+                'The chart query failed.',
             },
           },
         })

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
@@ -184,10 +184,26 @@ describe('applyConstraintValue', () => {
       })
     })
 
-    it.each([[null], [undefined], [''], ['   ']])('rejects a missing value (%p)', async input => {
-      await expect(applyConstraintValue(dispatch, constraint(), input)).rejects.toThrow('Missing value for Age')
-      expect(dispatch).not.toHaveBeenCalled()
+    // Regression (#2913): emptying an optional text / concept-set filter clears it
+    // (dispatches an empty value) instead of erroring, so the required-filters modal can
+    // remove a previously-set optional value.
+    it.each([['text'], ['conceptSet']])('clears an empty %s constraint instead of rejecting', async type => {
+      await applyConstraintValue(dispatch, constraint({}, { type }), '')
+      expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', {
+        constraintId: 'constraint-1',
+        value: [],
+      })
     })
+
+    it.each([[null], [undefined], [''], ['   ']])(
+      'rejects a missing value for a non-clearable constraint type (%p)',
+      async input => {
+        await expect(applyConstraintValue(dispatch, constraint({}, { type: 'attribute' }), input)).rejects.toThrow(
+          'Missing value for Age'
+        )
+        expect(dispatch).not.toHaveBeenCalled()
+      }
+    )
 
     it('rejects an unsupported object value instead of stringifying it', async () => {
       await expect(applyConstraintValue(dispatch, constraint(), { foo: 'bar' })).rejects.toThrow(

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/constraintValueSnapshot.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/constraintValueSnapshot.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { snapshotConstraintValue, restoreConstraintValue } from '../constraintValueSnapshot'
+
+describe('constraintValueSnapshot', () => {
+  let dispatch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    dispatch = vi.fn().mockResolvedValue(undefined)
+  })
+
+  it('round-trips a value-only constraint', async () => {
+    const constraint = { id: 'con1', props: { value: [{ op: '>=', value: 65 }] } }
+
+    await restoreConstraintValue(dispatch, snapshotConstraintValue(constraint))
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', {
+      constraintId: 'con1',
+      value: [{ op: '>=', value: 65 }],
+    })
+  })
+
+  // A date constraint keeps no props.value at all, so a snapshot of `value` alone
+  // restores nothing and the edited range silently stays on the cohort.
+  it('round-trips the date slot a date constraint keeps instead of a value', async () => {
+    const from = new Date('2019-01-01')
+    const to = new Date('2019-12-31')
+    const constraint = { id: 'con2', props: { fromDate: { value: from }, toDate: { value: to } } }
+
+    const snapshot = snapshotConstraintValue(constraint)
+    expect(snapshot).toEqual({ constraintId: 'con2', value: undefined, dates: { from, to } })
+
+    await restoreConstraintValue(dispatch, snapshot)
+
+    // isUTC:true is the pass-through branch; isUTC:false would shift the restored
+    // range by the timezone offset on every revert.
+    expect(dispatch).toHaveBeenCalledWith('updateDateConstraintValue', {
+      constraintId: 'con2',
+      fromDateValue: from,
+      toDateValue: to,
+      isUTC: true,
+    })
+    // No value dispatch: the constraint had no value slot to put back.
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  // The cleared state of an optional text/conceptSet filter. Bookkeeping that
+  // restores only truthy values leaves the edit in place instead of clearing it.
+  it('restores a value that was legitimately empty', async () => {
+    await restoreConstraintValue(dispatch, snapshotConstraintValue({ id: 'con3', props: { value: [] } }))
+
+    expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', { constraintId: 'con3', value: [] })
+  })
+
+  it('restores each slot independently when the other one fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    dispatch.mockImplementation((action: string) =>
+      action === 'updateDateConstraintValue' ? Promise.reject(new Error('nope')) : Promise.resolve(undefined)
+    )
+
+    await restoreConstraintValue(dispatch, {
+      constraintId: 'con4',
+      value: ['x'],
+      dates: { from: '', to: '' },
+    })
+
+    // The failed date restore must not swallow the value restore, and must not throw:
+    // the caller is already unwinding a failed edit.
+    expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', { constraintId: 'con4', value: ['x'] })
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/applyConstraintValue.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/applyConstraintValue.ts
@@ -90,6 +90,14 @@ export async function applyConstraintValue(
   }
   const rawValue = rawInput?.value ?? rawInput
   if (rawValue === null || typeof rawValue === 'undefined' || String(rawValue).trim() === '') {
+    // An emptied free-text or concept-set filter is a *clear*, not an error: the
+    // required-filters modal has to be able to remove a value it previously set.
+    if (constraintType === 'text' || constraintType === 'conceptSet') {
+      return dispatch('updateConstraintValue', {
+        constraintId: constraint.id,
+        value: [],
+      })
+    }
     return Promise.reject(new Error(`Missing value for ${constraint.props.name || constraint.id}`))
   }
   // Never String() an object into "[object Object]" — that silently produces a broken
@@ -100,7 +108,8 @@ export async function applyConstraintValue(
     return Promise.reject(
       new Error(
         `Unsupported object value for ${constraint.props.name || constraint.id}: ` +
-          'this constraint expects a scalar value (string or number).'
+          'pass a scalar value (string or number), { from, to } for a date range, or ' +
+          '{ conceptSetId } for a concept set.'
       )
     )
   }

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/applyConstraintValue.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/applyConstraintValue.ts
@@ -108,8 +108,7 @@ export async function applyConstraintValue(
     return Promise.reject(
       new Error(
         `Unsupported object value for ${constraint.props.name || constraint.id}: ` +
-          'pass a scalar value (string or number), { from, to } for a date range, or ' +
-          '{ conceptSetId } for a concept set.'
+          'pass a scalar value (string or number).'
       )
     )
   }

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/constraintValueSnapshot.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/constraintValueSnapshot.ts
@@ -1,0 +1,72 @@
+import type { ConstraintDispatch } from './applyConstraintValue'
+
+/**
+ * A constraint's value as it stood before an edit, so the edit can be undone.
+ *
+ * TWO slots, not one: a date/time constraint carries no `props.value` at all —
+ * its state lives in `props.fromDate.value` / `props.toDate.value` (see
+ * DateConstraintModel and CONSTRAINTS_DATETIME_SET_VALUE) — so bookkeeping that
+ * snapshots only `value` records `undefined` for a date range and then restores
+ * nothing. That is how a widened date window survived a failed edit while the
+ * user was told nothing had been applied.
+ *
+ * Used by the WebMCP cohort-patch applier's rollback. The dashboard wizard's
+ * revertFieldChanges has the same job and the same two slots to put back (see
+ * useDashboardFlow) — the same reason applyConstraintValue is shared.
+ */
+export interface ConstraintValueSnapshot {
+  constraintId: string
+  value: any
+  /** Present only for a constraint that keeps a date range. */
+  dates?: { from: any; to: any }
+}
+
+/** Record a constraint's current value so restoreConstraintValue can put it back. */
+export function snapshotConstraintValue(constraint: any): ConstraintValueSnapshot {
+  const props = constraint?.props
+  return {
+    constraintId: constraint?.id,
+    value: props?.value,
+    ...(props?.fromDate || props?.toDate ? { dates: { from: props?.fromDate?.value, to: props?.toDate?.value } } : {}),
+  }
+}
+
+/**
+ * Put a snapshot back on its constraint (or on `constraintId`'s replacement, if
+ * the caller re-created the constraint and passes the new id).
+ *
+ * Best-effort: each slot is restored independently and a failure is logged rather
+ * than thrown, because the caller is already unwinding a failed edit and one bad
+ * undo must not mask the error that started it.
+ */
+export async function restoreConstraintValue(
+  dispatch: ConstraintDispatch,
+  { constraintId, value, dates }: ConstraintValueSnapshot
+): Promise<void> {
+  if (dates) {
+    try {
+      // isUTC:true is the pass-through branch of updateDateConstraintValue: the
+      // snapshot is already normalized, and the only transform that branch applies
+      // (toUTCEndOfDay on a 'time' attribute) is idempotent on a Date and leaves ''
+      // — an unset constraint — untouched. The isUTC:false branch would shift the
+      // range by the timezone offset on every restore.
+      await dispatch('updateDateConstraintValue', {
+        constraintId,
+        fromDateValue: dates.from,
+        toDateValue: dates.to,
+        isUTC: true,
+      })
+    } catch (e) {
+      console.error('[constraintValueSnapshot] restoring the date range failed', e)
+    }
+  }
+  // `undefined` means the constraint never had a value slot (a date-only
+  // constraint), not that it was empty — an empty array IS a value: the cleared
+  // state of a text/conceptSet filter, which has to be restorable too.
+  if (typeof value === 'undefined') return
+  try {
+    await dispatch('updateConstraintValue', { constraintId, value })
+  } catch (e) {
+    console.error('[constraintValueSnapshot] restoring the value failed', e)
+  }
+}


### PR DESCRIPTION
Summary:
1. Robustness fix with no AI dependency: an all-`n/a` axis selection turned into an opaque HTTP 500 from the database. It now resolves to the empty result with an explanatory reason.

3. **Deterministic cohort patch applier**: A new `src/ai/cohortPatch.ts` that applies
  typed *intent* (`PatchOp[]`) to the live cohort through the app's own Vuex actions, plus
  the changes to `applyConstraintValue`. It ships dormant with callers only in the following webmcp PR.

An LLM editing a cohort has two possible interfaces:

| | What the model produces | Problem |
|---|---|---|
| ❌ Bookmark JSON | A whole IFR / bookmark tree | A *well-formed-yet-wrong* tree loads a silently different cohort — a clinical error, not a rendering glitch. Nothing validates it against the dataset config. |
| ✅ Typed intent | `PatchOp[]` — "add this card", "constrain this attribute" | Applied in place by the app's own store actions, so it inherits the exact validation and normalization the wizard UI uses. |

`cohortPatch.ts` implements the second. **The applier *is* the builder**: every mutation goes through a `store.dispatch` that a UI click also dispatches (`addFilterCard`, `addFilterCardConstraint`, `updateConstraintValue`, `toggleFilterBooleanCondition`, …). An AI-driven edit and a click therefore produce the same tree. There is no second code path to keep in sync.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)