### PR TITLE
Add WebMCP tool surface in PA (delta vs. #3000)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -395,6 +395,7 @@ services:
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
       AI_MODEL: ${AI_MODEL:-}
+      COHORT_HISTORY_MAX_TOKENS: ${COHORT_HISTORY_MAX_TOKENS:-4000}
       # Pythia agent (Amazon Bedrock). AWS_BEARER_TOKEN_BEDROCK from the deploy env.
       AWS_REGION: ${AWS_REGION:-us-east-1}
       BAO_AGENT_MODEL: ${BAO_AGENT_MODEL:-us.anthropic.claude-sonnet-4-6}

--- a/plugins/functions/analytics-svc/src/mri/endpoint/StackedBarchartEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/StackedBarchartEndpoint.ts
@@ -40,6 +40,37 @@ export class StackedBarchartEndpoint extends BaseQueryEngineEndpoint {
         return false;
     }
 
+    /**
+     * True when the request selects at least one axis attribute.
+     *
+     * With every axis on "n/a" there is no measure and no category, so the
+     * generated MeasurePopulation CTE comes out as `SELECT  FROM PatientRequest0`
+     * and the database rejects the whole statement with "Parser Error: SELECT
+     * clause without selection list" — a 500 whose message says nothing about the
+     * actual problem. Callers that clear the axes programmatically (the AI
+     * assistant's cohort patches) then see only a "--" count. Detect it here and
+     * answer with the empty result instead.
+     */
+    private hasAxisSelection(bookmarkInputStr: string): boolean {
+        let axisSelection: any;
+        try {
+            axisSelection = JSON.parse(bookmarkInputStr)?.axisSelection;
+        } catch (e) {
+            // Not our call to reject a malformed body — let the normal path report it.
+            return true;
+        }
+        if (!Array.isArray(axisSelection)) {
+            return true;
+        }
+        return axisSelection.some(
+            (axis) =>
+                axis &&
+                typeof axis.attributeId === "string" &&
+                axis.attributeId !== "" &&
+                axis.attributeId !== "n/a"
+        );
+    }
+
     public processRequest(
         req,
         configId,
@@ -68,6 +99,11 @@ export class StackedBarchartEndpoint extends BaseQueryEngineEndpoint {
                     },
                 };
                 if (bookmarkInputStr === "{}") {
+                    return resolve(emptyResult);
+                }
+                if (!this.hasAxisSelection(bookmarkInputStr)) {
+                    emptyResult.noDataReason =
+                        "MRI_PA_CHART_NO_AXIS_SELECTED";
                     return resolve(emptyResult);
                 }
                 let queryResponse: QuerySvcResultType = await generateQuery(

--- a/plugins/functions/code-suggestion/README.md
+++ b/plugins/functions/code-suggestion/README.md
@@ -38,7 +38,11 @@ The provider is selected by the prefix on `AI_MODEL`:
 # AI Model Configuration
 AI_MODEL=gpt-4o
 OPENAI_API_KEY=sk-...
+COHORT_HISTORY_MAX_TOKENS=4000
 ```
+
+`COHORT_HISTORY_MAX_TOKENS` controls the approximate conversation-history
+budget used by the cohort builder and defaults to `4000`.
 
 ### POST /code-suggestion/chat
 Interactive chat with AI assistant, with optional MCP integration.

--- a/plugins/functions/code-suggestion/src/code-suggestion/cohortMemory.ts
+++ b/plugins/functions/code-suggestion/src/code-suggestion/cohortMemory.ts
@@ -1,0 +1,66 @@
+import type { ChatHistoryTurn } from "../type.ts";
+
+const CHARS_PER_TOKEN = 4;
+const MESSAGE_OVERHEAD_TOKENS = 4;
+
+function estimateTokens(message: ChatHistoryTurn): number {
+  return (
+    Math.ceil(message.content.length / CHARS_PER_TOKEN) +
+    MESSAGE_OVERHEAD_TOKENS
+  );
+}
+
+/**
+ * Keep cohort history within an approximate token budget while retaining the
+ * latest messages verbatim. If compaction removes the latest assistant plan,
+ * preserve it as a clearly labelled memory anchor.
+ */
+export function compactCohortHistory(
+  history: ChatHistoryTurn[],
+  maxTokens = 4_000,
+): ChatHistoryTurn[] {
+  const nonBlank = history.filter((message) => message.content?.trim());
+  const totalTokens = nonBlank.reduce(
+    (total, message) => total + estimateTokens(message),
+    0,
+  );
+  if (totalTokens <= maxTokens) return nonBlank;
+
+  const recent: ChatHistoryTurn[] = [];
+  let usedTokens = 0;
+  for (let i = nonBlank.length - 1; i >= 0; i--) {
+    const messageTokens = estimateTokens(nonBlank[i]);
+    if (recent.length > 0 && usedTokens + messageTokens > maxTokens) break;
+    recent.unshift(nonBlank[i]);
+    usedTokens += messageTokens;
+  }
+
+  const firstRecentIndex = nonBlank.length - recent.length;
+  const latestOmittedPlan = nonBlank
+    .slice(0, firstRecentIndex)
+    .findLast((message) => message.role === "assistant");
+  if (!latestOmittedPlan) return recent;
+
+  const prefix = "Earlier cohort plan (preserve unless the user changed it):\n";
+  const fullAnchor: ChatHistoryTurn = {
+    role: "assistant",
+    content: prefix + latestOmittedPlan.content,
+  };
+  const fullAnchorTokens = estimateTokens(fullAnchor);
+  while (
+    recent.length > 1 &&
+    usedTokens + fullAnchorTokens > maxTokens
+  ) {
+    usedTokens -= estimateTokens(recent.shift()!);
+  }
+  if (usedTokens + fullAnchorTokens <= maxTokens) {
+    return [fullAnchor, ...recent];
+  }
+
+  const availableTokens = maxTokens - usedTokens - MESSAGE_OVERHEAD_TOKENS;
+  const availableChars = availableTokens * CHARS_PER_TOKEN - prefix.length;
+  if (availableChars <= 0) return recent;
+
+  const plan = latestOmittedPlan.content.slice(0, availableChars);
+  return [{ role: "assistant", content: prefix + plan }, ...recent];
+}

--- a/plugins/functions/code-suggestion/src/code-suggestion/prompts.ts
+++ b/plugins/functions/code-suggestion/src/code-suggestion/prompts.ts
@@ -142,6 +142,162 @@ function isStrategusRelated(userInput: string): boolean {
   return STRATEGUS_KEYWORDS.some((kw) => lower.includes(kw));
 }
 
+/**
+ * Dedicated system prompt for the Patient Analytics cohort builder chatbot.
+ *
+ * Two-stage job: read the user's plain-English description, propose a detailed
+ * cohort plan and refine it across as many turns as the user needs, and only
+ * call build_d2e_cohort_deeplink once they explicitly approve. Kept separate
+ * from getRolePrompting because mixing the ATLAS/Strategus assistant's
+ * directives with this one degrades both (see DATA-2305 design, decision 5).
+ *
+ * Returns a static prompt with no userInput interpolation: the caller supplies
+ * userInput as the trailing HumanMessage, which keeps this system prompt
+ * identical across turns so the provider can cache it.
+ */
+export const getCohortPrompting = () => {
+  return `
+    You are the D2E Patient Analytics cohort builder assistant. Help researchers
+    define cohorts from plain-English descriptions. You work in two stages: first
+    PLAN & REFINE the cohort with the user, then BUILD it only after they approve.
+    Never invent config paths, concept ids, or the link URL.
+
+    TOOLS
+    - list_cohort_filters: the filter cards and attributes available on THIS
+      dataset (each attribute tagged num | category | conceptSet | datetime).
+    - search_concepts(query, domain?): clinical term -> candidate OMOP concepts
+      (id, name, domain), ranked by frequency in this dataset.
+    - search_phenotype_library / fetch_templates_for_cohort_generation: reference
+      OHDSI phenotype definitions / ATLAS templates for recognized diseases. Use
+      them to DISCOVER which OMOP concepts define a phenotype. They return
+      phenotype/cohort ids and template JSON — these are NOT concept sets and
+      their ids are NOT concept-set ids.
+    - check_concept_coverage_in_dataset(conceptIds): which ids exist here.
+    - list_concept_sets / get_concept_set / create_concept_set: find or create a
+      concept set; create_concept_set returns the concept-set id.
+    - build_d2e_cohort_deeplink(clauses): builds the link from filter clauses.
+
+    CONCEPT-SET IDs — CRITICAL
+    Every conceptSetId in a clause MUST be a persisted concept-set id returned by
+    create_concept_set (or found via list_concept_sets / get_concept_set). NEVER
+    use an OMOP concept id (from search_concepts) or any phenotype / library /
+    cohort id (from the phenotype library) as a conceptSetId — those are not
+    concept sets and the link will fail.
+    If create_concept_set reports that a same-name concept set has a different
+    definition, never reuse or overwrite it; create the requested definition
+    under a different descriptive name.
+
+    ─────────────────────────────────────────────
+    PLAN & REFINE  (repeat for as many turns as needed)
+    ─────────────────────────────────────────────
+    Whenever the user describes a cohort, OR corrects / adds / removes a filter
+    on a plan you previously proposed:
+
+    1. Call list_cohort_filters (if you haven't already this conversation) to know
+       the real cards and attributes.
+    2. Resolve any clinical concepts using search_concepts, the phenotype library,
+       check_concept_coverage_in_dataset, and create_concept_set as needed. Finish
+       ALL of these tool calls BEFORE you write any reply, so that every clinical
+       term already maps to a final, persisted concept-set id. Never show a term in
+       your reply as still "needing exploration", "to be created", or unresolved.
+    3. Apply the user's latest changes to the working set of clauses (keep the
+       filters they didn't touch; add/remove/edit the ones they mentioned).
+    4. Do NOT call build_d2e_cohort_deeplink yet.
+    5. Reply concisely, and exactly ONCE. Produce a single final answer — do not
+       stream or show drafts, do not restate the plan a second time, and never emit
+       internal reasoning, tool names, role markers, or placeholder/scratch text.
+       Present the plan as a short, human-readable summary the user can scan at a
+       glance. Each filter and each resolved term must appear exactly once:
+       • Start with a one-sentence plain-English description of who the cohort
+         includes.
+       • Then a bullet list of the active filters. Basic Data filters
+         (like age, gender, race) may be written in everyday terms
+         (e.g. "Age: over 50"). For clinical filters, show the exact concept /
+         concept-set name as resolved (e.g. "Condition: Type 2 diabetes mellitus"),
+         not a paraphrase. Group related criteria so the list is easy to read.
+       • Note any unmappable criteria or blocking ambiguities only (skip minor
+         assumptions).
+    6. End with a single confirmation prompt, e.g.
+       "Shall I build this, or would you like to change anything?"
+
+    Stay in this loop until the user explicitly approves. On edits, highlight only
+    what changed; do not re-explain unchanged filters.
+
+    ─────────────────────────────────────────────
+    BUILD  (only after explicit approval)
+    ─────────────────────────────────────────────
+    When the user clearly approves the current plan (e.g. "yes", "build it",
+    "looks good", "go ahead") with no further changes:
+
+    1. Call build_d2e_cohort_deeplink with the exact clauses from the current plan.
+    2. If the call fails or reports a problem (e.g. a clinical clause has no
+       concept set attached, an invalid or duplicate conceptSetId, an unknown
+       card or attribute), DO NOT ask the user for permission and DO NOT hand the
+       problem back to them. Silently self-correct and retry:
+       • Missing/invalid conceptSetId -> re-resolve the term with search_concepts,
+         list_concept_sets and create_concept_set (reusing an existing set when its
+         name matches), then attach the real persisted concept-set id.
+       • Unknown card/attribute -> re-check list_cohort_filters and map to the
+         correct real name.
+       • Then call build_d2e_cohort_deeplink again with the corrected clauses.
+       Repeat this fix-and-retry loop (a few attempts) until it succeeds. Only fall
+       back to asking the user if, after genuinely attempting fixes, a criterion
+       truly cannot be mapped to anything available in this dataset.
+    3. Reply briefly confirming the cohort was built.
+
+    If a message both approves AND asks for a change (e.g. "yes, but drop the age
+    filter"), treat it as a refinement: update the plan and ask again — do not build.
+
+    ─────────────────────────────────────────────
+    FILTER CONSTRUCTION RULES
+    ─────────────────────────────────────────────
+    Demographics (age, gender, race, year of birth...) are attributes on the
+    "Basic Data" card. Use a constraint, e.g. age over 50 ->
+    {attribute:"Age", op:">", value:50}; a range 18-65 -> op:"range",
+    value:[18,65]. For category attributes (gender, race) pass the plain word
+    as value; the backend resolves it to the dataset's coded value. Use at most
+    one constraint per attribute in a card. Never express a numeric range as
+    separate >= and <= constraints.
+
+    Clinical events (conditions, drugs, measurements, procedures): resolve each
+    to a concept-set id:
+    - Recognized phenotype / disease (e.g. "type 2 diabetes", "hypertension"):
+      use search_phenotype_library to identify the phenotype, then
+      fetch_templates_for_cohort_generation to pull its template; take the OMOP
+      concept ids from the template's concept sets (NOT the phenotype/cohort id)
+      and carry those forward.
+    - Specific concept (a measurement/lab like "systolic blood pressure", a drug,
+      a procedure) OR anything paired with a value: use search_concepts(term,
+      domain) and pick the right standard concept.
+    - Then check_concept_coverage_in_dataset. A same-name concept set may be
+      reused only when its saved concept definition is identical; never reuse a
+      same-name set with different concepts or flags. create_concept_set enforces
+      this and requires a different descriptive name on conflict. Use the
+      resulting concept-set id in your clause.
+
+    Compose clauses, one per filter card occurrence:
+      { card, conceptSetId?, constraints?:[{attribute, op, value}], exclude? }
+    - A measurement with a value is ONE clause: conceptSetId for the concept + a
+      constraint on its value attribute (e.g. {attribute:"Value As Number",
+      op:"<", value:120}).
+    - "without" / "excluding" / "no <X>" -> an INTERACTION card's clause gets
+      exclude:true. Never use exclude:true on Basic Data because all demographic
+      attributes share one card; use != or an inverse numeric operator instead.
+    - Two different conditions -> two separate Condition Occurrence clauses.
+
+    RULES
+    - Only use card and attribute NAMES returned by list_cohort_filters. If the
+      Basic Data card lists several gender-like attributes, use the plain one
+      named "Gender" (or "Gender concept name"), not the *source value* / *id* ones.
+    - If a term is ambiguous or search_concepts returns no clear match, ask the
+      user to clarify instead of guessing.
+    - If the request has no usable filter at all, ask for at least one criterion;
+      do not call build_d2e_cohort_deeplink with empty clauses.
+    - Do NOT write the link, a URL, or a markdown link — the system appends the real link
+      automatically.
+  `;
+};
+
 export const getRolePrompting = (userInput: string, context: string) => {
   const includeStrategus = isStrategusRelated(userInput);
   const strategusExpertise = includeStrategus

--- a/plugins/functions/code-suggestion/src/code-suggestion/routes.ts
+++ b/plugins/functions/code-suggestion/src/code-suggestion/routes.ts
@@ -1,4 +1,8 @@
-import { getCodeSuggestion, getChatResponse } from "./services";
+import {
+  getCodeSuggestion,
+  getChatResponse,
+  getCohortResponse,
+} from "./services";
 import express, { Request, Response } from "express";
 import { env } from "../env";
 
@@ -76,6 +80,72 @@ export class CodeSuggestionRouter {
           error: true,
           message: `Cannot fetch chat response: ${error.message}`,
         });
+      }
+    });
+    this.router.post("/cohort", async (req: Request, res: Response) => {
+      try {
+        // Same SSE streaming setup as /chat.
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+        req.body.model = AI_MODEL;
+
+        const { stream, linkRef } = await getCohortResponse(req);
+        let lastChar = "\n";
+        let modelText = "";
+        const COHORT_URL_RE =
+          /(?:\/d2e)?\/portal\/researcher\/cohort\?[^\s")']+/;
+        // Cast: langchain's messages-mode stream isn't precisely typed; the
+        // /chat route gets `any` for free via its fallback branch's wider union.
+        for await (const [token, metadata] of stream as any) {
+          if (
+            metadata.langgraph_node === "model_request" &&
+            token.contentBlocks?.[0]?.text
+          ) {
+            let text: string = token.contentBlocks[0].text;
+            if (text.startsWith("#") && lastChar !== "\n") {
+              text = "\n" + text;
+            } else if (lastChar === "." && /^\S/.test(text)) {
+              text = " " + text;
+            }
+            lastChar = text[text.length - 1];
+            modelText += text;
+            console.log("Cohort Streaming token:", text);
+            res.write(text);
+          } else if (!linkRef.url && typeof token?.content === "string") {
+            // Fallback: capture the deep link if it surfaces as a tool message
+            // in the stream rather than via the invoke interceptor.
+            const m = token.content.match(COHORT_URL_RE);
+            if (m) linkRef.url = m[0];
+          }
+        }
+        // Append the real, deterministic deep link — never trust the LLM to
+        // relay it (it placeholders long URLs). The front end prepends origin.
+        // Dedupe: skip the append if the model already emitted the exact link.
+        if (linkRef.url && !modelText.includes(linkRef.url)) {
+          res.write(`\n\n${linkRef.url}`);
+        } else if (linkRef.attempted && !linkRef.url) {
+          // The build tool ran but returned no link → genuine failure. When the
+          // agent only planned/refined (tool never called), append nothing so the
+          // plan-and-confirm turns read cleanly.
+          res.write(
+            "\n\n(Could not generate the cohort link — please try again.)",
+          );
+        }
+        res.status(200);
+        res.end();
+      } catch (error) {
+        console.error("Error in /cohort route:", error);
+        if (res.headersSent) {
+          // Streaming has already started — cannot send a new JSON response.
+          // Just close the connection cleanly; throwing here would crash the worker.
+          res.end();
+        } else {
+          res.status(500).json({
+            error: true,
+            message: `Cannot fetch cohort response: ${error.message}`,
+          });
+        }
       }
     });
   }

--- a/plugins/functions/code-suggestion/src/code-suggestion/services.ts
+++ b/plugins/functions/code-suggestion/src/code-suggestion/services.ts
@@ -1,10 +1,52 @@
 import { IUICodeSnippet, IChatSnippet } from "../type";
-import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { compactCohortHistory } from "./cohortMemory.ts";
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+} from "@langchain/core/messages";
 import { getModels } from "../utils/utils";
 import { createMcpClient } from "../mcp/client";
+import { env } from "../env";
 import { StringOutputParser } from "@langchain/core/output_parsers";
 import { createAgent } from "langchain";
-import { getRolePrompting } from "./prompts";
+import { getRolePrompting, getCohortPrompting } from "./prompts";
+
+// The tool that returns the final deep link.
+const COHORT_BUILDER_TOOL = "build_d2e_cohort_deeplink";
+// The toolset the cohort agent may call: discover filters, resolve clinical
+// terms to concept-set ids (concept search + phenotype library + concept-set
+// management), then build. Excludes the ATLAS/strategus cohort-definition tools.
+const COHORT_AGENT_TOOLS = new Set<string>([
+  "list_cohort_filters",
+  "search_concepts",
+  "search_phenotype_library",
+  "fetch_templates_for_cohort_generation",
+  "check_concept_coverage_in_dataset",
+  "list_concept_sets",
+  "get_concept_set",
+  "create_concept_set",
+  COHORT_BUILDER_TOOL,
+]);
+// The deep-link path the tool returns; captured deterministically so the LLM
+// never has to relay the (long, easily-placeholdered) URL itself. The optional
+// /d2e prefix must be kept (the tool emits /d2e/portal/...); anchoring at
+// /portal here is what was silently stripping it.
+const COHORT_URL_RE = /(?:\/d2e)?\/portal\/researcher\/cohort\?[^\s")']+/;
+
+/** Pull the deep-link URL out of whatever shape the tool result arrives in. */
+function extractCohortUrl(toolResult: unknown): string | undefined {
+  let text: string;
+  if (typeof toolResult === "string") {
+    text = toolResult;
+  } else if (typeof (toolResult as any)?.content === "string") {
+    text = (toolResult as any).content;
+  } else {
+    text = JSON.stringify(toolResult ?? "");
+  }
+  const match = text.match(COHORT_URL_RE);
+  return match ? match[0] : undefined;
+}
 
 export const getCodeSuggestion = async (uiCode: IUICodeSnippet) => {
   const context = `
@@ -50,7 +92,7 @@ export const getCodeSuggestion = async (uiCode: IUICodeSnippet) => {
     throw new Error(
       `Failed to generate code suggestion with model ${uiCode.model}: ${
         error instanceof Error ? error.message : String(error)
-      }`
+      }`,
     );
   }
 };
@@ -102,7 +144,162 @@ export const getChatResponse = async (req: any) => {
     throw new Error(
       `Failed to get chat response with model ${uiChat.model}${datasetId}: ${
         error instanceof Error ? error.message : String(error)
-      }`
+      }`,
+    );
+  }
+};
+
+/**
+ * Cohort builder chat: a separate single-tool agent that turns a natural
+ * language age/gender description into a PA cohort deep link.
+ *
+ * Mirrors getChatResponse's streaming plumbing, but (1) filters the MCP tools
+ * down to just build_d2e_cohort_deeplink so the narrow job calls reliably, and
+ * (2) uses the dedicated cohort system prompt. See DATA-2305 design, Piece 2.
+ */
+export const getCohortResponse = async (req: any) => {
+  const uiChat: IChatSnippet = req.body;
+  const token = req.headers.authorization;
+  const datasetId = req.query.datasetId; // datasetId is passed as a query parameter
+  const model = await getModels(uiChat.model);
+
+  try {
+    const chatStart = performance.now();
+    const mcpClient = createMcpClient(token, datasetId);
+    const allTools = await mcpClient.getTools();
+    // Multi-tool cohort agent: discover filters, resolve concepts to concept-set
+    // ids, then build. Scope to the cohort-building toolset (not the ATLAS /
+    // strategus tools) so the agent stays on-task.
+    const tools = allTools.filter((t: any) => COHORT_AGENT_TOOLS.has(t.name));
+    const buildTool = tools.find((t: any) => t.name === COHORT_BUILDER_TOOL);
+    if (!buildTool) {
+      throw new Error(
+        `Cohort builder tool '${COHORT_BUILDER_TOOL}' not found on the MCP server`,
+      );
+    }
+
+    // Intercept the build tool at its invoke boundary so we capture the REAL URL
+    // it returned, regardless of how the model later phrases (or mangles) it.
+    // linkRef is filled while the route consumes the stream (when the agent
+    // actually calls the tool); the route reads it after the stream ends.
+    const linkRef: { url: string; attempted: boolean } = {
+      url: "",
+      attempted: false,
+    };
+    // get_concept_set is used by the guard below to verify persisted ids.
+    const getConceptSetTool = tools.find(
+      (t: any) => t.name === "get_concept_set",
+    );
+    const originalInvoke = buildTool.invoke.bind(buildTool);
+    buildTool.invoke = async (input: any, config: any) => {
+      linkRef.attempted = true;
+
+      // Safety guard: before building, verify every conceptSetId in the clauses
+      // is a real persisted concept set (portal.user_artifact row).  This catches
+      // the class of bug where the LLM passes a phenotype/library id (e.g. 503)
+      // or a raw OMOP concept id instead of a create_concept_set-returned id.
+      if (getConceptSetTool) {
+        const clauses: Array<{ conceptSetId?: number }> = Array.isArray(
+          input?.clauses,
+        )
+          ? input.clauses
+          : [];
+        const uniqueIds = [
+          ...new Set(
+            clauses
+              .map((c) => c.conceptSetId)
+              .filter((id): id is number => id != null),
+          ),
+        ];
+
+        const invalid: number[] = [];
+        await Promise.all(
+          uniqueIds.map(async (id) => {
+            // 0 (and any non-positive / non-integer id) is the "unset" sentinel
+            // and is never a real persisted concept set — reject it without a
+            // round-trip.
+            if (!Number.isInteger(id) || id <= 0) {
+              invalid.push(id);
+              return;
+            }
+            try {
+              const res: any = await getConceptSetTool.invoke(
+                { conceptSetId: id },
+                config,
+              );
+              // MCP tool failures may surface as an isError result (or error
+              // text) instead of a thrown exception depending on the adapter,
+              // so inspect the return value too.
+              const text =
+                typeof res === "string" ? res : JSON.stringify(res ?? "");
+              if (res?.isError === true || /not found/i.test(text)) {
+                invalid.push(id);
+              }
+            } catch {
+              invalid.push(id);
+            }
+          }),
+        );
+
+        if (invalid.length > 0) {
+          throw new Error(
+            `conceptSetId(s) [${invalid.join(", ")}] are not persisted concept sets ` +
+              `and cannot be used in a cohort deep link. ` +
+              `Do NOT use phenotype/library ids or raw OMOP concept ids as conceptSetId. ` +
+              `For each invalid id, call create_concept_set with the OMOP concept ids ` +
+              `for that condition/drug/measurement, then use the id returned by ` +
+              `create_concept_set in your clause.`,
+          );
+        }
+      }
+
+      const out = await originalInvoke(input, config);
+      const url = extractCohortUrl(out);
+      if (url) linkRef.url = url;
+      return out;
+    };
+
+    const agent = createAgent({
+      model: model,
+      tools: tools,
+    });
+    console.log(
+      `[MCP-TIMING] [cohort-builder] MCP tools and Agent created ${(performance.now() - chatStart).toFixed(1)}ms`,
+    );
+    // Bound history by estimated tokens rather than message count. When older
+    // turns are compacted, keep the latest omitted cohort plan as a memory
+    // anchor so an unchanged filter is not silently forgotten.
+    const historyMessages = compactCohortHistory(
+      uiChat.history ?? [],
+      env.COHORT_HISTORY_MAX_TOKENS,
+    )
+      .map((m) =>
+        m.role === "assistant"
+          ? new AIMessage(m.content)
+          : new HumanMessage(m.content),
+      );
+
+    const messages = [
+      new SystemMessage(getCohortPrompting()),
+      ...historyMessages,
+      new HumanMessage(uiChat.userInput),
+    ];
+
+    const streamStart = performance.now();
+    const stream = await agent.stream(
+      { messages: messages },
+      { streamMode: "messages" },
+    );
+    console.log(
+      `[MCP-TIMING] [cohort-builder] agent.stream() initiated in ${(performance.now() - streamStart).toFixed(1)}ms`,
+    );
+    return { stream, linkRef };
+  } catch (error) {
+    console.error("Error in getCohortResponse:", error);
+    throw new Error(
+      `Failed to get cohort response with model ${uiChat.model}${datasetId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
     );
   }
 };

--- a/plugins/functions/code-suggestion/src/env.ts
+++ b/plugins/functions/code-suggestion/src/env.ts
@@ -38,6 +38,11 @@ const Env = z.object({
   GOOGLE_API_KEY: optionalSecret,
   OLLAMA_BASE_URL: optionalSecret,
   OLLAMA_API_KEY: optionalSecret,
+  COHORT_HISTORY_MAX_TOKENS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(4000),
 });
 
 export const env = Env.parse(_env);

--- a/plugins/functions/code-suggestion/src/type.ts
+++ b/plugins/functions/code-suggestion/src/type.ts
@@ -2,8 +2,15 @@ export interface IUICodeSnippet {
   code: string;
   model: string;
 }
+export interface ChatHistoryTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export interface IChatSnippet {
   context: string;
   userInput: string;
   model: string;
+  /** Prior conversation turns, oldest-first. Optional for backwards compat. */
+  history?: ChatHistoryTurn[];
 }

--- a/plugins/functions/code-suggestion/src/utils/utils.ts
+++ b/plugins/functions/code-suggestion/src/utils/utils.ts
@@ -1,5 +1,7 @@
 import { env } from "../env";
 
+// About streaming responses: Ollama streams smoothly token-by-token, Anthropic streams in phrase chunks, AzureOpenAI buffers into bursts — Azure's content filter
+
 export const getModels = async (llm) => {
   console.info(`AI: ${llm}`);
   if (llm === null || llm === undefined || llm === "null") {
@@ -45,6 +47,7 @@ export const getModels = async (llm) => {
           new ChatOpenAI({
             model: llm.replace("gpt:", ""),
             apiKey: env.OPENAI_API_KEY,
+            streaming: true,
           }),
       ),
     azure: () =>
@@ -56,6 +59,7 @@ export const getModels = async (llm) => {
             azureOpenAIApiVersion: env.AZURE_OPENAI_API_VERSION,
             azureOpenAIApiDeploymentName: env.AZURE_OPENAI_API_DEPLOYMENT_NAME,
             azureOpenAIApiInstanceName: env.AZURE_OPENAI_API_INSTANCE_NAME,
+            streaming: true,
           }),
       ),
     ollama: () =>
@@ -67,6 +71,7 @@ export const getModels = async (llm) => {
             ...(env.OLLAMA_API_KEY && {
               headers: { Authorization: `Bearer ${env.OLLAMA_API_KEY}` },
             }),
+            streaming: true,
           }),
       ),
     anthropic: () =>
@@ -75,6 +80,7 @@ export const getModels = async (llm) => {
           new ChatAnthropic({
             model: llm.replace("anthropic:", ""),
             apiKey: env.ANTHROPIC_API_KEY,
+            streaming: true,
           }),
       ),
     gemini: () =>
@@ -83,6 +89,7 @@ export const getModels = async (llm) => {
           new ChatGoogle({
             model: llm.replace("gemini:", ""),
             apiKey: env.GOOGLE_API_KEY,
+            streaming: true,
           }),
       ),
   };

--- a/plugins/functions/mcp-server/deno.json
+++ b/plugins/functions/mcp-server/deno.json
@@ -19,9 +19,16 @@
     "./src/api/BaseAPI": "./src/api/BaseAPI.ts",
     "./src/api/WebAPIAPI": "./src/api/WebAPIAPI.ts",
     "./src/api/TerminologyAPI": "./src/api/TerminologyAPI.ts",
+    "./src/api/VocabularyAPI": "./src/api/VocabularyAPI.ts",
     "./src/tools/cohort-management.tools": "./src/tools/cohort-management.tools.ts",
     "./src/tools/cohort-instruction.tools": "./src/tools/cohort-instruction.tools.ts",
     "./src/tools/cohort-validation.tools": "./src/tools/cohort-validation.tools.ts",
+    "./src/tools/cohort-builder.tools": "./src/tools/cohort-builder.tools.ts",
+    "./src/api/AnalyticsAPI": "./src/api/AnalyticsAPI.ts",
+    "./src/lib/cohortDeepLink": "./src/lib/cohortDeepLink.ts",
+    "./src/lib/cohortBookmarkTree": "./src/lib/cohortBookmarkTree.ts",
+    "./src/lib/cohortModel": "./src/lib/cohortModel.ts",
+    "./src/lib/cohortResolver": "./src/lib/cohortResolver.ts",
     "./src/tools/phenotype-library.tools": "./src/tools/phenotype-library.tools.ts",
     "./src/prompts/cohort.prompts": "./src/prompts/cohort.prompts.ts",
     "./src/types/tool-schemas": "./src/types/tool-schemas.ts",
@@ -37,6 +44,7 @@
     "@modelcontextprotocol/sdk/server/streamableHttp.js": "npm:@modelcontextprotocol/sdk@^1.20.2/server/streamableHttp.js",
     "@modelcontextprotocol/sdk/server/mcp.js": "npm:@modelcontextprotocol/sdk@^1.20.2/server/mcp.js",
     "zod": "npm:zod@^3.25.76",
-    "papaparse": "npm:papaparse@^5.4.1"
+    "papaparse": "npm:papaparse@^5.4.1",
+    "pako": "npm:pako@1.0.11"
   }
 }

--- a/plugins/functions/mcp-server/deno.lock
+++ b/plugins/functions/mcp-server/deno.lock
@@ -5,6 +5,7 @@
     "npm:@modelcontextprotocol/sdk@^1.20.2": "1.25.1_zod@3.25.76_ajv@8.17.1_express@5.2.1",
     "npm:axios@^1.7.9": "1.13.2",
     "npm:express@^4.19.2": "4.22.1",
+    "npm:pako@1.0.11": "1.0.11",
     "npm:papaparse@^5.4.1": "5.5.3",
     "npm:zod@^3.25.76": "3.25.76"
   },
@@ -528,6 +529,9 @@
         "wrappy"
       ]
     },
+    "pako@1.0.11": {
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "papaparse@5.5.3": {
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A=="
     },
@@ -758,6 +762,7 @@
       "npm:@modelcontextprotocol/sdk@^1.20.2",
       "npm:axios@^1.7.9",
       "npm:express@^4.19.2",
+      "npm:pako@1.0.11",
       "npm:papaparse@^5.4.1",
       "npm:zod@^3.25.76"
     ]

--- a/plugins/functions/mcp-server/src/api/AnalyticsAPI.ts
+++ b/plugins/functions/mcp-server/src/api/AnalyticsAPI.ts
@@ -1,0 +1,149 @@
+import { env } from "../env";
+import { extractConfigStamp, type ConfigStamp } from "../lib/cohortDeepLink";
+
+/**
+ * Thin client for analytics-svc, used to fetch the PA config stamp
+ * (configId + configVersion) a cohort bookmark must be stamped with.
+ *
+ * Mirrors the Trex-channel pattern of bookmark-svc's AnalyticsSvcAPI and
+ * mcp-server's WebAPIAPI: one tokio channel + SERVICE_ROUTES base URL.
+ *
+ * getMyConfig hits the PA endpoint that dispatches `action=getMyConfig`
+ * (analytics-svc/src/main.ts:218-293), reading datasetId from the query string
+ * and returning the config object whose `meta` carries the stamp
+ * (alp-config-utils mriConfigConnection — meta.configId / meta.configVersion).
+ */
+export class AnalyticsAPI {
+  private readonly channel: any;
+  private readonly baseURL: string;
+
+  constructor() {
+    if (!env.SERVICE_ROUTES.analytics) {
+      throw new Error("No url is set for analytics-svc (SERVICE_ROUTES.analytics)");
+    }
+    this.baseURL = env.SERVICE_ROUTES.analytics;
+    // @ts-ignore Trex global injected by the host runtime
+    this.channel = Trex.tokioChannel("d2e-functions/analytics-svc");
+  }
+
+  /**
+   * Fetch the PA config stamp for a dataset. Returns null when the dataset has
+   * no PA config, so the caller can emit an LLM-actionable error.
+   */
+  async getConfigStamp(
+    authorization: string,
+    datasetId: string,
+  ): Promise<ConfigStamp | null> {
+    const url =
+      `${this.baseURL}/analytics-svc/pa/services/analytics.xsjs` +
+      `?action=getMyConfig&datasetId=${encodeURIComponent(datasetId)}`;
+    const options = {
+      headers: { Authorization: authorization },
+      timeout: 20000,
+    };
+
+    let response: any;
+    try {
+      response = await this.channel.get(url, options);
+    } catch (error) {
+      console.error(
+        `[cohort-builder] getConfigStamp request failed: ${error}`,
+      );
+      throw error;
+    }
+
+    const data = response?.data;
+
+    const stamp = extractConfigStamp(data);
+    if (!stamp) {
+      console.error(
+        `[cohort-builder] getConfigStamp: no meta.configId/configVersion in response. ` +
+          `status=${response?.status} isArray=${Array.isArray(data)}`,
+      );
+      return null;
+    }
+    return stamp;
+  }
+
+  /**
+   * Fetch the full PA frontend config for a dataset: the same getMyConfig
+   * `{ config, meta }` the PA UI loads, where `config.patient` carries the
+   * filter cards and attributes. The cohort catalog is built from this exact
+   * object, so what we expose matches what the loader will accept.
+   *
+   * Returns null when the dataset has no PA config, so the caller can emit an
+   * LLM-actionable error instead of an empty catalog.
+   */
+  async getFrontendConfig(
+    authorization: string,
+    datasetId: string,
+  ): Promise<{ config: any; meta: ConfigStamp } | null> {
+    const url =
+      `${this.baseURL}/analytics-svc/pa/services/analytics.xsjs` +
+      `?action=getMyConfig&datasetId=${encodeURIComponent(datasetId)}`;
+    const options = {
+      headers: { Authorization: authorization },
+      timeout: 20000,
+    };
+
+    let response: any;
+    try {
+      response = await this.channel.get(url, options);
+    } catch (error) {
+      console.error(
+        `[cohort-builder] getFrontendConfig request failed: ${error}`,
+      );
+      throw error;
+    }
+
+    const data = response?.data;
+    // getMyConfig returns a LIST of configs; a dataset has one active PA
+    // config, so we take the first (tolerating a bare object too).
+    const entry = Array.isArray(data) ? data[0] : data;
+    const meta = extractConfigStamp(data);
+    if (!entry?.config || !meta) {
+      console.error(
+        `[cohort-builder] getFrontendConfig: missing config/meta. ` +
+          `status=${response?.status} isArray=${Array.isArray(data)} ` +
+          `hasConfig=${!!entry?.config} hasMeta=${!!meta}`,
+      );
+      return null;
+    }
+    return { config: entry.config, meta };
+  }
+
+  /**
+   * Resolve the allowed values of a category/text attribute, optionally
+   * filtered by a fuzzy search term. Hits the same `values` endpoint the PA UI
+   * uses, so the returned `value` is exactly what the bookmark expression must
+   * carry (this is what turns "male" into the dataset's coded gender value).
+   * Returns `{label, value}` pairs (`label` = display text).
+   */
+  async getAttributeValues(
+    authorization: string,
+    datasetId: string,
+    attributePath: string,
+    configId: string,
+    configVersion: string,
+    searchQuery = "",
+  ): Promise<{ label: string; value: string }[]> {
+    const params = new URLSearchParams({
+      attributePath,
+      configId,
+      configVersion,
+      datasetId,
+      searchQuery,
+      attributeType: "text",
+    });
+    const url =
+      `${this.baseURL}/analytics-svc/api/services/values?${params.toString()}`;
+    const options = {
+      headers: { Authorization: authorization },
+      timeout: 20000,
+    };
+    const response = await this.channel.get(url, options);
+    // Endpoint wraps the list in `data.data`, items shaped `{ value, text }`.
+    const items: { value: string; text?: string }[] = response?.data?.data ?? [];
+    return items.map((it) => ({ label: it.text || it.value, value: it.value }));
+  }
+}

--- a/plugins/functions/mcp-server/src/api/VocabularyAPI.ts
+++ b/plugins/functions/mcp-server/src/api/VocabularyAPI.ts
@@ -1,0 +1,60 @@
+import { BaseAPI } from "./BaseAPI";
+
+/**
+ * Fuzzy OMOP concept search over d2e-webapi's vocabulary endpoint
+ * (`POST /vocabulary/:sourceKey/search`, the same search the cohort/ATLAS UI
+ * uses). Turns a clinical term into candidate standard concepts — the missing
+ * rung between a plain word ("systolic blood pressure") and the concept-set
+ * tools, which work in concept IDs.
+ *
+ * In D2E the vocabulary `sourceKey` equals the `datasetId` (each dataset is
+ * registered as its own source), so we pass the datasetId as the sourceKey.
+ * Results come back ranked by record count in the dataset (most-used first).
+ */
+
+export type ConceptHit = {
+  conceptId: number;
+  conceptName: string;
+  domainId: string;
+  vocabularyId: string;
+  standardConcept: string | null;
+};
+
+export class VocabularyAPI extends BaseAPI {
+  constructor() {
+    super("d2e-webapi", "d2e-webapi");
+  }
+
+  async searchConcepts(
+    authorization: string,
+    datasetId: string,
+    query: string,
+    domain?: string,
+    standardOnly = true,
+    limit = 20,
+  ): Promise<ConceptHit[]> {
+    const body: Record<string, unknown> = {
+      QUERY: query,
+      DOMAIN_ID: domain ? [domain] : [],
+      ...(standardOnly ? { STANDARD_CONCEPT: "S" } : {}),
+    };
+    // sourceKey === datasetId; page is 0-based, rowsPerPage caps the candidates.
+    const path =
+      `/vocabulary/${encodeURIComponent(datasetId)}/search` +
+      `?page=0&rowsPerPage=${limit}`;
+    const { data, status } = await this.call<any[]>(
+      "post",
+      path,
+      { authorization, datasetId },
+      body,
+    );
+    if (status !== 200 || !Array.isArray(data)) return [];
+    return data.map((c) => ({
+      conceptId: c.CONCEPT_ID,
+      conceptName: c.CONCEPT_NAME,
+      domainId: c.DOMAIN_ID,
+      vocabularyId: c.VOCABULARY_ID,
+      standardConcept: c.STANDARD_CONCEPT,
+    }));
+  }
+}

--- a/plugins/functions/mcp-server/src/api/example.json
+++ b/plugins/functions/mcp-server/src/api/example.json
@@ -1,0 +1,65 @@
+{
+  "patient": {
+    "attributes": {
+      "Age": {
+        "name": "Age",
+        "type": "num",
+        "filtercard": {
+          "visible": true
+        }
+      }
+    },
+    "interactions": {
+      "measurement": {
+        "name": "Measurement",
+        "filtercard": {
+          "visible": true
+        },
+        "attributes": {
+          "numval": {
+            "name": "Value As Number",
+            "type": "num",
+            "filtercard": {
+              "visible": true
+            }
+          },
+          "measurementconceptset": {
+            "name": "Measurement concept set",
+            "type": "conceptSet",
+            "domainFilter": "Measurement",
+            "cohortDefinitionKey": "CodesetId",
+            "filtercard": {
+              "visible": true
+            }
+          },
+          "unitconceptset": {
+            "name": "Unit concept set",
+            "type": "conceptSet",
+            "domainFilter": "Unit",
+            "cohortDefinitionKey": "Unit",
+            "filtercard": {
+              "visible": true
+            }
+          }
+        }
+      },
+      "conditionoccurrence": {
+        "name": "Condition Occurrence",
+        "filtercard": {
+          "visible": true
+        },
+        "attributes": {
+          "conditionconceptset": {
+            "name": "Condition concept set",
+            "type": "conceptSet",
+            "domainFilter": "Condition",
+            "cohortDefinitionKey": "CodesetId",
+            "filtercard": {
+              "visible": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/functions/mcp-server/src/lib/cohortBookmarkTree.ts
+++ b/plugins/functions/mcp-server/src/lib/cohortBookmarkTree.ts
@@ -1,0 +1,200 @@
+import type { ConfigStamp } from "./cohortDeepLink";
+
+/**
+ * Multi-card bookmark serializer for the PA cohort builder deep link.
+ *
+ * Ported and generalised from `wizards/src/utils/mriQuery.ts:buildMriBookmark`,
+ * which is pinned against the real `BMv2Parser`. It takes constraints that have
+ * already been resolved (attribute paths matched against the dataset config,
+ * values resolved to the form PA expects) and emits the bookmark tree the loader
+ * accepts: `filter.cards = AND > [ inclusion: OR > FilterCard, exclusion: NOT >
+ * (OR > FilterCard) ]`.
+ *
+ * Two things this adds over the stiff age/gender builder:
+ *  - any number of cards / interaction cards, grouped by `cardInstanceKey`;
+ *  - card-level exclusion via a `NOT` container (confirmed: `BMv2Parser`
+ *    `addNot`, and query.ts serialises `excludeFilter` as `Not([filterCard])`).
+ *
+ * Scope note: emits the minimal filter-only bookmark (no axisSelection/chartType)
+ * — the cohort-definition deep link doesn't chart, matching the working POC.
+ */
+
+export interface CohortExpression {
+  operator: string; // ">=", "<=", "=", "<", ">", "!="
+  value: string | number;
+}
+
+/**
+ * One resolved attribute constraint. `cardInstanceKey` groups constraints that
+ * must live in the SAME filter-card instance (e.g. a measurement's concept name
+ * + its numeric value), while two clauses with different keys on the same
+ * `cardConfigPath` become separate cards ("Condition Occurrence A" / "B").
+ */
+export interface CohortConstraint {
+  /** Generic card path: "patient" | "patient.interactions.<key>". */
+  cardConfigPath: string;
+  /** Display name for the card, e.g. "Basic Data", "Condition Occurrence". */
+  cardName: string;
+  /** Groups constraints into one card instance. */
+  cardInstanceKey: string;
+  /** Card-level exclusion → wrap in a NOT container. */
+  exclude?: boolean;
+  /** Generic attribute path, e.g. "patient.attributes.Age". */
+  attributeConfigPath: string;
+  /** Expressions for this attribute. */
+  expressions: CohortExpression[];
+  /** How to combine the expressions; defaults to OR (AND for numeric ranges). */
+  combine?: "AND" | "OR";
+}
+
+interface Attribute {
+  type: "Attribute";
+  configPath: string;
+  instanceID: string;
+  constraints: {
+    type: "BooleanContainer";
+    op: "AND" | "OR";
+    content: ({ type: "Expression" } & CohortExpression)[];
+  };
+}
+
+interface FilterCard {
+  type: "FilterCard";
+  configPath: string;
+  instanceNumber: number;
+  instanceID: string;
+  name: string;
+  inactive: boolean;
+  attributes: { type: "BooleanContainer"; op: "AND"; content: Attribute[] };
+}
+
+interface BooleanContainer {
+  type: "BooleanContainer";
+  op: "AND" | "OR" | "NOT";
+  content: (BooleanContainer | FilterCard)[];
+}
+
+interface CohortBookmark {
+  filter: {
+    configMetadata: { id: string; version: string };
+    cards: BooleanContainer;
+  };
+  metadata: { version: number };
+}
+
+/** Last path segment, e.g. "patient.attributes.Age" -> "Age". */
+function attrKey(configPath: string): string {
+  return configPath.split(".").pop() || configPath;
+}
+
+/**
+ * Build the bookmark tree from resolved constraints. Constraints sharing a
+ * `cardInstanceKey` are merged into one FilterCard; cards are letter-suffixed
+ * per card type (mirroring buildMriBookmark) and excluded cards are wrapped in
+ * NOT. The patient card keeps `instanceID:"patient"`, `instanceNumber:1`.
+ */
+export function buildCohortBookmarkTree(
+  constraints: CohortConstraint[],
+  config: ConfigStamp,
+): CohortBookmark {
+  // Group constraints by card instance, preserving first-seen order.
+  const order: string[] = [];
+  const groups = new Map<
+    string,
+    { cardConfigPath: string; cardName: string; exclude: boolean; attrs: CohortConstraint[] }
+  >();
+  for (const c of constraints) {
+    let g = groups.get(c.cardInstanceKey);
+    if (!g) {
+      g = {
+        cardConfigPath: c.cardConfigPath,
+        cardName: c.cardName,
+        exclude: !!c.exclude,
+        attrs: [],
+      };
+      groups.set(c.cardInstanceKey, g);
+      order.push(c.cardInstanceKey);
+    }
+    // Any constraint in the group marking exclude makes the card excluded.
+    if (c.exclude) g.exclude = true;
+    g.attrs.push(c);
+  }
+
+  // Letter suffix per card type ("Condition Occurrence A/B"); instance number
+  // per generic card path (.1, .2) for unique instanceIDs.
+  const typeCounters = new Map<string, number>();
+  const instanceCounters = new Map<string, number>();
+  const containers: BooleanContainer[] = [];
+
+  for (const key of order) {
+    const g = groups.get(key)!;
+    const isPatient = g.cardConfigPath === "patient";
+
+    let name = g.cardName;
+    if (!isPatient) {
+      const used = typeCounters.get(g.cardName) || 0;
+      name = `${g.cardName} ${String.fromCharCode(65 + used)}`; // A, B, C...
+      typeCounters.set(g.cardName, used + 1);
+    }
+
+    let instanceID: string;
+    let instanceNumber: number;
+    if (isPatient) {
+      instanceID = "patient";
+      instanceNumber = 1;
+    } else {
+      instanceNumber = (instanceCounters.get(g.cardConfigPath) || 0) + 1;
+      instanceCounters.set(g.cardConfigPath, instanceNumber);
+      instanceID = `${g.cardConfigPath}.${instanceNumber}`;
+    }
+
+    const attributes: Attribute[] = g.attrs.map((a) => {
+      const combine: "AND" | "OR" =
+        a.combine ?? (a.expressions.length > 1 ? "AND" : "OR");
+      return {
+        type: "Attribute",
+        configPath: a.attributeConfigPath,
+        instanceID: `${instanceID}.attributes.${attrKey(a.attributeConfigPath)}`,
+        constraints: {
+          type: "BooleanContainer",
+          op: combine,
+          content: a.expressions.map((e) => ({
+            type: "Expression" as const,
+            operator: e.operator,
+            value: e.value,
+          })),
+        },
+      };
+    });
+
+    const filterCard: FilterCard = {
+      type: "FilterCard",
+      configPath: g.cardConfigPath,
+      instanceNumber,
+      instanceID,
+      name,
+      inactive: false,
+      attributes: { type: "BooleanContainer", op: "AND", content: attributes },
+    };
+
+    // Inclusion: OR > FilterCard. Exclusion: NOT > (OR > FilterCard).
+    const inclusion: BooleanContainer = {
+      type: "BooleanContainer",
+      op: "OR",
+      content: [filterCard],
+    };
+    containers.push(
+      g.exclude
+        ? { type: "BooleanContainer", op: "NOT", content: [inclusion] }
+        : inclusion,
+    );
+  }
+
+  return {
+    filter: {
+      configMetadata: { id: config.configId, version: config.configVersion },
+      cards: { type: "BooleanContainer", op: "AND", content: containers },
+    },
+    metadata: { version: 3 },
+  };
+}

--- a/plugins/functions/mcp-server/src/lib/cohortDeepLink.ts
+++ b/plugins/functions/mcp-server/src/lib/cohortDeepLink.ts
@@ -1,0 +1,80 @@
+import pako from "pako";
+
+export interface ConfigStamp {
+  configId: string;
+  configVersion: string;
+}
+
+const COHORT_ROUTE = "/d2e/portal/researcher/cohort";
+const LINK_TYPE = "cohort-definition";
+const URL_WARN_THRESHOLD = 2048;
+
+/**
+ * Extract the active Patient Analytics configuration stamp from getMyConfig,
+ * which may return either a list containing one configuration or a bare entry.
+ */
+export function extractConfigStamp(data: unknown): ConfigStamp | null {
+  const entry = Array.isArray(data) ? data[0] : data;
+  const meta = (entry as any)?.meta;
+  if (!meta?.configId || !meta?.configVersion) {
+    return null;
+  }
+  return {
+    configId: String(meta.configId),
+    configVersion: String(meta.configVersion),
+  };
+}
+
+/**
+ * Compress an object to a pako-deflated base64url string.
+ *
+ * Ported verbatim from plugins/ui/apps/wizards/src/utils/cohortUrlCodec.ts,
+ * which is documented "Compatible with vue-mri CohortUrlCodec". Both UTF-8
+ * encode then deflate with the same pako defaults, so the output is the deep
+ * link `query` param the PA loader (vue-mri CohortUrlCodec.safeDecompress)
+ * accepts. The explicit byte handling (Array.from -> String.fromCharCode ->
+ * btoa) is the part that breaks if mis-ported to Deno, so it is kept exactly.
+ *
+ * NOTE: this emits base64url (`-`/`_`, no `=`). Do NOT reuse it for the
+ * analytics-svc `mriquery` param, which uses standard base64 (`+`/`/`/`=`).
+ */
+export function compress(obj: unknown): string {
+  const jsonString = JSON.stringify(obj);
+  const deflated = pako.deflate(new TextEncoder().encode(jsonString));
+  const binaryString = Array.from(
+    deflated,
+    (byte: number) => String.fromCharCode(byte),
+  ).join("");
+  const base64 = btoa(binaryString);
+  // Convert to base64url
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Decompress a pako-deflated base64url string back to an object.
+ * Inverse of compress(); used by the round-trip oracle test.
+ */
+export function decompress<T = unknown>(str: string): T {
+  // Convert from base64url to base64
+  let base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  // Add padding
+  while (base64.length % 4 !== 0) {
+    base64 += "=";
+  }
+  const binaryString = atob(base64);
+  const bytes = Uint8Array.from(binaryString, (char) => char.charCodeAt(0));
+  const inflated = pako.inflate(bytes);
+  const jsonString = new TextDecoder().decode(inflated);
+  return JSON.parse(jsonString) as T;
+}
+
+/** Compress a bookmark and assemble the Patient Analytics cohort deep link. */
+export function buildDeepLinkUrl(
+  bookmark: unknown,
+  datasetId: string,
+): { url: string; tooLong: boolean } {
+  const query = compress(bookmark);
+  const params = new URLSearchParams({ datasetId, linkType: LINK_TYPE });
+  const url = `${COHORT_ROUTE}?${params.toString()}&query=${query}`;
+  return { url, tooLong: url.length > URL_WARN_THRESHOLD };
+}

--- a/plugins/functions/mcp-server/src/lib/cohortModel.ts
+++ b/plugins/functions/mcp-server/src/lib/cohortModel.ts
@@ -1,0 +1,190 @@
+/**
+ * Build the cohort filter catalog from a Patient Analytics frontend config
+ * (the getMyConfig `config` object).
+ *
+ * The catalog is the set of filter cards + attributes the PA cohort builder
+ * will actually accept, derived by applying the SAME visibility rules the
+ * loader uses (MriFrontendConfig / MriConfigAttribute, mri-pa-ui):
+ *   - a filter card is usable when its `filtercard` is absent or
+ *     `filtercard.visible === true`;
+ *   - an attribute is filterable when `filtercard.visible === true`
+ *     (MriConfigAttribute.isVisibleInFilterCard).
+ *
+ * Enumerating from the same config the loader validates against is what makes
+ * every (card, attribute) we expose loadable by construction: the build step
+ * can only ever reference paths PA's isValidFilterCardAttribute would accept,
+ * which is the guarantee that prevents a bookmark referencing an attribute the
+ * dataset doesn't have (the class of bug where a card silently fails to load).
+ */
+
+export type AttributeKind = "num" | "category" | "conceptSet" | "datetime";
+
+export interface CatalogAttribute {
+  /** Config key, e.g. "Age", "condition_occ_concept_name". */
+  key: string;
+  /** Full path used in the bookmark, e.g. "patient.attributes.Age". */
+  configPath: string;
+  /** Display name, e.g. "Age", "Condition concept Name". */
+  name: string;
+  /** Raw config type: num | text | datetime | time | conceptSet. */
+  type: string;
+  /** How the value is supplied when building a constraint. */
+  kind: AttributeKind;
+  /**
+   * Config `cohortDefinitionKey`. The card's PRIMARY concept set is the
+   * conceptSet attribute with `cohortDefinitionKey === "CodesetId"` — that is
+   * the attribute a clause's `concept` maps to.
+   */
+  cohortDefinitionKey?: string;
+  /** Config `domainFilter` (e.g. "Visit", "Procedure"); may be empty. */
+  domainFilter?: string;
+}
+
+export interface CatalogCard {
+  /** "patient" or an interaction key, e.g. "conditionoccurrence". */
+  key: string;
+  /** "patient" or "patient.interactions.<key>". */
+  configPath: string;
+  /** "Basic Data" or the interaction's display name. */
+  name: string;
+  attributes: CatalogAttribute[];
+}
+
+// A type alias (not interface) so it is assignable to the MCP SDK's
+// structuredContent `{ [x: string]: unknown }` shape.
+export type CohortCatalog = {
+  cards: CatalogCard[];
+};
+
+/**
+ * The card-centric clause contract the LLM produces using names from
+ * list_cohort_filters; the resolver maps these requests onto the catalog.
+ */
+export interface ClauseConstraint {
+  /** Catalog attribute name, e.g. "Age", "Value As Number", "Gender". */
+  attribute: string;
+  /** ">=" | "<=" | "=" | "<" | ">" | "!=" | "range". */
+  op: string;
+  /** Number, string, or [low, high] for op "range". */
+  value: number | string | (number | string)[];
+}
+
+export interface CohortClause {
+  /** Catalog card name, e.g. "Basic Data", "Condition Occurrence". */
+  card: string;
+  /** Card-level include/exclude (exclude becomes a NOT container). */
+  exclude?: boolean;
+  /**
+   * Persisted concept-set id for an event card, resolved by the agent before
+   * the clause reaches the deterministic pipeline.
+   */
+  conceptSetId?: number;
+  /** Value constraints on this card's attributes. */
+  constraints?: ClauseConstraint[];
+}
+
+/** Config stores names as a string or an array of { lang, value }. */
+function resolveName(nameVal: unknown, fallbackKey: string): string {
+  if (typeof nameVal === "string" && nameVal) return nameVal;
+  if (
+    Array.isArray(nameVal) && nameVal.length > 0 && (nameVal[0] as any)?.value
+  ) {
+    return String((nameVal[0] as any).value);
+  }
+  return fallbackKey.charAt(0).toUpperCase() + fallbackKey.slice(1);
+}
+
+/** Map the raw config `type` to how the resolver must supply a value. */
+function attrKind(type: string): AttributeKind {
+  switch (type) {
+    case "num":
+      return "num";
+    case "conceptSet":
+      return "conceptSet";
+    case "datetime":
+    case "time":
+      return "datetime";
+    default:
+      // text + any coded categorical (gender, race, concept names)
+      return "category";
+  }
+}
+
+/** An attribute is filterable iff filtercard.visible === true. */
+function isAttrVisible(attr: any): boolean {
+  return !!(attr?.filtercard && attr.filtercard.visible === true);
+}
+
+function buildAttributes(
+  attrs: Record<string, any> | undefined,
+  basePath: string,
+): CatalogAttribute[] {
+  const out: CatalogAttribute[] = [];
+  for (const [key, attr] of Object.entries(attrs ?? {})) {
+    if (!isAttrVisible(attr)) continue;
+    const type = String(attr?.type ?? "text");
+    out.push({
+      key,
+      configPath: `${basePath}.attributes.${key}`,
+      name: resolveName(attr?.name, key),
+      type,
+      kind: attrKind(type),
+      cohortDefinitionKey: attr?.cohortDefinitionKey || undefined,
+      domainFilter: attr?.domainFilter || undefined,
+    });
+  }
+  return out;
+}
+
+/**
+ * Turn a getMyConfig `config` object into the cohort filter catalog.
+ * The patient ("Basic Data") card is always present; interaction cards are
+ * included when visible. Attributes are filtered to the visible-in-filtercard
+ * set, matching the loader.
+ */
+export function buildCohortCatalog(config: any): CohortCatalog {
+  const cards: CatalogCard[] = [];
+
+  // Patient card — always present; its name is conventional ("Basic Data"),
+  // mirroring getFilterCardName in mriQuery.ts (config.patient has no `name`).
+  cards.push({
+    key: "patient",
+    configPath: "patient",
+    name: "Basic Data",
+    attributes: buildAttributes(config?.patient?.attributes, "patient"),
+  });
+
+  // Interaction cards — visible when filtercard is absent or visible === true.
+  const interactions = config?.patient?.interactions ?? {};
+  for (const [key, inter] of Object.entries<any>(interactions)) {
+    const fc = inter?.filtercard;
+    const visible = fc === undefined || fc.visible === true;
+    if (!visible) continue;
+    const basePath = `patient.interactions.${key}`;
+    cards.push({
+      key,
+      configPath: basePath,
+      name: resolveName(inter?.name, key),
+      attributes: buildAttributes(inter?.attributes, basePath),
+    });
+  }
+
+  return { cards };
+}
+
+/**
+ * Compact human/LLM-readable summary of the catalog: one line per card listing
+ * each attribute as `Name[kind]`, so the model can ground its filter choices on
+ * the real cards/attributes before calling the build tool.
+ */
+export function summarizeCatalog(catalog: CohortCatalog): string {
+  const lines = catalog.cards.map((c) => {
+    const attrs = c.attributes.map((a) => `${a.name}[${a.kind}]`).join(", ");
+    return `- ${c.name}: ${attrs || "(no filterable attributes)"}`;
+  });
+  return (
+    "Filter cards available on this dataset (use only these cards and " +
+    "attributes when composing cohort filters):\n" +
+    lines.join("\n")
+  );
+}

--- a/plugins/functions/mcp-server/src/lib/cohortPipeline.test.ts
+++ b/plugins/functions/mcp-server/src/lib/cohortPipeline.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Pipeline test: clauses -> resolver (stubbed I/O) -> serializer -> codec,
+ * with a best-effort round-trip through the REAL BMv2Parser.
+ *
+ * The structural assertions are the silent-wrong-cohort guard: a subtly wrong
+ * tree loads the WRONG cohort, so we pin the exact shape (cards, paths,
+ * instanceIDs, NOT for exclusion, compound measurement card).
+ *
+ * Run: deno test --allow-read --sloppy-imports --no-check src/lib/cohortPipeline.test.ts
+ */
+
+import {
+  buildCohortCatalog,
+  type CohortClause,
+} from "./cohortModel.ts";
+import {
+  resolveClausesToConstraints,
+  type ResolverDeps,
+} from "./cohortResolver.ts";
+import { buildCohortBookmarkTree } from "./cohortBookmarkTree.ts";
+import { compress, decompress } from "./cohortDeepLink.ts";
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error("ASSERT FAILED: " + msg);
+}
+function eq(actual: unknown, expected: unknown, msg: string) {
+  if (actual !== expected) {
+    throw new Error(
+      `ASSERT FAILED: ${msg} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+const STAMP = { configId: "test-config", configVersion: "A" };
+
+// Deterministic stubs so the resolver runs offline. Real deps hit the values
+// endpoint; here categories just map raw -> upper. Concept sets are NOT resolved
+// here — the agent resolves them to ids up front, so clauses carry conceptSetId.
+const PERSISTED_CONCEPT_SETS = new Set([111, 222, 333]);
+const stubDeps: ResolverDeps = {
+  resolveValue: (_card, _attr, raw) => Promise.resolve(raw.toUpperCase()),
+  conceptSetExists: (id) => Promise.resolve(PERSISTED_CONCEPT_SETS.has(id)),
+};
+
+// "aged > 50 with hypertension(111), systolic BP(222) < 120, excluding diabetes(333)"
+const CLAUSES: CohortClause[] = [
+  {
+    card: "Basic Data",
+    constraints: [{ attribute: "Age", op: ">", value: 50 }],
+  },
+  { card: "Condition Occurrence", conceptSetId: 111 },
+  {
+    card: "Measurement",
+    conceptSetId: 222,
+    constraints: [{ attribute: "Value As Number", op: "<", value: 120 }],
+  },
+  { card: "Condition Occurrence", conceptSetId: 333, exclude: true },
+];
+
+async function buildTree() {
+  const configText = await Deno.readTextFile(
+    new URL("../api/example.json", import.meta.url),
+  );
+  const catalog = buildCohortCatalog(JSON.parse(configText));
+  const constraints = await resolveClausesToConstraints(
+    CLAUSES,
+    catalog,
+    stubDeps,
+  );
+  return buildCohortBookmarkTree(constraints, STAMP);
+}
+
+Deno.test(
+  "tree shape: AND over 4 cards, exclusion wrapped in NOT",
+  async () => {
+    const bm = await buildTree();
+    eq(bm.metadata.version, 3, "metadata.version");
+    eq(bm.filter.configMetadata.id, "test-config", "configMetadata.id");
+    eq(bm.filter.configMetadata.version, "A", "configMetadata.version");
+
+    const cards = bm.filter.cards;
+    eq(cards.op, "AND", "top op");
+    eq(cards.content.length, 4, "number of card containers");
+
+    // [0] patient inclusion
+    const c0: any = cards.content[0];
+    eq(c0.op, "OR", "patient container op");
+    const fc0 = c0.content[0];
+    eq(fc0.type, "FilterCard", "patient is FilterCard");
+    eq(fc0.configPath, "patient", "patient configPath");
+    eq(fc0.instanceID, "patient", "patient instanceID");
+    eq(fc0.name, "Basic Data", "patient name");
+    const age = fc0.attributes.content[0];
+    eq(age.configPath, "patient.attributes.Age", "age configPath");
+    eq(age.instanceID, "patient.attributes.Age", "age instanceID");
+    eq(age.constraints.content[0].operator, ">", "age op");
+    eq(age.constraints.content[0].value, 50, "age value");
+
+    // [1] condition A (hypertension) -> primary conceptSet attr, id 111
+    const fc1: any = cards.content[1].content[0];
+    eq(fc1.name, "Condition Occurrence A", "condition A name");
+    eq(
+      fc1.instanceID,
+      "patient.interactions.conditionoccurrence.1",
+      "condition A instanceID",
+    );
+    const condAttr = fc1.attributes.content[0];
+    eq(
+      condAttr.configPath,
+      "patient.interactions.conditionoccurrence.attributes.conditionconceptset",
+      "condition concept set path",
+    );
+    eq(
+      condAttr.constraints.content[0].value,
+      "111",
+      "hypertension concept set id",
+    );
+
+    // [2] measurement A — COMPOUND: concept set + numval in ONE card
+    const fc2: any = cards.content[2].content[0];
+    eq(fc2.name, "Measurement A", "measurement name");
+    eq(fc2.attributes.content.length, 2, "measurement has 2 attributes");
+    const mAttrs = fc2.attributes.content.map((a: any) => a.configPath);
+    assert(
+      mAttrs.includes(
+        "patient.interactions.measurement.attributes.measurementconceptset",
+      ),
+      "measurement concept set present",
+    );
+    assert(
+      mAttrs.includes("patient.interactions.measurement.attributes.numval"),
+      "numval present",
+    );
+    const numval = fc2.attributes.content.find((a: any) =>
+      a.configPath.endsWith("numval"),
+    );
+    eq(numval.constraints.content[0].operator, "<", "numval op");
+    eq(numval.constraints.content[0].value, 120, "numval value");
+
+    // [3] EXCLUSION: diabetes condition wrapped in NOT
+    const c3: any = cards.content[3];
+    eq(c3.op, "NOT", "exclusion container is NOT");
+    const inner = c3.content[0];
+    eq(inner.op, "OR", "NOT wraps an OR");
+    const fc3 = inner.content[0];
+    eq(fc3.name, "Condition Occurrence B", "excluded condition name (B)");
+    eq(
+      fc3.instanceID,
+      "patient.interactions.conditionoccurrence.2",
+      "excluded condition instanceID .2",
+    );
+    eq(
+      fc3.attributes.content[0].constraints.content[0].value,
+      "333",
+      "diabetes concept set id",
+    );
+  },
+);
+
+Deno.test("numeric range -> two AND expressions", async () => {
+  const configText = await Deno.readTextFile(
+    new URL("../api/example.json", import.meta.url),
+  );
+  const catalog = buildCohortCatalog(JSON.parse(configText));
+  const constraints = await resolveClausesToConstraints(
+    [
+      {
+        card: "Basic Data",
+        constraints: [{ attribute: "Age", op: "range", value: [50, 80] }],
+      },
+    ],
+    catalog,
+    stubDeps,
+  );
+  const bm = buildCohortBookmarkTree(constraints, STAMP);
+  const age: any = (bm.filter.cards.content[0] as any).content[0].attributes
+    .content[0];
+  eq(age.constraints.op, "AND", "range uses AND");
+  eq(age.constraints.content.length, 2, "range has 2 expressions");
+  eq(age.constraints.content[0].operator, ">=", "lower op");
+  eq(age.constraints.content[1].operator, "<=", "upper op");
+});
+
+Deno.test("codec round-trips the bookmark", async () => {
+  const bm = await buildTree();
+  const round = decompress(compress(bm));
+  eq(
+    JSON.stringify(round),
+    JSON.stringify(bm),
+    "decompress(compress(x)) === x",
+  );
+});
+
+Deno.test(
+  "resolver rejects unknown card with an actionable error",
+  async () => {
+    const configText = await Deno.readTextFile(
+      new URL("../api/example.json", import.meta.url),
+    );
+    const catalog = buildCohortCatalog(JSON.parse(configText));
+    let threw = false;
+    try {
+      await resolveClausesToConstraints(
+        [{ card: "Nonexistent Card", conceptSetId: 1 }],
+        catalog,
+        stubDeps,
+      );
+    } catch (e) {
+      threw = true;
+      assert(
+        String(e).includes("Unknown filter card"),
+        "error names the problem",
+      );
+    }
+    assert(threw, "unknown card must throw");
+  },
+);
+
+Deno.test(
+  "resolver rejects a non-persisted concept-set id (raw OMOP / phenotype id)",
+  async () => {
+    const configText = await Deno.readTextFile(
+      new URL("../api/example.json", import.meta.url),
+    );
+    const catalog = buildCohortCatalog(JSON.parse(configText));
+
+    // 9201 ("Inpatient Visit") is a raw OMOP concept id, not a persisted
+    // concept set. It passes a positivity check, so only an existence lookup
+    // can reject it — both id-arrival paths must do so.
+    const BAD_ID = 9201;
+    assert(
+      !PERSISTED_CONCEPT_SETS.has(BAD_ID),
+      "BAD_ID must not be a persisted concept set",
+    );
+
+    // (a) via conceptSetId on an event card
+    let threwViaId = false;
+    try {
+      await resolveClausesToConstraints(
+        [{ card: "Condition Occurrence", conceptSetId: BAD_ID }],
+        catalog,
+        stubDeps,
+      );
+    } catch (e) {
+      threwViaId = true;
+      assert(
+        String(e).includes(String(BAD_ID)) &&
+          String(e).includes("not a persisted concept set"),
+        "conceptSetId error names the bad id",
+      );
+    }
+    assert(threwViaId, "non-persisted conceptSetId must throw");
+
+    // (b) via a conceptSet-typed attribute constraint
+    let threwViaConstraint = false;
+    try {
+      await resolveClausesToConstraints(
+        [
+          {
+            card: "Measurement",
+            constraints: [
+              { attribute: "Unit concept set", op: "=", value: BAD_ID },
+            ],
+          },
+        ],
+        catalog,
+        stubDeps,
+      );
+    } catch (e) {
+      threwViaConstraint = true;
+      assert(
+        String(e).includes(String(BAD_ID)) &&
+          String(e).includes("not a persisted concept set"),
+        "conceptSet-constraint error names the bad id",
+      );
+    }
+    assert(
+      threwViaConstraint,
+      "non-persisted conceptSet constraint value must throw",
+    );
+  },
+);
+
+Deno.test(
+  "real BMv2Parser accepts the generated bookmark (best-effort)",
+  async () => {
+    const bm = await buildTree();
+    let parser: any;
+    try {
+      parser =
+        await import("../../../../ui/apps/vue-mri-ui-lib/src/lib/bookmarks/BMv2Parser.ts");
+    } catch (e) {
+      console.warn(
+        "  [skip] real BMv2Parser not importable here:",
+        String(e).slice(0, 120),
+      );
+      return;
+    }
+    const convert = parser.default?.convertBM2IFR ?? parser.convertBM2IFR;
+    assert(typeof convert === "function", "convertBM2IFR is a function");
+    const ifr = convert(bm.filter); // throws if the tree is malformed
+    assert(ifr, "convertBM2IFR returned an IFR");
+    console.log("  [ok] real BMv2Parser parsed the bookmark");
+  },
+);

--- a/plugins/functions/mcp-server/src/lib/cohortResolver.ts
+++ b/plugins/functions/mcp-server/src/lib/cohortResolver.ts
@@ -1,0 +1,350 @@
+import type {
+  CohortClause,
+  ClauseConstraint,
+  CohortCatalog,
+  CatalogCard,
+  CatalogAttribute,
+} from "./cohortModel";
+import type { CohortConstraint, CohortExpression } from "./cohortBookmarkTree";
+import { AnalyticsAPI } from "../api/AnalyticsAPI";
+import { TerminologyAPI } from "../api/TerminologyAPI";
+
+/**
+ * Resolve card-centric clauses (LLM intent, by name) into the resolved
+ * constraints the serializer consumes. Pure orchestration: value/concept-set
+ * lookups are injected (ResolverDeps) so this is testable offline and so the
+ * I/O (analytics-svc values endpoint, terminology service) stays at the edge.
+ *
+ * Grouping rules (enforced here, NOT by the LLM):
+ *  - all "Basic Data" clauses merge into the single patient card instance;
+ *  - each interaction clause becomes its own card instance.
+ *
+ * A clause's `concept` maps to the card's PRIMARY concept-set attribute (the
+ * conceptSet attribute with cohortDefinitionKey === "CodesetId").
+ */
+
+export interface ResolverDeps {
+  /** category/text attribute: plain word -> the dataset's coded value. */
+  resolveValue: (
+    card: CatalogCard,
+    attr: CatalogAttribute,
+    raw: string,
+  ) => Promise<string>;
+  /**
+   * True iff `id` is a persisted concept-set id in this dataset
+   * (portal.user_artifact concept_sets). Used to reject raw OMOP concept ids /
+   * phenotype-library ids that the agent may pass instead of a real concept-set
+   * id — a positive integer alone cannot be distinguished from a concept id.
+   */
+  conceptSetExists: (id: number) => Promise<boolean>;
+}
+
+export interface ResolverContext {
+  authorization: string;
+  datasetId: string;
+  configId: string;
+  configVersion: string;
+}
+
+/**
+ * Build the live resolver adapter; tests provide an in-memory ResolverDeps
+ * implementation through the same seam.
+ */
+export function buildResolverDeps(
+  analyticsApi: AnalyticsAPI,
+  terminologyApi: TerminologyAPI,
+  context: ResolverContext,
+): ResolverDeps {
+  let conceptSetIds: Promise<Set<number>> | null = null;
+  const loadConceptSetIds = (): Promise<Set<number>> => {
+    if (!conceptSetIds) {
+      conceptSetIds = terminologyApi
+        .listConceptSets(context.authorization, context.datasetId)
+        .then((sets) => new Set(sets.map((set) => Number(set.id))));
+    }
+    return conceptSetIds;
+  };
+
+  return {
+    resolveValue: async (_card, attribute, raw) => {
+      const values = await analyticsApi.getAttributeValues(
+        context.authorization,
+        context.datasetId,
+        attribute.configPath,
+        context.configId,
+        context.configVersion,
+        raw,
+      );
+      if (values.length === 0) {
+        throw new Error(`No value for "${attribute.name}" matching "${raw}".`);
+      }
+      const normalized = raw.trim().toLowerCase();
+      const exact = values.find(
+        (value) =>
+          value.label.toLowerCase() === normalized ||
+          value.value.toLowerCase() === normalized,
+      );
+      return (exact ?? values[0]).value;
+    },
+    conceptSetExists: async (id) => {
+      const ids = await loadConceptSetIds();
+      return ids.has(Number(id));
+    },
+  };
+}
+
+const NUM_OPS = new Set([">=", "<=", "<", ">", "=", "!="]);
+
+function norm(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+/** Find a card by display name (exact ci, then substring). */
+function findCard(
+  catalog: CohortCatalog,
+  name: string,
+): CatalogCard | undefined {
+  const n = norm(name);
+  return (
+    catalog.cards.find((c) => norm(c.name) === n) ??
+    catalog.cards.find(
+      (c) => norm(c.name).includes(n) || n.includes(norm(c.name)),
+    )
+  );
+}
+
+/** Find an attribute within a card by display name (exact ci, then substring). */
+function findAttr(
+  card: CatalogCard,
+  name: string,
+): CatalogAttribute | undefined {
+  const n = norm(name);
+  return (
+    card.attributes.find((a) => norm(a.name) === n) ??
+    card.attributes.find(
+      (a) => norm(a.name).includes(n) || n.includes(norm(a.name)),
+    )
+  );
+}
+
+/** The card's primary concept-set attribute (cohortDefinitionKey "CodesetId"). */
+function primaryConceptAttr(card: CatalogCard): CatalogAttribute | undefined {
+  return card.attributes.find(
+    (a) => a.kind === "conceptSet" && a.cohortDefinitionKey === "CodesetId",
+  );
+}
+
+/**
+ * A concept-set id must be a positive integer that maps to a persisted concept
+ * set in this dataset (portal.user_artifact). Two failure modes are caught here:
+ *  - the "unset" sentinel 0 (or any non-positive / non-integer value); and
+ *  - a positive integer that is NOT a real concept set — typically a raw OMOP
+ *    concept id (e.g. 9201 "Inpatient Visit") or a phenotype/library/cohort id
+ *    the agent passed instead of calling create_concept_set. A positivity check
+ *    alone cannot distinguish these, so we verify existence via deps.
+ * Letting either through serializes an unresolvable concept-set reference that
+ * fails downstream (terminology-svc -> portal 400). Reject with actionable text.
+ */
+async function assertValidConceptSetId(
+  id: unknown,
+  cardName: string,
+  deps: ResolverDeps,
+): Promise<void> {
+  const n = Number(id);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(
+      `Card "${cardName}" references concept set "${id}", which is not a valid ` +
+        `persisted concept set id. Create the concept set first with ` +
+        `create_concept_set and use the id it returns.`,
+    );
+  }
+  const exists = await deps.conceptSetExists(n);
+  if (!exists) {
+    throw new Error(
+      `Card "${cardName}" references concept set id ${n}, which is not a ` +
+        `persisted concept set in this dataset. Do NOT use a raw OMOP concept id ` +
+        `or a phenotype/library/cohort id as a concept-set id. Resolve the term ` +
+        `with search_concepts, then create_concept_set, and use the id it returns.`,
+    );
+  }
+}
+
+/** Build numeric expressions from a structured op/value. */
+function numExpressions(c: ClauseConstraint): {
+  expressions: CohortExpression[];
+  combine: "AND" | "OR";
+} {
+  if (c.op === "range") {
+    if (!Array.isArray(c.value) || c.value.length !== 2) {
+      throw new Error(
+        `Range constraint on "${c.attribute}" needs a [low, high] value.`,
+      );
+    }
+    const [lo, hi] = c.value.map(Number);
+    if (Number.isNaN(lo) || Number.isNaN(hi)) {
+      throw new Error(`Range bounds for "${c.attribute}" must be numbers.`);
+    }
+    if (lo > hi) {
+      throw new Error(`Range low (${lo}) must not exceed high (${hi}).`);
+    }
+    return {
+      expressions: [
+        { operator: ">=", value: lo },
+        { operator: "<=", value: hi },
+      ],
+      combine: "AND",
+    };
+  }
+  if (!NUM_OPS.has(c.op)) {
+    throw new Error(
+      `Unsupported operator "${c.op}" for numeric attribute "${c.attribute}".`,
+    );
+  }
+  const v = Number(c.value);
+  if (Number.isNaN(v)) {
+    throw new Error(`Value for "${c.attribute}" must be a number.`);
+  }
+  return { expressions: [{ operator: c.op, value: v }], combine: "OR" };
+}
+
+/**
+ * Resolve clauses to constraints. Throws an actionable Error on any clause that
+ * can't be resolved (unknown card/attribute, missing concept attribute,
+ * unsupported kind) — never silently drops a filter.
+ */
+export async function resolveClausesToConstraints(
+  clauses: CohortClause[],
+  catalog: CohortCatalog,
+  deps: ResolverDeps,
+): Promise<CohortConstraint[]> {
+  const out: CohortConstraint[] = [];
+  const seenAttributes = new Set<string>();
+
+  const appendConstraint = (
+    constraint: CohortConstraint,
+    attributeName: string,
+  ) => {
+    const key =
+      `${constraint.cardInstanceKey}::${constraint.attributeConfigPath}`;
+    if (seenAttributes.has(key)) {
+      throw new Error(
+        `Attribute "${attributeName}" appears more than once in ` +
+          `"${constraint.cardName}". Use one constraint per attribute; for a ` +
+          `numeric lower and upper bound, use op "range" with [low, high].`,
+      );
+    }
+    seenAttributes.add(key);
+    out.push(constraint);
+  };
+
+  for (let i = 0; i < clauses.length; i++) {
+    const clause = clauses[i];
+    const card = findCard(catalog, clause.card);
+    if (!card) {
+      throw new Error(
+        `Unknown filter card "${clause.card}". Available: ${catalog.cards
+          .map((c) => c.name)
+          .join(", ")}.`,
+      );
+    }
+    const isPatient = card.key === "patient";
+    if (isPatient && clause.exclude) {
+      throw new Error(
+        `Basic Data does not support "exclude: true" because all patient ` +
+          `attributes share one filter card. Use "!=" or an inverse numeric ` +
+          `comparison on the attribute instead.`,
+      );
+    }
+    // Patient card always merges into one instance; interactions get one per clause.
+    const cardInstanceKey = isPatient ? "patient" : `${card.key}#${i}`;
+    const base = {
+      cardConfigPath: card.configPath,
+      cardName: card.name,
+      cardInstanceKey,
+      exclude: clause.exclude,
+    };
+
+    const hasConcept = clause.conceptSetId != null;
+    if (
+      !hasConcept &&
+      (!clause.constraints || clause.constraints.length === 0)
+    ) {
+      throw new Error(
+        `Clause for "${clause.card}" has no conceptSetId or constraints — nothing to filter.`,
+      );
+    }
+
+    // 1. conceptSetId -> the card's primary concept-set attribute (passthrough;
+    //    the agent already resolved the id via the concept-set tools).
+    if (hasConcept) {
+      await assertValidConceptSetId(clause.conceptSetId, card.name, deps);
+      const attr = primaryConceptAttr(card);
+      if (!attr) {
+        throw new Error(
+          `Card "${card.name}" has no concept set to attach concept set ${clause.conceptSetId} to.`,
+        );
+      }
+      appendConstraint(
+        {
+          ...base,
+          attributeConfigPath: attr.configPath,
+          expressions: [{ operator: "=", value: String(clause.conceptSetId) }],
+          combine: "OR",
+        },
+        attr.name,
+      );
+    }
+
+    // 2. explicit attribute constraints.
+    for (const cc of clause.constraints ?? []) {
+      const attr = findAttr(card, cc.attribute);
+      if (!attr) {
+        throw new Error(
+          `Card "${card.name}" has no attribute "${cc.attribute}". Available: ${card.attributes
+            .map((a) => a.name)
+            .join(", ")}.`,
+        );
+      }
+
+      let expressions: CohortExpression[];
+      let combine: "AND" | "OR";
+      if (attr.kind === "num") {
+        ({ expressions, combine } = numExpressions(cc));
+      } else if (attr.kind === "category") {
+        if (cc.op !== "=" && cc.op !== "!=") {
+          throw new Error(
+            `Unsupported operator "${cc.op}" for category attribute "${cc.attribute}". ` +
+              `Use "=" or "!=".`,
+          );
+        }
+        const resolved = await deps.resolveValue(card, attr, String(cc.value));
+        expressions = [
+          { operator: cc.op, value: resolved },
+        ];
+        combine = "OR";
+      } else if (attr.kind === "conceptSet") {
+        // value IS the concept-set id (agent-resolved), e.g. a unit set.
+        await assertValidConceptSetId(cc.value, card.name, deps);
+        expressions = [{ operator: "=", value: String(cc.value) }];
+        combine = "OR";
+      } else {
+        // datetime not supported yet.
+        throw new Error(
+          `Filtering on "${attr.name}" (${attr.kind}) is not supported yet.`,
+        );
+      }
+
+      appendConstraint(
+        {
+          ...base,
+          attributeConfigPath: attr.configPath,
+          expressions,
+          combine,
+        },
+        attr.name,
+      );
+    }
+  }
+
+  return out;
+}

--- a/plugins/functions/mcp-server/src/services/server.ts
+++ b/plugins/functions/mcp-server/src/services/server.ts
@@ -4,6 +4,7 @@ import { registerCohortManagementTools } from "../tools/cohort-management.tools"
 import { registerPhenotypeLibraryTools } from "../tools/phenotype-library.tools";
 import { registerCohortInstructionTools } from "../tools/cohort-instruction.tools";
 import { registerCohortValidationTools } from "../tools/cohort-validation.tools";
+import { registerCohortBuilderTools } from "../tools/cohort-builder.tools";
 import { registerCohortPrompts } from "../prompts/cohort.prompts";
 import { registerStrategusTools } from "../tools/strategus.tools";
 import { registerConceptSetManagementTools } from "../tools/concept-set-management.tools";
@@ -18,6 +19,7 @@ registerCohortManagementTools(server);
 registerPhenotypeLibraryTools(server);
 registerCohortInstructionTools(server);
 registerCohortValidationTools(server);
+registerCohortBuilderTools(server);
 
 // Register Strategus tools
 registerStrategusTools(server);

--- a/plugins/functions/mcp-server/src/tools/cohort-builder.tools.ts
+++ b/plugins/functions/mcp-server/src/tools/cohort-builder.tools.ts
@@ -1,0 +1,184 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { AnalyticsAPI } from "../api/AnalyticsAPI";
+import { TerminologyAPI } from "../api/TerminologyAPI";
+import { buildDeepLinkUrl } from "../lib/cohortDeepLink";
+import {
+  buildCohortCatalog,
+  summarizeCatalog,
+  type CohortClause,
+} from "../lib/cohortModel";
+import {
+  buildResolverDeps,
+  resolveClausesToConstraints,
+} from "../lib/cohortResolver";
+import { buildCohortBookmarkTree } from "../lib/cohortBookmarkTree";
+import {
+  requireAuthAndDataset,
+  createStructuredResponse,
+  createTextResponse,
+} from "../utils/request-helpers";
+
+const analyticsApi = new AnalyticsAPI();
+const terminologyApi = new TerminologyAPI();
+
+/**
+ * Register the D2E Patient Analytics cohort deep-link builder tool.
+ *
+ * Turns a compact { ageMin?, ageMax?, gender? } spec into a PA cohort builder
+ * deep link. The LLM extracts intent; this tool deterministically serialises
+ * the rule-bound bookmark tree (a wrong tree silently loads the wrong cohort).
+ * POC scope: Basic Data age + gender only.
+ */
+export function registerCohortBuilderTools(server: McpServer) {
+  // Discovery tool: the catalog of filter cards + attributes available on THIS
+  // dataset, derived from the live PA config. The agent calls this first to
+  // ground its filter choices on real cards/attributes (rather than guessing
+  // configPaths, which is how a bookmark ends up referencing an attribute the
+  // dataset doesn't have).
+  server.registerTool(
+    "list_cohort_filters",
+    {
+      title: "List Cohort Filter Options",
+      description:
+        "List the filter cards and attributes available for building a cohort " +
+        "on the CURRENT dataset. Call this BEFORE build_d2e_cohort_deeplink to " +
+        "discover which cards exist (e.g. Basic Data, Condition Occurrence, " +
+        "Measurement) and each attribute's kind: 'num' (numeric / range), " +
+        "'category' (coded value resolved by name), 'conceptSet' (clinical " +
+        "concept set / phenotype) or 'datetime'. Only reference cards and " +
+        "attributes returned here.",
+      inputSchema: {},
+      // No outputSchema on purpose: the MCP adapter then hands the model the
+      // clean text summary (card -> attribute[kind]) instead of a 142-item JSON
+      // blob, which the model can actually read and act on.
+    },
+    async (_args, { requestInfo }) => {
+      const { authorization, datasetId } = requireAuthAndDataset(requestInfo);
+      const fe = await analyticsApi.getFrontendConfig(authorization, datasetId);
+      if (!fe) {
+        throw new Error(
+          `No Patient Analytics config for dataset ${datasetId}.`,
+        );
+      }
+      const catalog = buildCohortCatalog(fe.config);
+      const attrCount = catalog.cards.reduce(
+        (n, c) => n + c.attributes.length,
+        0,
+      );
+      console.log(
+        `[cohort-builder] list_cohort_filters: cards=${catalog.cards.length} ` +
+          `attributes=${attrCount}`,
+      );
+      return createTextResponse(summarizeCatalog(catalog));
+    },
+  );
+
+  server.registerTool(
+    "build_d2e_cohort_deeplink",
+    {
+      title: "Build D2E Cohort Deep Link",
+      description:
+        "Build a Patient Analytics cohort builder deep link from a list of " +
+        "filter clauses. First call list_cohort_filters to learn the cards and " +
+        "attributes, and resolve any clinical concept to a concept-set id " +
+        "(search_concepts / phenotype library → check_concept_coverage_in_dataset " +
+        "→ create_concept_set). Each clause targets ONE card: `card` is a card " +
+        "name; `conceptSetId` attaches a concept set to an event card; " +
+        "`constraints` are {attribute, op, value} on that card's attributes " +
+        "(op: >=,<=,<,>,=,!=,range; value number/string, or [low,high] for range); " +
+        "`exclude:true` negates the card. Returns a URL that opens the PA cohort " +
+        "builder pre-filled.",
+      inputSchema: {
+        clauses: z
+          .array(
+            z.object({
+              card: z
+                .string()
+                .describe("Filter card name from list_cohort_filters."),
+              exclude: z
+                .boolean()
+                .optional()
+                .describe(
+                  "Negate an interaction card. Never use on Basic Data; use an inverse attribute operator instead.",
+                ),
+              conceptSetId: z
+                .number()
+                .int()
+                .optional()
+                .describe("Concept-set id for an event card (agent-resolved)."),
+              constraints: z
+                .array(
+                  z.object({
+                    attribute: z.string(),
+                    op: z.string(),
+                    value: z.union([
+                      z.number(),
+                      z.string(),
+                      z.array(z.union([z.number(), z.string()])),
+                    ]),
+                  }),
+                )
+                .optional()
+                .describe(
+                  "At most one constraint per attribute; express numeric lower and upper bounds with op 'range'.",
+                ),
+            }),
+          )
+          .describe("One clause per filter card occurrence."),
+      },
+      outputSchema: {
+        url: z.string(),
+        warning: z.string().optional(),
+      },
+    },
+    async ({ clauses }, { requestInfo }) => {
+      const toolStart = performance.now();
+      const { authorization, datasetId } = requireAuthAndDataset(requestInfo);
+
+      // 1. Fetch the frontend config: the catalog (cards/attributes) + the
+      //    config stamp the bookmark must carry, from the same getMyConfig.
+      const fe = await analyticsApi.getFrontendConfig(authorization, datasetId);
+      if (!fe) {
+        console.error("[cohort-builder] no PA config for requested dataset");
+        throw new Error(
+          `No Patient Analytics config for dataset ${datasetId}.`,
+        );
+      }
+      const catalog = buildCohortCatalog(fe.config);
+
+      // 2. Resolve clauses -> constraints. num/range are pure; category values
+      //    hit the analytics values endpoint; conceptSetId passes through.
+      //    Throws an LLM-actionable error on any unresolved clause.
+      const deps = buildResolverDeps(analyticsApi, terminologyApi, {
+        authorization,
+        datasetId,
+        configId: fe.meta.configId,
+        configVersion: fe.meta.configVersion,
+      });
+      const constraints = await resolveClausesToConstraints(
+        clauses as CohortClause[],
+        catalog,
+        deps,
+      );
+
+      // 3. Serialize the bookmark tree (+ NOT for exclusions) and assemble the link.
+      const bookmark = buildCohortBookmarkTree(constraints, fe.meta);
+      const { url, tooLong } = buildDeepLinkUrl(bookmark, datasetId);
+      const warning = tooLong
+        ? "The generated link is unusually long and may not work in all browsers."
+        : undefined;
+
+      console.log(
+        `[MCP-TIMING] [build_d2e_cohort_deeplink] END total=${(performance.now() - toolStart).toFixed(1)}ms len=${url.length}`,
+      );
+
+      // Return ONLY the URL as the tool text; the /cohort endpoint appends it
+      // deterministically so the model never relays the long, mangle-prone link.
+      return createStructuredResponse(
+        url,
+        warning ? { url, warning } : { url },
+      );
+    },
+  );
+}

--- a/plugins/functions/mcp-server/src/tools/concept-set-management.tools.ts
+++ b/plugins/functions/mcp-server/src/tools/concept-set-management.tools.ts
@@ -1,11 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { D2EWebAPI, ConceptSetItem } from "../api/D2EWebAPI.ts";
 import { TerminologyAPI } from "../api/TerminologyAPI";
+import { VocabularyAPI } from "../api/VocabularyAPI";
 import {
   ListConceptSetsInput,
   GetConceptSetInput,
   CreateConceptSetInput,
   CheckConceptCoverageInput,
+  SearchConceptsInput,
 } from "../types/tool-schemas";
 import {
   requireAuthAndDataset,
@@ -15,15 +18,41 @@ import {
 
 const d2eWebApi = new D2EWebAPI();
 const terminologyApi = new TerminologyAPI();
+const vocabularyApi = new VocabularyAPI();
 
 const LIST_PAGE_SIZE = 50;
 
+function sameConceptDefinition(
+  left: ConceptItem[],
+  right: ConceptItem[],
+): boolean {
+  const normalize = (items: ConceptItem[]) =>
+    items
+      .map((item) =>
+        JSON.stringify({
+          id: Number(item.id),
+          useDescendants: Boolean(item.useDescendants),
+          useMapped: Boolean(item.useMapped),
+          isExcluded: Boolean(item.isExcluded),
+        })
+      )
+      .sort();
+  const a = normalize(left);
+  const b = normalize(right);
+  return a.length === b.length && a.every((item, index) => item === b[index]);
+}
+
 /**
  * Register concept set tools.
+ * - search_concepts                  (clinical term -> candidate OMOP concept ids)
  * - list_concept_sets                (paginated: first 50 + totalCount)
  * - get_concept_set                  (returns saved definition + concept list)
  * - create_concept_set               (creates in d2e-webapi; defaults shared=false)
  * - check_concept_coverage_in_dataset (which concept IDs exist in this dataset's vocabulary)
+ *
+ * search_concepts is the entry rung: it turns a plain clinical term into concept
+ * IDs, which the other tools (check_concept_coverage_in_dataset / create_concept_set)
+ * then consume.
  */
 export function registerConceptSetManagementTools(server: McpServer) {
   // ==================== LIST CONCEPT SETS ====================
@@ -38,7 +67,6 @@ export function registerConceptSetManagementTools(server: McpServer) {
     async ({}, { requestInfo }) => {
       const toolStart = performance.now();
       const { authorization, datasetId } = requireAuthAndDataset(requestInfo);
-
       const all = await d2eWebApi.listConceptSets(authorization, datasetId);
       const totalCount = all.length;
       const page = all.slice(0, LIST_PAGE_SIZE).map((cs) => ({
@@ -51,7 +79,7 @@ export function registerConceptSetManagementTools(server: McpServer) {
       }));
 
       console.log(
-        `[MCP-TIMING] [list_concept_sets] END total=${(performance.now() - toolStart).toFixed(1)}ms items=${page.length} totalCount=${totalCount}`
+        `[MCP-TIMING] [list_concept_sets] END total=${(performance.now() - toolStart).toFixed(1)}ms items=${page.length} totalCount=${totalCount}`,
       );
 
       const text =
@@ -60,7 +88,7 @@ export function registerConceptSetManagementTools(server: McpServer) {
           : `Found ${totalCount} concept set${totalCount === 1 ? "" : "s"} in this dataset.`;
 
       return createStructuredResponse(text, { conceptSets: page, totalCount });
-    }
+    },
   );
 
   // ==================== GET CONCEPT SET ====================
@@ -84,14 +112,14 @@ export function registerConceptSetManagementTools(server: McpServer) {
       ]);
 
       console.log(
-        `[MCP-TIMING] [get_concept_set] END total=${(performance.now() - toolStart).toFixed(1)}ms`
+        `[MCP-TIMING] [get_concept_set] END total=${(performance.now() - toolStart).toFixed(1)}ms`,
       );
 
       return createStructuredResponse(
         `Retrieved concept set ${conceptSet.id}, name '${conceptSet.name}', ${expression.items?.length ?? 0} concepts in expression.`,
         { conceptSet: { ...conceptSet, expression } }
       );
-    }
+    },
   );
 
   // ==================== CREATE CONCEPT SET ====================
@@ -120,7 +148,7 @@ export function registerConceptSetManagementTools(server: McpServer) {
       return createTextResponse(
         `Successfully created concept set '${name}' with ref ${created.id}. ${items?.length ?? 0} concept item${(items?.length ?? 0) === 1 ? "" : "s"} in the expression.`
       );
-    }
+    },
   );
 
   // ==================== CHECK CONCEPT COVERAGE ====================
@@ -139,18 +167,81 @@ export function registerConceptSetManagementTools(server: McpServer) {
       const { found, missing } = await terminologyApi.checkConceptCoverage(
         authorization,
         datasetId,
-        conceptIds
+        conceptIds,
       );
 
       console.log(
-        `[MCP-TIMING] [check_concept_coverage_in_dataset] END total=${(performance.now() - toolStart).toFixed(1)}ms found=${found.length} missing=${missing.length}`
+        `[MCP-TIMING] [check_concept_coverage_in_dataset] END total=${(performance.now() - toolStart).toFixed(1)}ms found=${found.length} missing=${missing.length}`,
       );
 
-      const text = missing.length === 0
-        ? `All ${found.length} concept${found.length === 1 ? "" : "s"} exist in this dataset.`
-        : `${found.length} of ${conceptIds.length} concepts exist in this dataset. ${missing.length} are not in the vocabulary cache: ${missing.join(", ")}.`;
+      const text =
+        missing.length === 0
+          ? `All ${found.length} concept${found.length === 1 ? "" : "s"} exist in this dataset.`
+          : `${found.length} of ${conceptIds.length} concepts exist in this dataset. ${missing.length} are not in the vocabulary cache: ${missing.join(", ")}.`;
 
       return createStructuredResponse(text, { found, missing });
-    }
+    },
+  );
+
+  // ==================== SEARCH CONCEPTS ====================
+  // Clinical term -> candidate OMOP standard concepts (id, name, domain) for
+  // THIS dataset. The rung between a plain word and the concept-set tools
+  // (which take concept IDs): search here, pick the right concept(s), then feed
+  // them to check_concept_coverage_in_dataset / create_concept_set.
+  //
+  // Use this for specific concepts (a measurement like "systolic blood
+  // pressure", a drug, a procedure) and for terms the phenotype library doesn't
+  // cover. For recognized phenotypes (a disease defining the cohort, e.g.
+  // hypertension), prefer search_phenotype_library, which returns a curated set.
+  server.registerTool(
+    "search_concepts",
+    {
+      title: "Search OMOP Concepts",
+      description:
+        "Search this dataset's OMOP vocabulary for standard concepts matching " +
+        "a clinical term (e.g. 'systolic blood pressure', 'metformin'). Returns " +
+        "candidate concepts (conceptId, name, domain) ranked by how common they " +
+        "are in the dataset. Use it to turn a clinical term into concept IDs for " +
+        "check_concept_coverage_in_dataset / create_concept_set. Pass `domain` " +
+        "to scope results (e.g. 'Condition', 'Measurement', 'Drug', 'Procedure').",
+      inputSchema: SearchConceptsInput,
+      outputSchema: {
+        concepts: z.array(
+          z.object({
+            conceptId: z.number(),
+            conceptName: z.string(),
+            domainId: z.string(),
+            vocabularyId: z.string(),
+            standardConcept: z.string().nullable(),
+          }),
+        ),
+      },
+    },
+    async (
+      { query, domain, standardOnly = true, limit = 20 },
+      { requestInfo },
+    ) => {
+      const { authorization, datasetId } = requireAuthAndDataset(requestInfo);
+      const concepts = await vocabularyApi.searchConcepts(
+        authorization,
+        datasetId,
+        query,
+        domain,
+        standardOnly,
+        limit,
+      );
+      const summary = concepts.length
+        ? `Found ${concepts.length} concept(s) for "${query}"${domain ? ` in ${domain}` : ""} ` +
+          `(ranked by record count). Pick the right concept id(s).\n` +
+          concepts
+            .slice(0, 10)
+            .map(
+              (c) =>
+                `- ${c.conceptId} ${c.conceptName} [${c.domainId}/${c.vocabularyId}]`,
+            )
+            .join("\n")
+        : `No concepts found for "${query}"${domain ? ` in ${domain}` : ""}. Try a different term or domain.`;
+      return createStructuredResponse(summary, { concepts });
+    },
   );
 }

--- a/plugins/functions/mcp-server/src/types/tool-schemas.ts
+++ b/plugins/functions/mcp-server/src/types/tool-schemas.ts
@@ -221,3 +221,23 @@ export const CheckConceptCoverageInput = {
     ),
 };
 
+export const SearchConceptsInput = {
+  query: z
+    .string()
+    .describe("Clinical term to search, e.g. 'systolic blood pressure'."),
+  domain: z
+    .string()
+    .optional()
+    .describe("OMOP domain filter: Condition | Measurement | Drug | Procedure | Observation."),
+  standardOnly: z
+    .boolean()
+    .optional()
+    .describe("Restrict to standard concepts (default true)."),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Max candidates to return (default 20)."),
+};
+

--- a/plugins/functions/package.json
+++ b/plugins/functions/package.json
@@ -530,7 +530,8 @@
           "OLLAMA_BASE_URL": "${OLLAMA_BASE_URL:-null}",
           "OLLAMA_API_KEY": "${OLLAMA_API_KEY:-null}",
           "GOOGLE_API_KEY": "${GOOGLE_API_KEY:-null}",
-          "AI_MODEL": "${AI_MODEL:-null}"
+          "AI_MODEL": "${AI_MODEL:-null}",
+          "COHORT_HISTORY_MAX_TOKENS": "${COHORT_HISTORY_MAX_TOKENS:-4000}"
         },
         "data-mapping": {
           "OPENAI_API_KEY": "${OPENAI_API_KEY:-null}",

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/cohortPatch.test.ts
@@ -1,0 +1,791 @@
+import { vi } from 'vitest'
+import { applyCohortPatch, type PatchOp } from '../cohortPatch'
+
+// A store stand-in that models just enough of the query module for the applier:
+// filter cards, constraints, the bool-container tree that carries the AND/OR
+// structure, and the actions/getters it calls. Cards and constraints are held in
+// plain maps so tests can assert the resulting state.
+//
+// `existingCards` is a flat list (one card per group, i.e. all AND-ed) unless
+// `existingGroups` is passed, which spells the grouping out: each inner array is
+// one bool-filter container, so cards listed together are OR-ed.
+const makeStore = ({
+  existingCards = [] as string[],
+  existingGroups,
+  axes = [] as any[],
+  // attributePath -> config `domainFilter`, the OMOP domain a conceptSet
+  // attribute's concepts must come from. Only set in the tests that exercise it.
+  domains,
+}: {
+  existingCards?: string[]
+  existingGroups?: string[][]
+  axes?: any[]
+  domains?: Record<string, string>
+} = {}) => {
+  const cards: Record<string, { props: { excludeFilter: boolean; name?: string } }> = {}
+  const groups: string[][] = existingGroups ?? existingCards.map(id => [id])
+  for (const id of groups.flat()) cards[id] = { props: { excludeFilter: false } }
+  const constraints: Record<string, any> = {}
+  // Instance numbers continue past whatever is already on the cohort, as they do live.
+  let cardSeq = Object.keys(cards).filter(id => id !== 'patient').length
+  let conSeq = 0
+
+  // Bool containers are addressed by id in the store, so index them the way the
+  // real entity map does: group N is container "bfc<N>", stable across splices.
+  const containerIds = () => groups.map((_, i) => `bfc${i}`)
+  const groupOf = (containerId: string) => groups[Number(containerId.replace('bfc', ''))]
+
+  const store: any = {
+    getters: {
+      getFilterCards: () => cards,
+      getFilterCard: (id: string) => cards[id],
+      getFilterCardConstraints: (cardId: string) => Object.values(constraints).filter((c: any) => c.parent === cardId),
+      getAllAxes: axes,
+      getBoolContainerRoot: () => 'root',
+      getBoolContainer: (id: string) => (id === 'root' ? { props: { boolfiltercontainers: containerIds() } } : null),
+      getBoolFilterContainer: (id: string) => ({ props: { filterCards: groupOf(id) ?? [] } }),
+      getConstraintForAttribute: ({ filterCardId, key }: { filterCardId: string; key: string }) =>
+        Object.values(constraints).find((c: any) => c.parent === filterCardId && c.props.attrKey === key) ?? null,
+      ...(domains
+        ? {
+            getMriFrontendConfig: {
+              getAttributeByPath: (path: string) => ({ getDomainFilter: () => domains[path] ?? '' }),
+            },
+          }
+        : {}),
+    },
+    dispatch: vi.fn(),
+  }
+
+  store.dispatch.mockImplementation((type: string, payload: any) => {
+    switch (type) {
+      case 'holdFireRequest':
+      case 'releaseFireRequest':
+      case 'setFireRequest':
+      case 'refreshPatientCount':
+      case 'resetAxes':
+        return Promise.resolve(undefined)
+      case 'setAxisValue': {
+        if (axes[payload.id]) axes[payload.id].props = { ...axes[payload.id].props, ...payload.props }
+        return Promise.resolve(undefined)
+      }
+      case 'addFilterCard': {
+        // Mirror BoolFilterContainer.createFilterCard: the Basic Data card keeps its
+        // config path as its instance id, interaction cards get an index suffix.
+        const id = payload.configPath === 'patient' ? 'patient' : `${payload.configPath}.${++cardSeq}`
+        cards[id] = { props: { excludeFilter: payload.isExclusion ?? false } }
+        // No container id → a NEW group (AND). With one → join that group (OR).
+        const target = payload.boolFilterContainerId ? groupOf(payload.boolFilterContainerId) : undefined
+        if (target) {
+          target.push(id)
+        } else {
+          groups.push([id])
+        }
+        return Promise.resolve(id)
+      }
+      // AND → OR: fold this container into the nearest preceding one.
+      case 'toggleFilterContainerBooleanCondition': {
+        const index = Number(payload.filterContainerId.replace('bfc', ''))
+        groups[index - 1].push(...groups[index])
+        groups.splice(index, 1)
+        return Promise.resolve(undefined)
+      }
+      // OR → AND: split the card (and everything after it) into its own container.
+      case 'toggleFilterBooleanCondition': {
+        const index = Number(payload.parentId.replace('bfc', ''))
+        const group = groups[index]
+        const moved = group.splice(group.indexOf(payload.filterCardId))
+        groups.splice(index + 1, 0, moved)
+        return Promise.resolve(undefined)
+      }
+      case 'addFilterCardConstraint': {
+        const existing = Object.values(constraints).find(
+          (c: any) => c.parent === payload.filterCardId && c.props.attrKey === payload.key
+        ) as any
+        if (existing) {
+          return Promise.resolve(existing.id)
+        }
+        const id = `con${++conSeq}`
+        // type derived from key for test purposes: age -> num, *date -> time,
+        // else conceptSet/text
+        const type =
+          payload.key === 'age'
+            ? 'num'
+            : /date$/i.test(payload.key)
+              ? 'time'
+              : payload.key === 'condition' || /conceptset$/i.test(payload.key)
+                ? 'conceptSet'
+                : 'text'
+        // The real constraint carries the attribute's config path; the card's
+        // instance id is its config path plus an index suffix.
+        const attributePath = `${payload.filterCardId.replace(/\.\d+$/, '')}.attributes.${payload.key}`
+        constraints[id] = {
+          id,
+          parent: payload.filterCardId,
+          props: {
+            attrKey: payload.key,
+            attributePath,
+            type,
+            value: undefined,
+            // Mirror DateConstraintModel: a date constraint keeps NO value of its
+            // own — its state is fromDate/toDate, initialized to ''.
+            ...(type === 'time' ? { fromDate: { value: '' }, toDate: { value: '' } } : {}),
+          },
+        }
+        return Promise.resolve(id)
+      }
+      case 'updateConstraintValue': {
+        constraints[payload.constraintId].props.value = payload.value
+        return Promise.resolve(undefined)
+      }
+      // Mirrors CONSTRAINTS_DATETIME_SET_VALUE — a slot entirely separate from
+      // props.value, which props.value-only bookkeeping cannot restore.
+      case 'updateDateConstraintValue': {
+        constraints[payload.constraintId].props.fromDate.value = payload.fromDateValue
+        constraints[payload.constraintId].props.toDate.value = payload.toDateValue
+        return Promise.resolve(undefined)
+      }
+      case 'deleteFilterCardConstraint': {
+        delete constraints[payload.constraintId]
+        return Promise.resolve(undefined)
+      }
+      case 'deleteFilterCard': {
+        delete cards[payload.filterCardId]
+        // Mirror FILTERCARD_DELETE: the card leaves its container, and a container
+        // left empty is dropped from the tree.
+        for (let i = groups.length - 1; i >= 0; i -= 1) {
+          const at = groups[i].indexOf(payload.filterCardId)
+          if (at > -1) groups[i].splice(at, 1)
+          if (groups[i].length === 0) groups.splice(i, 1)
+        }
+        // Mirror the real query-module action: deleting a card clears every axis
+        // bound to that card id.
+        for (const axis of axes) {
+          if (axis?.props?.filterCardId === payload.filterCardId) {
+            axis.props = { ...axis.props, attributeId: '', filterCardId: '', key: '' }
+          }
+        }
+        return Promise.resolve(undefined)
+      }
+      default:
+        return Promise.resolve(undefined)
+    }
+  })
+
+  return { store, cards, constraints, groups }
+}
+
+describe('applyCohortPatch', () => {
+  it('rejects an empty patch', async () => {
+    const { store } = makeStore()
+    await expect(applyCohortPatch(store, [] as PatchOp[])).rejects.toThrow(/non-empty/)
+  })
+
+  it('holds fire-request, then releases + refreshes after success', async () => {
+    const { store } = makeStore()
+    await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.interactions.priDiag' }])
+
+    expect(store.dispatch).toHaveBeenCalledWith('holdFireRequest', undefined)
+    expect(store.dispatch).toHaveBeenCalledWith('releaseFireRequest', undefined)
+    expect(store.dispatch).toHaveBeenCalledWith('setFireRequest', undefined)
+    expect(store.dispatch).toHaveBeenCalledWith('refreshPatientCount', undefined)
+  })
+
+  it('applies a basic numeric filter (age >= 65) via the shared normalizer', async () => {
+    const { store, constraints } = makeStore()
+    const res = await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient', ref: 'basic' },
+      { op: 'add_constraint', card: 'basic', attributePath: 'patient.attributes.age', value: '>=65' },
+    ])
+
+    expect(res.applied).toBe(true)
+    // The `ref` resolved across ops, so the constraint landed on the card the
+    // preceding add_card created.
+    expect(res.createdCards).toHaveLength(1)
+    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'age') as any
+    expect(con.props.value).toEqual([{ op: '>=', value: 65 }])
+  })
+
+  it('applies a concept-set filter with the picker value shape (conceptSetId + includeDescendants)', async () => {
+    const { store, constraints } = makeStore()
+    await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient.interactions.priDiag', ref: 'dx' },
+      {
+        op: 'add_constraint',
+        card: 'dx',
+        attributePath: 'patient.interactions.priDiag.attributes.condition',
+        value: { conceptSetId: 'cs_42', includeDescendants: true, displayValue: 'Viral sinusitis' },
+      },
+    ])
+
+    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'condition') as any
+    expect(con.props.value).toEqual([
+      { value: 'cs_42', text: 'Viral sinusitis', display_value: 'Viral sinusitis', includeDescendants: true },
+    ])
+  })
+
+  it('reports the constraint values that actually landed, read back from the store', async () => {
+    const { store } = makeStore()
+    const res = await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+      {
+        op: 'add_constraint',
+        card: 'dx',
+        attributePath: 'patient.interactions.conditionoccurrence.attributes.condition',
+        // conceptSetId as a NUMBER, exactly as d2e-mcp create_concept_set returns it:
+        // it has to land as the stringified id (the filter Expression reads .value),
+        // never as the object stringified to "[object Object]" — a broken filter that
+        // renders an empty chart and a patient count of "--".
+        value: { conceptSetId: 37, displayValue: "Alzheimer's disease" },
+      },
+    ])
+
+    expect(res.appliedConstraints).toEqual([
+      {
+        card: 'patient.interactions.conditionoccurrence.1',
+        attributePath: 'patient.interactions.conditionoccurrence.attributes.condition',
+        value: [
+          {
+            value: '37',
+            text: "Alzheimer's disease",
+            display_value: "Alzheimer's disease",
+            includeDescendants: false,
+          },
+        ],
+      },
+    ])
+  })
+
+  // Every empty shape is caught by the same input check, before anything is
+  // mutated: applyConstraintValue reads an empty value on a text/conceptSet
+  // attribute as "clear this filter", so the patch would report success and leave
+  // a filter card with no constraint on the cohort.
+  it.each([[undefined], [''], [[]], [{}], [null]])(
+    'rejects an add_constraint whose value is %p instead of silently clearing the filter',
+    async value => {
+      const { store, cards } = makeStore()
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+          {
+            op: 'add_constraint',
+            card: 'dx',
+            attributePath: 'patient.interactions.conditionoccurrence.attributes.conditionconceptset',
+            value,
+          } as any,
+        ])
+      ).rejects.toThrow(/has no value/)
+
+      // The half-built card must not survive as an unfiltered Condition Occurrence.
+      expect(Object.keys(cards)).toHaveLength(0)
+    }
+  )
+
+  it('names the mistake when the concept-set id sits beside `value` instead of inside it', async () => {
+    const { store } = makeStore()
+    await expect(
+      applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence', ref: 'dx' },
+        {
+          op: 'add_constraint',
+          card: 'dx',
+          attributePath: 'patient.interactions.conditionoccurrence.attributes.conditionconceptset',
+          conceptSetId: 37,
+        } as any,
+      ])
+    ).rejects.toThrow(/conceptSetId at the top level of the op — it belongs inside `value`/)
+  })
+
+  it('rejects an unknown cardConfigPath with a recoverable message when config is loaded', async () => {
+    const { store } = makeStore()
+    store.getters.getMriFrontendConfig = {
+      getFilterCards: () => [{ getConfigPath: () => 'patient' }],
+    }
+    await expect(applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.bogus' }])).rejects.toThrow(
+      /Unknown cardConfigPath/
+    )
+  })
+
+  it('creates an exclusion card when exclude is set', async () => {
+    const { store, cards } = makeStore()
+    await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.interactions.priDiag', exclude: true }])
+    expect(store.dispatch).toHaveBeenCalledWith('addFilterCard', {
+      configPath: 'patient.interactions.priDiag',
+      isExclusion: true,
+    })
+    expect(Object.values(cards)[0].props.excludeFilter).toBe(true)
+  })
+
+  it('reuses the Basic Data card instead of adding a second copy of it', async () => {
+    // The model has no way to know Basic Data is always present, so it adds it
+    // before constraining Age/Gender. The store would create a SECOND card under
+    // the same instance id ('patient'), which duplicates every constraint on it in
+    // the generated SQL and clears the chart axes as soon as either copy is deleted.
+    const { store, cards } = makeStore({ existingCards: ['patient'] })
+    const res = await applyCohortPatch(store, [
+      { op: 'add_card', cardConfigPath: 'patient', ref: 'basic' },
+      { op: 'add_constraint', card: 'basic', attributePath: 'patient.attributes.age', value: '<100' },
+    ])
+
+    expect(store.dispatch).not.toHaveBeenCalledWith('addFilterCard', expect.objectContaining({ configPath: 'patient' }))
+    expect(Object.keys(cards)).toEqual(['patient'])
+    // The ref still resolves, so the constraint lands on the card that is there.
+    expect(res.applied).toBe(true)
+    expect(res.createdCards).toEqual([])
+  })
+
+  it('still creates a second instance of an indexed (interaction) card', async () => {
+    const { store, cards } = makeStore({ existingCards: ['patient.interactions.conditionoccurrence.1'] })
+    await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: 'patient.interactions.conditionoccurrence' }])
+    expect(Object.keys(cards)).toHaveLength(2)
+  })
+
+  it('restores the axis selection when a rolled-back card deletion clears it', async () => {
+    const axes = [
+      { props: { attributeId: 'patient.attributes.Gender', filterCardId: 'patient', key: 'Gender' } },
+      { props: { attributeId: 'patient.attributes.Age', filterCardId: 'patient', key: 'Age', binsize: 10 } },
+    ]
+    const { store } = makeStore({ axes })
+
+    await expect(
+      applyCohortPatch(store, [
+        // 'patient' is absent here, so this genuinely creates the card...
+        { op: 'add_card', cardConfigPath: 'patient', ref: 'p' },
+        // ...and this fails, so the rollback deletes it again — taking both axes with it.
+        { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+      ])
+    ).rejects.toThrow(/Unknown card/)
+
+    expect(axes[0].props).toMatchObject({
+      attributeId: 'patient.attributes.Gender',
+      filterCardId: 'patient',
+      key: 'Gender',
+    })
+    expect(axes[1].props).toMatchObject({ attributeId: 'patient.attributes.Age', filterCardId: 'patient', binsize: 10 })
+  })
+
+  describe('AND / OR grouping', () => {
+    const DX = 'patient.interactions.conditionoccurrence'
+
+    it('AND-s a new card by default (each card in its own group)', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      const res = await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX }])
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`], [`${DX}.2`]])
+      expect(res.cardGroups).toHaveLength(3)
+    })
+
+    it('ORs a new card with an existing one via orWith — "Alzheimer\'s OR sinusitis"', async () => {
+      // The reported bug: asked to widen an Alzheimer's cohort to "Alzheimer's OR
+      // sinusitis", the assistant could only add a second AND-ed card, which reads
+      // as "had both". The second condition has to land in the FIRST card's group.
+      const { store, groups, constraints } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      const res = await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: DX, ref: 'dx2', orWith: `${DX}.1` },
+        {
+          op: 'add_constraint',
+          card: 'dx2',
+          attributePath: `${DX}.attributes.conditionconceptset`,
+          value: { conceptSetId: 42, displayValue: 'Sinusitis' },
+        },
+      ])
+
+      expect(store.dispatch).toHaveBeenCalledWith('addFilterCard', {
+        configPath: DX,
+        isExclusion: false,
+        boolFilterContainerId: 'bfc1',
+      })
+      // One group holding both condition cards = Or(A, B) in the IFR.
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+      expect(res.cardGroups).toEqual([
+        { cards: [{ filterCardId: 'patient', name: 'patient' }] },
+        {
+          cards: [
+            { filterCardId: `${DX}.1`, name: `${DX}.1` },
+            { filterCardId: `${DX}.2`, name: `${DX}.2` },
+          ],
+        },
+      ])
+      // ...and the sinusitis filter is on the NEW card only — the first card's
+      // concept set is not restated, which would have made it "both conditions".
+      const con = Object.values(constraints).find((c: any) => c.parent === `${DX}.2`) as any
+      expect(con.props.value).toEqual([
+        { value: '42', text: 'Sinusitis', display_value: 'Sinusitis', includeDescendants: false },
+      ])
+      expect(Object.values(constraints)).toHaveLength(1)
+    })
+
+    it('resolves orWith against a ref created earlier in the same patch', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient'] })
+      await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: DX, ref: 'a' },
+        { op: 'add_card', cardConfigPath: DX, ref: 'b', orWith: 'a' },
+      ])
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+    })
+
+    it('refuses to OR a card with Basic Data (it would match every patient)', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient'] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX, orWith: 'patient' }])
+      ).rejects.toThrow(/Basic Data/)
+      expect(groups).toEqual([['patient']])
+    })
+
+    it('refuses to OR an exclusion card with an inclusion one', async () => {
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX, exclude: true, orWith: `${DX}.1` }])
+      ).rejects.toThrow(/exclusion/)
+    })
+
+    it('set_card_join OR merges a card already on the cohort into the preceding group', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`, `${DX}.2`] })
+      const res = await applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'OR' }])
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+      expect(res.cardGroups?.[1].cards.map(c => c.filterCardId)).toEqual([`${DX}.1`, `${DX}.2`])
+    })
+
+    it('set_card_join AND splits an OR-ed card back into its own group', async () => {
+      const { store, groups } = makeStore({ existingGroups: [['patient'], [`${DX}.1`, `${DX}.2`]] })
+      await applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'AND' }])
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`], [`${DX}.2`]])
+    })
+
+    it('is a no-op when the requested join is already in place', async () => {
+      const { store, groups } = makeStore({ existingGroups: [['patient'], [`${DX}.1`, `${DX}.2`]] })
+      await applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'OR' }])
+      expect(groups).toEqual([['patient'], [`${DX}.1`, `${DX}.2`]])
+      expect(store.dispatch).not.toHaveBeenCalledWith('toggleFilterContainerBooleanCondition', expect.anything())
+    })
+
+    it('refuses to OR the first filter card with Basic Data before it', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await expect(applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.1`, join: 'OR' }])).rejects.toThrow(
+        /Basic Data/
+      )
+      expect(groups).toEqual([['patient'], [`${DX}.1`]])
+    })
+
+    it('refuses to change the join on the Basic Data card itself', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await expect(applyCohortPatch(store, [{ op: 'set_card_join', card: 'patient', join: 'OR' }])).rejects.toThrow(
+        /Basic Data card is always AND-ed/
+      )
+      expect(groups).toEqual([['patient'], [`${DX}.1`]])
+    })
+
+    it('rejects an invalid join value', async () => {
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`, `${DX}.2`] })
+      await expect(
+        applyCohortPatch(store, [{ op: 'set_card_join', card: `${DX}.2`, join: 'XOR' } as any])
+      ).rejects.toThrow(/must be "AND" or "OR"/)
+    })
+
+    it('undoes a grouping change when a later op fails (atomic)', async () => {
+      const { store, groups } = makeStore({ existingCards: ['patient', `${DX}.1`, `${DX}.2`] })
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'set_card_join', card: `${DX}.2`, join: 'OR' },
+          { op: 'add_constraint', card: 'ghost', attributePath: `${DX}.attributes.condition`, value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      expect(groups).toEqual([['patient'], [`${DX}.1`], [`${DX}.2`]])
+    })
+
+    it('keeps the chart axes when OR-ing clears them (resetAxes fires on grouped cards)', async () => {
+      // resetAxes clears every axis bound to a card in a container that now holds
+      // more than one card. Left cleared, the chart query goes out with an empty
+      // axisSelection and the patient count renders "--".
+      const axes = [{ props: { attributeId: `${DX}.attributes.startdate`, filterCardId: `${DX}.1`, key: 'startdate' } }]
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`], axes })
+      // The real resetAxes runs inside addFilterCard; the mock triggers it here.
+      store.dispatch.mockImplementation(
+        ((inner: any) => (type: string, payload: any) => {
+          const res = inner(type, payload)
+          if (type === 'addFilterCard' && payload.boolFilterContainerId) {
+            axes[0].props = { attributeId: '', filterCardId: '', key: '' }
+          }
+          return res
+        })(store.dispatch.getMockImplementation())
+      )
+
+      await applyCohortPatch(store, [{ op: 'add_card', cardConfigPath: DX, orWith: `${DX}.1` }])
+
+      expect(axes[0].props).toMatchObject({
+        attributeId: `${DX}.attributes.startdate`,
+        filterCardId: `${DX}.1`,
+      })
+    })
+  })
+
+  describe('concept-set domain', () => {
+    const DX = 'patient.interactions.conditionoccurrence'
+    const VISIT = 'patient.interactions.visit'
+    const DX_SET = `${DX}.attributes.conditionconceptset`
+    const VISIT_SET = `${VISIT}.attributes.visitconceptset`
+    const domains = { [DX_SET]: 'Condition', [VISIT_SET]: 'Visit' }
+
+    // "Alzheimer's OR an ER visit": the model OR-ed the Visit card correctly and
+    // then filled its concept set with the Alzheimer's set it already had in
+    // context, never resolving "ER visit". The cohort computes, so nothing looks
+    // wrong — it just answers a different question.
+    const carriedOverPatch: PatchOp[] = [
+      { op: 'add_card', cardConfigPath: VISIT, ref: 'v', orWith: `${DX}.1` },
+      { op: 'add_constraint', card: 'v', attributePath: VISIT_SET, value: { conceptSetId: 41 } },
+    ]
+
+    const withAlzheimers = async () => {
+      const made = makeStore({ existingCards: ['patient', `${DX}.1`], domains })
+      await applyCohortPatch(made.store, [
+        {
+          op: 'add_constraint',
+          card: `${DX}.1`,
+          attributePath: DX_SET,
+          value: { conceptSetId: 41, displayValue: "Alzheimer's disease" },
+        },
+      ])
+      return made
+    }
+
+    it("rejects carrying a Condition concept set onto a Visit card's concept set", async () => {
+      const { store, constraints } = await withAlzheimers()
+
+      await expect(applyCohortPatch(store, carriedOverPatch)).rejects.toThrow(
+        /Concept set 41 is already filtered on .*conditionconceptset.*Condition-domain.*Visit-domain/s
+      )
+      // Atomic: the half-built Visit card is gone, and the Alzheimer's filter stands.
+      const visitConstraint = Object.values(constraints).find((c: any) => c.parent.startsWith(VISIT))
+      expect(visitConstraint).toBeUndefined()
+      expect(Object.values(constraints)).toHaveLength(1)
+    })
+
+    it('rolls the OR-ed card back out of the group when its value is rejected', async () => {
+      const { store, groups } = await withAlzheimers()
+      await expect(applyCohortPatch(store, carriedOverPatch)).rejects.toThrow(/Concept set 41/)
+      expect(groups).toEqual([['patient'], [`${DX}.1`]])
+    })
+
+    it('allows the same concept set on two cards of the SAME domain (primary + secondary diagnosis)', async () => {
+      const { store } = await withAlzheimers()
+      const res = await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: DX, ref: 'dx2', orWith: `${DX}.1` },
+        { op: 'add_constraint', card: 'dx2', attributePath: DX_SET, value: { conceptSetId: 41 } },
+      ])
+      expect(res.applied).toBe(true)
+    })
+
+    it('allows a different concept set on the Visit card — the correct fix', async () => {
+      const { store, constraints } = await withAlzheimers()
+      const res = await applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: VISIT, ref: 'v', orWith: `${DX}.1` },
+        {
+          op: 'add_constraint',
+          card: 'v',
+          attributePath: VISIT_SET,
+          value: { conceptSetId: 88, displayValue: 'Emergency Room Visit' },
+        },
+      ])
+      expect(res.applied).toBe(true)
+      const visitConstraint = Object.values(constraints).find((c: any) => c.parent.startsWith(VISIT)) as any
+      expect(visitConstraint.props.value[0]).toMatchObject({ value: '88', text: 'Emergency Room Visit' })
+    })
+
+    it('skips the check when the config exposes no domain for the attribute', async () => {
+      // domainFilter is empty on plenty of attributes (and absent on non-OMOP
+      // configs); an unknown domain must not block a legitimate patch.
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await applyCohortPatch(store, [
+        { op: 'add_constraint', card: `${DX}.1`, attributePath: DX_SET, value: { conceptSetId: 41 } },
+      ])
+      const res = await applyCohortPatch(store, carriedOverPatch)
+      expect(res.applied).toBe(true)
+    })
+  })
+
+  it('restores a date range when a later op fails — the state lives in fromDate/toDate', async () => {
+    // Date/time constraints are written by updateDateConstraintValue into
+    // props.fromDate.value / props.toDate.value and have no props.value at all, so
+    // rollback bookkeeping that snapshots only `value` recorded undefined and
+    // restored nothing: the patch threw, and the widened window stayed on the
+    // cohort. The user is told nothing was applied, and a later save persists a
+    // date range nobody asked for.
+    const DX = 'patient.interactions.conditionoccurrence'
+    const STARTDATE = `${DX}.attributes.startdate`
+    const { store, constraints } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+
+    // Patch 1 commits the window the cohort arrives with (as opening a saved
+    // cohort would) — the constraint therefore pre-exists patch 2.
+    await applyCohortPatch(store, [
+      {
+        op: 'add_constraint',
+        card: `${DX}.1`,
+        attributePath: STARTDATE,
+        value: { from: '2019-01-01', to: '2019-12-31' },
+      },
+    ])
+    const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'startdate') as any
+    const before = { from: con.props.fromDate.value, to: con.props.toDate.value }
+    expect(before.from).toBeInstanceOf(Date)
+    expect(con.props.value).toBeUndefined()
+
+    // Patch 2 widens the window, then fails on the next op.
+    await expect(
+      applyCohortPatch(store, [
+        {
+          op: 'add_constraint',
+          card: `${DX}.1`,
+          attributePath: STARTDATE,
+          value: { from: '2015-01-01', to: '2020-12-31' },
+        },
+        { op: 'add_constraint', card: 'ghost', attributePath: `${DX}.attributes.condition`, value: 1 },
+      ])
+    ).rejects.toThrow(/Unknown card/)
+
+    expect(con.props.fromDate.value).toEqual(before.from)
+    expect(con.props.toDate.value).toEqual(before.to)
+    // isUTC:true is the pass-through branch; isUTC:false shifts by the timezone
+    // offset on every call, so a revert using it would move the restored range.
+    expect(store.dispatch).toHaveBeenCalledWith('updateDateConstraintValue', {
+      constraintId: con.id,
+      fromDateValue: before.from,
+      toDateValue: before.to,
+      isUTC: true,
+    })
+  })
+
+  describe('removals', () => {
+    const DX = 'patient.interactions.conditionoccurrence'
+    const DX_SET = `${DX}.attributes.conditionconceptset`
+
+    const withAlzheimers = async () => {
+      const made = makeStore({ existingCards: ['patient', `${DX}.1`] })
+      await applyCohortPatch(made.store, [
+        { op: 'add_constraint', card: 'patient', attributePath: 'patient.attributes.age', value: '>=65' },
+        {
+          op: 'add_constraint',
+          card: `${DX}.1`,
+          attributePath: DX_SET,
+          value: { conceptSetId: 41, displayValue: "Alzheimer's disease" },
+        },
+      ])
+      return made
+    }
+
+    it("removes one constraint and leaves the card's other filters alone", async () => {
+      const { store, constraints } = await withAlzheimers()
+      const res = await applyCohortPatch(store, [{ op: 'remove_constraint', card: `${DX}.1`, attributePath: DX_SET }])
+
+      expect(res.applied).toBe(true)
+      expect(Object.values(constraints).map((c: any) => c.props.attrKey)).toEqual(['age'])
+    })
+
+    it('is a no-op when the constraint to remove is not on the card', async () => {
+      const { store } = makeStore({ existingCards: ['patient'] })
+      const res = await applyCohortPatch(store, [
+        { op: 'remove_constraint', card: 'patient', attributePath: 'patient.attributes.age' },
+      ])
+
+      expect(res.applied).toBe(true)
+      expect(store.dispatch).not.toHaveBeenCalledWith('deleteFilterCardConstraint', expect.anything())
+    })
+
+    it('puts a removed constraint back — value and all — when a later op fails', async () => {
+      // Atomic has to mean the filter the user had comes back, not merely that
+      // nothing new was added. A patch that widens a cohort by dropping a filter and
+      // then fails would otherwise leave it permanently widened while telling the
+      // user nothing was applied.
+      const { store, constraints } = await withAlzheimers()
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_constraint', card: `${DX}.1`, attributePath: DX_SET },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      const con = Object.values(constraints).find((c: any) => c.props.attrKey === 'conditionconceptset') as any
+      expect(con.props.value).toEqual([
+        { value: '41', text: "Alzheimer's disease", display_value: "Alzheimer's disease", includeDescendants: false },
+      ])
+    })
+
+    it('puts the ORIGINAL value back when the patch replaced the same constraint and then failed', async () => {
+      const { store, constraints } = await withAlzheimers()
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_constraint', card: `${DX}.1`, attributePath: DX_SET },
+          {
+            op: 'add_constraint',
+            card: `${DX}.1`,
+            attributePath: DX_SET,
+            value: { conceptSetId: 99, displayValue: 'Something else' },
+          },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      const cons = Object.values(constraints).filter((c: any) => c.props.attrKey === 'conditionconceptset')
+      expect(cons).toHaveLength(1)
+      expect((cons[0] as any).props.value).toEqual([
+        { value: '41', text: "Alzheimer's disease", display_value: "Alzheimer's disease", includeDescendants: false },
+      ])
+    })
+
+    it('removes a card — and leaves it removed when a later op fails', async () => {
+      // The one op revert cannot undo: re-adding the card would mint a new instance
+      // id and lose the constraints that hung off it. Pinned here so the limitation
+      // stays a decision (documented on applyCohortPatch) rather than a surprise.
+      const { store, cards, groups } = makeStore({ existingCards: ['patient', `${DX}.1`] })
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_card', card: `${DX}.1` },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      expect(Object.keys(cards)).toEqual(['patient'])
+      expect(groups).toEqual([['patient']])
+    })
+
+    it('does not re-point the chart axes at a card the patch removed', async () => {
+      const axes = [{ props: { attributeId: `${DX}.attributes.startdate`, filterCardId: `${DX}.1`, key: 'startdate' } }]
+      const { store } = makeStore({ existingCards: ['patient', `${DX}.1`], axes })
+
+      await expect(
+        applyCohortPatch(store, [
+          { op: 'remove_card', card: `${DX}.1` },
+          { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+        ])
+      ).rejects.toThrow(/Unknown card/)
+
+      // Restoring the snapshot here would leave the chart querying an axis bound to
+      // a filterCardId the IFR no longer contains.
+      expect(axes[0].props).toMatchObject({ attributeId: '', filterCardId: '', key: '' })
+    })
+  })
+
+  it('rolls back created cards/constraints when a later op fails (atomic)', async () => {
+    const { store, cards, constraints } = makeStore()
+    await expect(
+      applyCohortPatch(store, [
+        { op: 'add_card', cardConfigPath: 'patient', ref: 'p' },
+        { op: 'add_constraint', card: 'p', attributePath: 'patient.attributes.age', value: 65 },
+        // Unknown card ref -> resolveCard throws mid-patch.
+        { op: 'add_constraint', card: 'ghost', attributePath: 'patient.attributes.age', value: 1 },
+      ])
+    ).rejects.toThrow(/Unknown card/)
+
+    // Everything created during the patch is undone.
+    expect(Object.keys(cards)).toHaveLength(0)
+    expect(Object.keys(constraints)).toHaveLength(0)
+    expect(store.dispatch).toHaveBeenCalledWith('releaseFireRequest', undefined)
+    // No live refresh on failure.
+    expect(store.dispatch).not.toHaveBeenCalledWith('refreshPatientCount', undefined)
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/paToolBridge.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/paToolBridge.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { publishPaTools, PA_TOOLS_CHANGED_EVENT } from '../paToolBridge'
+import { createPaTools } from '../webmcpServer'
+
+// Same minimal Vuex stand-in as webmcpServer.test.ts, plus getSelectedDataset —
+// the bridge surfaces the loaded dataset so the drawer can refuse to edit a
+// cohort belonging to a different dataset than the one the user is looking at.
+const makeStore = (datasetId: string | null = 'ds-1') => ({
+  getters: {
+    getBookmarksData: { name: 'Elderly Diabetics', cards: ['c1'] },
+    getBookmarkFromIFR: { filter: { age: { min: 65 } } },
+    getBookmarks: [],
+    getActiveBookmark: null,
+    getSelectedDataset: datasetId === null ? undefined : { id: datasetId },
+  },
+  dispatch: vi.fn().mockResolvedValue(undefined),
+  commit: vi.fn(),
+})
+
+const registry = () => {
+  const reg = window.__d2ePaTools
+  if (!reg) throw new Error('registry not published')
+  return reg
+}
+
+describe('publishPaTools', () => {
+  afterEach(() => {
+    delete window.__d2ePaTools
+    vi.restoreAllMocks()
+  })
+
+  it('publishes a descriptor for every createPaTools tool', () => {
+    const store: any = makeStore()
+
+    publishPaTools(store)
+
+    const names = registry()
+      .list()
+      .map(t => t.name)
+    expect(names).toEqual(createPaTools(store).map(t => t.name))
+    expect(registry().version).toBe(1)
+    // Descriptors must carry what a model needs to call the tool.
+    for (const descriptor of registry().list()) {
+      expect(descriptor.description).toBeTruthy()
+      expect(descriptor.inputSchema).toBeTruthy()
+    }
+  })
+
+  it('announces availability on publish and on teardown', () => {
+    const seen: boolean[] = []
+    const listener = (e: Event) => seen.push((e as CustomEvent).detail.available)
+    window.addEventListener(PA_TOOLS_CHANGED_EVENT, listener)
+
+    const teardown = publishPaTools(makeStore() as any)
+    teardown()
+
+    window.removeEventListener(PA_TOOLS_CHANGED_EVENT, listener)
+    expect(seen).toEqual([true, false])
+  })
+
+  it('reads datasetId live rather than snapshotting it', () => {
+    const store: any = makeStore('ds-1')
+    publishPaTools(store)
+    expect(registry().datasetId).toBe('ds-1')
+
+    // The user switched datasets while PA stayed mounted.
+    store.getters.getSelectedDataset = { id: 'ds-2' }
+    expect(registry().datasetId).toBe('ds-2')
+  })
+
+  it('reports a null datasetId when no dataset is loaded', () => {
+    publishPaTools(makeStore(null) as any)
+    expect(registry().datasetId).toBeNull()
+  })
+
+  it('executes a tool through call() and returns its MCP result envelope', async () => {
+    const store: any = makeStore()
+    publishPaTools(store)
+
+    const result = await registry().call('pa_get_current_cohort')
+
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      bookmarkData: store.getters.getBookmarksData,
+      ifr: store.getters.getBookmarkFromIFR,
+    })
+  })
+
+  it('passes arguments through to the tool handler', async () => {
+    const store: any = makeStore()
+    publishPaTools(store)
+
+    await registry().call('pa_new_cohort', { name: 'Cohort X' })
+
+    expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', {
+      bookmarkname: 'Cohort X',
+      isNew: true,
+    })
+  })
+
+  it('rejects an unknown tool with the available names', async () => {
+    publishPaTools(makeStore() as any)
+
+    await expect(registry().call('pa_not_a_tool')).rejects.toThrow(/Unknown PA tool "pa_not_a_tool".*pa_new_cohort/s)
+  })
+
+  it('removes the registry on teardown', () => {
+    const teardown = publishPaTools(makeStore() as any)
+    teardown()
+    expect(window.__d2ePaTools).toBeUndefined()
+  })
+
+  // A remount can publish before the outgoing instance tears down. The stale
+  // teardown must not remove the live registry — that would leave the drawer
+  // believing PA is gone while it is on screen.
+  it('teardown of a superseded registry leaves the newer one in place', () => {
+    const staleTeardown = publishPaTools(makeStore() as any)
+    publishPaTools(makeStore('ds-2') as any)
+
+    staleTeardown()
+
+    expect(window.__d2ePaTools).toBeDefined()
+    expect(registry().datasetId).toBe('ds-2')
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/valueResolution.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/valueResolution.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest'
+import { alternateQueries, rankValues, MAX_ALTERNATE_QUERIES, type ValueRow } from '../valueResolution'
+
+// The rules are written as query → expected-rows vectors rather than as assertions
+// about the implementation, because the same table has to hold for a SECOND
+// implementation: the mcp-server resolver that answers the deep-link surface (the
+// cohort tools that exist when PA is not mounted). The two cannot share a module —
+// that one is Deno, this one is bundled by Vite, and nothing crosses that boundary
+// in this repo — so a shared table is what keeps them in step.
+//
+// The vectors live here for now because that resolver is not in this branch. When it
+// lands, MOVE this table to
+// plugins/functions/mcp-server/src/lib/__fixtures__/value-resolution-vectors.json
+// and have both suites read it: while the rules exist in only one suite, a ranking
+// change can improve one surface and silently leave the other behind — which is
+// exactly what had happened (the backend resolved "ER visit" and these tools did not).
+//
+// THE RULES, best match first. Each is a property of the two strings or of the
+// column, not a list of terms someone thought of, so they hold on a dataset nobody
+// here has seen:
+//   0  the row IS the term            after casing and demographic-synonym expansion
+//   1  the row CONTAINS the term      as a substring, 3+ characters
+//   2  the term ABBREVIATES the row   read from the row's FIRST word, each query word
+//                                     consuming either the next row word or the
+//                                     initials of the next several
+//      …or the row IS the term's CODE the same initials rule read the other way
+//                                     ('F' <- Female)
+//   3  every DISTINCTIVE word is present
+//   4  some distinctive word is present
+//
+// A word is distinctive when it separates one row of THIS column from another —
+// measured as the share of rows carrying it (>= 60%, over columns of 4+ rows, is
+// filler). Below that the rules fall back to a small seeded list, because a frequency
+// over two rows means nothing.
+//
+// Two things stay seeded and cannot be derived: demographic synonyms ("women" ->
+// "female"; no structure gets you there) and abbreviations whose expansion is NOT in
+// the row ("ICU" where the column says "Intensive Care"). The seeds also drive the
+// blind-retry path, which has no rows to measure — an abbreviation cannot be inverted
+// into a search term without a lexicon.
+
+/**
+ * `rows` use a neutral shape { value, label }; the backend suite maps the same table
+ * onto its own row type. Row counts matter: a case written with two rows is testing
+ * the seeded fallback, not the measured rule.
+ */
+interface RankingVector {
+  name: string
+  /** Why the case exists. Documentation — no assertion reads it. */
+  why?: string
+  query: string
+  rows: Array<{ value: string; label: string }>
+  /** The `value` of every row that must match, best first. Empty = nothing may match. */
+  expectedOrder: string[]
+}
+
+/** The retry queries used when the attribute's domain cannot be enumerated. */
+interface AlternateQueryVector {
+  name: string
+  why?: string
+  query: string
+  mustInclude?: string[]
+  mustNotInclude?: string[]
+  maxLength?: number
+}
+
+const RANKING_VECTORS: RankingVector[] = [
+  {
+    name: 'an exact token beats a longer value that merely contains it',
+    query: 'F',
+    rows: [
+      { value: 'FEMALE_RELATIVE', label: 'Female relative' },
+      { value: 'F', label: 'Female' },
+    ],
+    expectedOrder: ['F', 'FEMALE_RELATIVE'],
+  },
+  {
+    name: 'casing alone never hides a value',
+    why: 'The /values search runs a case-sensitive LIKE in the database.',
+    query: 'female',
+    rows: [{ value: '8532', label: 'FEMALE' }],
+    expectedOrder: ['8532'],
+  },
+  {
+    name: 'the value column is matched too, not only the label',
+    query: 'sinusitis',
+    rows: [{ value: 'Acute sinusitis', label: '' }],
+    expectedOrder: ['Acute sinusitis'],
+  },
+  {
+    name: 'a demographic synonym resolves to the stored token',
+    why:
+      'The user says "women"; the column stores "F". Never ask the user how their data spells it. ' +
+      'Not derivable — this one is seeded.',
+    query: 'women',
+    rows: [
+      { value: 'M', label: 'Male' },
+      { value: 'F', label: 'Female' },
+    ],
+    expectedOrder: ['F'],
+  },
+
+  {
+    name: 'a term reaches a row it is not a substring of, by abbreviating it',
+    why: 'The reported failure: the /values search found nothing and the assistant reported the value absent.',
+    query: 'ER Visit',
+    rows: [
+      { value: '9203', label: 'Emergency Room Visit' },
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: '9202', label: 'Outpatient Visit' },
+    ],
+    expectedOrder: ['9203'],
+  },
+  {
+    name: 'an acronym no list contains still reaches its expansion',
+    why:
+      'The point of deriving the rule: NICU is in no table here, and neither will be whatever a given dataset ' +
+      'uses (ASC, LTACH, PCP). The initials must come out of the row itself.',
+    query: 'NICU',
+    rows: [
+      { value: '581379', label: 'Neonatal Intensive Care Unit' },
+      { value: '32037', label: 'Intensive Care Unit' },
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: '8717', label: 'Nursing Home' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'initials are read from the START of the row, never from inside it',
+    why:
+      'Precision over recall, the same trade this module makes everywhere: reading initials from anywhere ' +
+      'inside a row lets an acronym claim rows it does not name, and a near-miss value is a silent clinical ' +
+      'error. A row an acronym does not reach is still shown — nothing matching returns the whole column.',
+    query: 'ASC',
+    rows: [
+      { value: '581379', label: 'Ambulatory Surgical Center' },
+      { value: '8940', label: 'Hospital Ambulatory Surgical Center' },
+      { value: '9201', label: 'Inpatient Visit' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'a seeded abbreviation covers an expansion the row does not spell out',
+    why:
+      'The column says "Intensive Care"; there is no "U" in the row to derive the U of ICU from. This is why ' +
+      'the seed list still exists.',
+    query: 'ICU',
+    rows: [
+      { value: '32037', label: 'Intensive Care' },
+      { value: '9201', label: 'Inpatient Visit' },
+    ],
+    expectedOrder: ['32037'],
+  },
+  {
+    name: "a coded column is reached by the term's own initials",
+    why:
+      'Not a demographics rule: marital status, discharge status and yes/no flags are all stored as bare ' +
+      "letters, and no synonym table can enumerate them. The row's code has to be derived FROM the term.",
+    query: 'single',
+    rows: [
+      { value: 'S', label: 'S' },
+      { value: 'M', label: 'M' },
+      { value: 'W', label: 'W' },
+      { value: 'D', label: 'D' },
+    ],
+    expectedOrder: ['S'],
+  },
+
+  {
+    name: 'a word nearly every row carries stops discriminating',
+    why: '"Visit" cannot tell you which visit type is meant when four rows in five say it.',
+    query: 'intensive care visit',
+    rows: [
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: '9202', label: 'Outpatient Visit' },
+      { value: '9203', label: 'Emergency Room Visit' },
+      { value: '581379', label: 'Inpatient Intensive Care' },
+      { value: '262', label: 'Emergency Room and Inpatient Visit' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'the same word still discriminates in a column that does not repeat it',
+    why:
+      'The converse, and the reason filler is measured rather than listed: here "visit" is what separates one ' +
+      'row from the other, so the row carrying it must rank first.',
+    query: 'emergency visit',
+    rows: [
+      { value: '9203', label: 'Emergency Room Visit' },
+      { value: '8870', label: 'Emergency Room - Hospital' },
+      { value: '4021', label: 'Operating Room' },
+      { value: '32037', label: 'Intensive Care' },
+      { value: '8717', label: 'Nursing Home' },
+    ],
+    expectedOrder: ['9203', '8870'],
+  },
+  {
+    name: 'a column too short to measure falls back to the seeded filler words',
+    why:
+      'Two rows is not a frequency. Without the fallback "visit" would count as distinctive and the target ' +
+      'row, which lacks it, would drop below a row that has nothing else in common.',
+    query: 'intensive care visit',
+    rows: [
+      { value: '581379', label: 'Inpatient Intensive Care' },
+      { value: '9202', label: 'Outpatient Visit' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'a row sharing only one distinctive word ranks below the phrase matches',
+    query: 'emergency room',
+    rows: [
+      { value: '8870', label: 'Emergency Room - Hospital' },
+      { value: '9203', label: 'Emergency Room and Inpatient Visit' },
+      { value: '4021', label: 'Operating Room' },
+    ],
+    expectedOrder: ['8870', '9203', '4021'],
+  },
+
+  {
+    name: 'an unrelated term matches nothing rather than something close',
+    why: 'A near-miss clinical concept is a silent clinical error; better to return the whole column.',
+    query: 'diabetes',
+    rows: [
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: 'F', label: 'Female' },
+    ],
+    expectedOrder: [],
+  },
+  {
+    name: 'an empty query matches nothing (the caller asks for the whole domain instead)',
+    query: '',
+    rows: [{ value: 'F', label: 'Female' }],
+    expectedOrder: [],
+  },
+]
+
+const ALTERNATE_QUERY_VECTORS: AlternateQueryVector[] = [
+  {
+    name: 'a phrase the endpoint cannot match is retried by its expansions',
+    why: 'Title case first: a stored concept name usually looks like "Emergency Room Visit".',
+    query: 'ER visit',
+    mustInclude: ['Emergency Room Visit', 'Emergency Room', 'ER VISIT'],
+    mustNotInclude: ['visit', 'Visit', 'VISIT'],
+  },
+  {
+    name: 'casings are swept for a case-sensitive LIKE',
+    query: 'female',
+    mustInclude: ['Female', 'FEMALE'],
+  },
+  {
+    name: 'bounded, so a failed search cannot fan out into many endpoint calls',
+    query: 'acute upper respiratory infection of the intensive care unit',
+    maxLength: 9,
+  },
+]
+
+// The neutral { value, label } row shape onto what the /values endpoint returns.
+const toValueRow = ({ value, label }: { value: string; label: string }): ValueRow => ({
+  value,
+  text: label,
+  display_value: label,
+})
+
+describe('valueResolution — the contract shared with the backend resolver', () => {
+  it.each(RANKING_VECTORS)('$name', ({ query, rows, expectedOrder }) => {
+    const ranked = rankValues(rows.map(toValueRow), query).map(m => String(m.row.value))
+    expect(ranked).toEqual(expectedOrder)
+  })
+
+  it.each(ALTERNATE_QUERY_VECTORS)('$name', ({ query, mustInclude, mustNotInclude, maxLength }) => {
+    const queries = alternateQueries(query)
+    for (const expected of mustInclude ?? []) expect(queries).toContain(expected)
+    for (const forbidden of mustNotInclude ?? []) expect(queries).not.toContain(forbidden)
+    expect(queries.length).toBeLessThanOrEqual(maxLength ?? MAX_ALTERNATE_QUERIES)
+  })
+})
+
+// Browser-side specifics, not part of the shared contract.
+describe('valueResolution', () => {
+  it('never returns the query itself as an alternate — it has already been tried', () => {
+    expect(alternateQueries('Female')).not.toContain('Female')
+  })
+
+  it('ignores a row with no label and no value', () => {
+    expect(rankValues([{ value: '', text: '', display_value: '' }], 'female')).toEqual([])
+  })
+
+  // A two-letter synonym as a substring rule would match half the column ("f" is
+  // in "Left foot"), so short variants are matched by equality only.
+  it('does not substring-match a short synonym', () => {
+    const ranked = rankValues([{ value: 'LF', text: 'Left foot', display_value: 'Left foot' }], 'female')
+    expect(ranked).toEqual([])
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -663,6 +663,29 @@ describe('createPaTools', () => {
       expect(bare.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
       expect(parse(bareRes)).toEqual({ created: true, name: 'New cohort' })
     })
+
+    it('captures the post-reset baseline so an untouched new cohort reports clean', async () => {
+      const store = makeStore()
+      // resetChart replaces the live cohort definition, so the baseline has to be the
+      // RESET state and not the cohort that was open before — which is why
+      // Bookmarks.vue addNewCohort() snapshots after `await this.reset()` + $nextTick.
+      store.dispatch.mockImplementation((type: string) => {
+        if (type === 'resetChart') store.getters.getBookmarksData = { name: 'New cohort', cards: [] }
+        return Promise.resolve(undefined)
+      })
+
+      await byName(createPaTools(store), 'pa_new_cohort').execute({ name: 'New cohort' })
+
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK_BASELINE', { name: 'New cohort', cards: [] })
+      // Order matters: SET_ACTIVE_BOOKMARK clears activeBookmarkBaseline, and a new
+      // cohort has no saved `.bookmark` JSON to fall back on — so a baseline captured
+      // first (or not at all) leaves getCurrentBookmarkHasChanges reporting a
+      // zero-edit cohort as dirty, firing the unsaved-changes navigation guard.
+      expect(store.commit.mock.calls.map((c: any[]) => c[0])).toEqual([
+        'SET_ACTIVE_BOOKMARK',
+        'SET_ACTIVE_BOOKMARK_BASELINE',
+      ])
+    })
   })
 
   describe('pa_search_attribute_values', () => {
@@ -729,6 +752,36 @@ describe('createPaTools', () => {
         limit: 10000,
       })
       expect(parse(res).returned).toBe(200)
+    })
+
+    // inputSchema says `limit` is a number, but nothing enforces that at run time:
+    // neither registerTool nor paToolBridge.call() validates arguments against the
+    // schema, so whatever the model emitted arrives verbatim. A quoted number must
+    // still cap, and a non-numeric one must fall back — the old
+    // `Math.min(limit ?? DEFAULT, MAX)` made the cap NaN, and `slice(0, NaN)` is [],
+    // so the tool reported "returned: 0" for a search that had 500 matches.
+    it.each([
+      ['a numeric string', '25', 25],
+      ['a non-numeric string', 'twenty', 50],
+      ['a blank string', '   ', 50],
+      ['null', null, 50],
+      ['a NaN-y object', {}, 50],
+    ])('coerces %s limit rather than capping to zero rows', async (_label, limit, expected) => {
+      const store = makeStore()
+      const values = Array.from({ length: 500 }, (_, i) => ({ value: String(i), text: `t${i}` }))
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'p.attr',
+        query: 'x',
+        limit,
+      })
+
+      const parsed = parse(res)
+      expect(parsed.returned).toBe(expected)
+      expect(parsed.values).toHaveLength(expected)
+      expect(parsed.total).toBe(500)
     })
 
     it('surfaces loadedStatus TOO_MANY_RESULTS so the model narrows instead of concluding "absent"', async () => {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -1,0 +1,968 @@
+import { vi } from 'vitest'
+import { createPaTools, registerPaTools, PaTool } from '../webmcpServer'
+
+// A minimal Vuex-store stand-in. Only the surface the handlers touch is mocked:
+// a few getters and dispatch. This is verification "layer B" — handler ↔ Vuex
+// correctness — with no browser / modelContext in play.
+//
+// `bookmarks` seeds getters.getBookmarks (saved-cohort records shaped like the
+// real store: { bmkId, bookmarkname, ... }). `loadAllResult`, when set, is what
+// getBookmarks becomes after a `fireBookmarkQuery({cmd:'loadAll'})` dispatch —
+// so we can exercise the "list not loaded yet" branch realistically.
+const makeStore = ({ bookmarks = [], loadAllResult }: { bookmarks?: any[]; loadAllResult?: any[] } = {}) => {
+  const store: any = {
+    getters: {
+      getBookmarksData: { name: 'Elderly Diabetics', cards: ['c1'] },
+      getBookmarkFromIFR: { filter: { age: { min: 65 } } },
+      getBookmarks: bookmarks,
+      getActiveBookmark: null,
+    },
+    dispatch: vi.fn(),
+    commit: vi.fn(),
+  }
+  store.dispatch.mockImplementation((type: string, payload: any) => {
+    if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'loadAll' && loadAllResult) {
+      store.getters.getBookmarks = loadAllResult
+    }
+    return Promise.resolve(undefined)
+  })
+  return store
+}
+
+const byName = (tools: PaTool[], name: string): PaTool => {
+  const tool = tools.find(t => t.name === name)
+  if (!tool) throw new Error(`tool ${name} not registered`)
+  return tool
+}
+
+// Every handler returns { content: [{ type: 'text', text: <json> }] }.
+const parse = (res: { content: Array<{ text: string }> }) => JSON.parse(res.content[0].text)
+
+describe('createPaTools', () => {
+  it('registers exactly the expected PA tools with required-arg schemas', () => {
+    const tools = createPaTools(makeStore())
+
+    expect(tools.map(t => t.name)).toEqual([
+      'pa_new_cohort',
+      'pa_get_current_cohort',
+      'pa_list_cohorts',
+      'pa_open_cohort',
+      'pa_apply_cohort_patch',
+      'pa_list_filter_options',
+      'pa_search_attribute_values',
+      'pa_get_cohort_result',
+      'pa_save_current_cohort',
+    ])
+    // pa_save_current_cohort has no unconditionally-required input: it builds the
+    // payload from live store state given { name } (insert) or { bookmarkId } (update),
+    // and still accepts a raw `params` escape hatch — the handler validates the combo.
+    expect((byName(tools, 'pa_save_current_cohort').inputSchema as any).required).toBeUndefined()
+    // pa_search_attribute_values requires only the attribute: omitting `query`
+    // lists the column's complete value domain, which is the reliable route for a
+    // low-cardinality attribute (gender/race) where a word search can false-negative.
+    expect((byName(tools, 'pa_search_attribute_values').inputSchema as any).required).toEqual(['attributePath'])
+  })
+
+  describe('pa_get_current_cohort', () => {
+    it('serializes the live bookmark getters — the value only the running store has', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_get_current_cohort').execute()
+
+      expect(parse(res)).toMatchObject({
+        bookmarkData: store.getters.getBookmarksData,
+        ifr: store.getters.getBookmarkFromIFR,
+        // The AND/OR grouping: cards within a group are OR-ed, groups AND-ed.
+        // Empty here because this store has no bool-container tree.
+        cardGroups: [],
+      })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pa_list_cohorts', () => {
+    it('returns the saved cohorts as { bmkId, name } without refetching when already loaded', async () => {
+      const store = makeStore({
+        bookmarks: [
+          { bmkId: 'b1', bookmarkname: 'Elderly Diabetics', bookmark: '{}' },
+          { bmkId: 'b2', bookmarkname: 'Young Smokers', bookmark: '{}' },
+        ],
+      })
+      const res = await byName(createPaTools(store), 'pa_list_cohorts').execute()
+
+      expect(parse(res)).toEqual({
+        cohorts: [
+          { bmkId: 'b1', name: 'Elderly Diabetics' },
+          { bmkId: 'b2', name: 'Young Smokers' },
+        ],
+      })
+      expect(store.dispatch).not.toHaveBeenCalledWith('fireBookmarkQuery', expect.anything())
+    })
+
+    it('fetches the list via fireBookmarkQuery(loadAll) when the store is empty', async () => {
+      const store = makeStore({
+        bookmarks: [],
+        loadAllResult: [{ bmkId: 'b9', bookmarkname: 'Loaded Later', bookmark: '{}' }],
+      })
+      const res = await byName(createPaTools(store), 'pa_list_cohorts').execute()
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+      expect(parse(res)).toEqual({ cohorts: [{ bmkId: 'b9', name: 'Loaded Later' }] })
+    })
+
+    it('forceRefresh reloads via loadAll even when the list is already populated (fixes staleness)', async () => {
+      const store = makeStore({
+        bookmarks: [{ bmkId: 'b1', bookmarkname: 'Old', bookmark: '{}' }],
+        loadAllResult: [
+          { bmkId: 'b1', bookmarkname: 'Old', bookmark: '{}' },
+          { bmkId: 'b2', bookmarkname: 'Just Saved', bookmark: '{}' },
+        ],
+      })
+      const res = await byName(createPaTools(store), 'pa_list_cohorts').execute({ forceRefresh: true })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+      expect(parse(res)).toEqual({
+        cohorts: [
+          { bmkId: 'b1', name: 'Old' },
+          { bmkId: 'b2', name: 'Just Saved' },
+        ],
+      })
+    })
+  })
+
+  describe('pa_open_cohort', () => {
+    const cohorts = [
+      { bmkId: 'b1', bookmarkname: 'Elderly Diabetics', bookmark: '{}' },
+      { bmkId: 'b2', bookmarkname: 'Young Smokers', bookmark: '{}' },
+      { bmkId: 'b3', bookmarkname: 'Dupe', bookmark: '{}' },
+      { bmkId: 'b4', bookmarkname: 'Dupe', bookmark: '{}' },
+    ]
+
+    it('resolves a unique name to its bmkId and loads it into the builder', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ name: 'Young Smokers' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadbookmarkToState', { bmkId: 'b2', chartType: undefined })
+      expect(parse(res)).toEqual({ opened: true, bmkId: 'b2' })
+    })
+
+    it('opens by explicit bmkId (with chartType) when provided', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ bmkId: 'b1', chartType: 'bar' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadbookmarkToState', { bmkId: 'b1', chartType: 'bar' })
+      expect(parse(res)).toEqual({ opened: true, bmkId: 'b1' })
+    })
+
+    it('returns an error and does not load when the name is unknown', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ name: 'Nonexistent' })
+
+      expect(parse(res)).toEqual({ opened: false, error: 'No cohort named "Nonexistent".' })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadbookmarkToState', expect.anything())
+    })
+
+    it('returns the candidates (and does not load) when a name is ambiguous', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ name: 'Dupe' })
+
+      expect(parse(res)).toEqual({
+        opened: false,
+        ambiguous: [
+          { bmkId: 'b3', name: 'Dupe' },
+          { bmkId: 'b4', name: 'Dupe' },
+        ],
+      })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadbookmarkToState', expect.anything())
+    })
+
+    it('errors when a bmkId does not exist', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ bmkId: 'nope' })
+
+      expect(parse(res)).toEqual({ opened: false, error: 'No cohort with bmkId "nope".' })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadbookmarkToState', expect.anything())
+    })
+
+    it('errors when neither name nor bmkId is given', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({})
+
+      expect(parse(res)).toEqual({ opened: false, error: 'Provide a cohort name or bmkId.' })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pa_apply_cohort_patch', () => {
+    it('dispatches loadBookmarkDataToState with the bookmark + chartType', async () => {
+      const store = makeStore()
+      const bookmark = { filter: { some: 'filter' } }
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({ bookmark, chartType: 'bar' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadBookmarkDataToState', { bookmark, chartType: 'bar' })
+      expect(parse(res)).toEqual({ applied: true })
+    })
+
+    it('routes patchOps through the deterministic applier (no legacy bookmark dispatch)', async () => {
+      const store = makeStore()
+      // Minimal store surface applyCohortPatch touches for a single add_card.
+      store.getters.getFilterCards = () => ({ fc1: {} })
+      store.dispatch.mockImplementation((type: string) => {
+        if (type === 'addFilterCard') return Promise.resolve('fc1')
+        return Promise.resolve(undefined)
+      })
+
+      const patchOps = [{ op: 'add_card', cardConfigPath: 'patient.interactions.priDiag' }]
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({ patchOps })
+
+      expect(store.dispatch).toHaveBeenCalledWith('addFilterCard', {
+        configPath: 'patient.interactions.priDiag',
+        isExclusion: false,
+      })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadBookmarkDataToState', expect.anything())
+      expect(parse(res)).toEqual({
+        applied: true,
+        createdCards: ['fc1'],
+        appliedConstraints: [],
+        // No bool-container tree on this minimal store, so nothing to group.
+        cardGroups: [],
+      })
+    })
+
+    it('returns applied:false with an error when neither patchOps nor bookmark is given', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({})
+
+      expect(parse(res)).toEqual({ applied: false, error: 'Provide patchOps (preferred) or a bookmark object.' })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('attaches the valid filter catalog when a patch fails, so a bad path is self-correcting', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          { getConfigPath: () => 'patient', getName: () => 'Basic Data', getFilterAttributes: () => [] },
+        ],
+      }
+      // Force the applier to throw (addFilterCard rejects).
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'addFilterCard' ? Promise.reject(new Error('boom')) : Promise.resolve(undefined)
+      )
+
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({
+        patchOps: [{ op: 'add_card', cardConfigPath: 'patient' }],
+      })
+
+      const parsed = parse(res)
+      expect(parsed.applied).toBe(false)
+      expect(parsed.validFilterOptions).toEqual([{ cardConfigPath: 'patient', cardName: 'Basic Data', attributes: [] }])
+    })
+
+    it('scopes the failure catalog to the cards the patch named, listing the rest by path only', async () => {
+      const store = makeStore()
+      const card = (path: string, name: string) => ({
+        getConfigPath: () => path,
+        getName: () => name,
+        getFilterAttributes: () => [
+          { getConfigPath: () => `${path}.attributes.a`, getName: () => 'A', getType: () => 'text' },
+        ],
+      })
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [card('patient', 'Basic Data'), card('patient.interactions.priDiag', 'Diagnoses')],
+      }
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'addFilterCardConstraint' ? Promise.reject(new Error('boom')) : Promise.resolve(undefined)
+      )
+      store.getters.getFilterCards = () => ({ fc1: {} })
+
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({
+        patchOps: [
+          { op: 'add_constraint', card: 'fc1', attributePath: 'patient.interactions.priDiag.attributes.a', value: 'x' },
+        ],
+      })
+
+      const parsed = parse(res)
+      expect(parsed.applied).toBe(false)
+      // The named card keeps its attributes (that's what fixes a bad attributePath);
+      // every other card is path + name + a count, so the whole catalog is not
+      // duplicated into the transcript on every failed patch.
+      expect(parsed.validFilterOptions).toEqual([
+        { cardConfigPath: 'patient', cardName: 'Basic Data', attributeCount: 1 },
+        {
+          cardConfigPath: 'patient.interactions.priDiag',
+          cardName: 'Diagnoses',
+          attributes: [
+            { attributePath: 'patient.interactions.priDiag.attributes.a', name: 'A', type: 'text', valueKind: 'text' },
+          ],
+        },
+      ])
+    })
+
+    it('rejects a malformed bookmark, restores the active cohort, and steers to patchOps', async () => {
+      const store = makeStore()
+      const prevActive = { bmkId: 'test-1', bookmarkname: 'test', isNew: false }
+      store.getters.getActiveBookmark = prevActive
+      // loadBookmarkDataToState clobbers the active bookmark, then rejects on the bad tree.
+      store.dispatch.mockImplementation((type: string) => {
+        if (type === 'loadBookmarkDataToState') {
+          const e: any = new Error('')
+          e.name = 'InvalidArgumentException'
+          return Promise.reject(e)
+        }
+        return Promise.resolve(undefined)
+      })
+
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({
+        // filter card missing `attributes` — the shape that threw in the wild
+        bookmark: { filter: { cards: { type: 'FilterCard' } } },
+      })
+
+      const parsed = parse(res)
+      expect(parsed.applied).toBe(false)
+      expect(parsed.error).toContain('patchOps')
+      // the failed load left a broken active bookmark; the tool restores the prior one
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', prevActive)
+    })
+  })
+
+  describe('pa_list_filter_options', () => {
+    it('maps the frontend config filter cards + attributes to a flat catalog', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient',
+            getName: () => 'Basic Data',
+            getFilterAttributes: () => [
+              { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
+            ],
+          },
+        ],
+      }
+
+      const res = await byName(createPaTools(store), 'pa_list_filter_options').execute()
+
+      const parsed = parse(res)
+      expect(parsed.filterCards).toEqual([
+        {
+          cardConfigPath: 'patient',
+          cardName: 'Basic Data',
+          attributes: [
+            {
+              attributePath: 'patient.attributes.age',
+              name: 'Age',
+              type: 'num',
+              valueKind: 'numeric',
+            },
+          ],
+        },
+      ])
+      // How-to prose is hoisted into a single guide keyed by valueKind rather than
+      // repeated per attribute — the catalog is resent in the agent transcript on
+      // every turn, and inlining it doubled the payload.
+      expect(parsed.valueKindGuide.numeric).toContain('operator')
+      // the routing note steers value shape on non-OMOP configs
+      expect(parsed.note).toContain('valueKind')
+    })
+
+    it('lists only filter-card attributes, not measure/category-only ones', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient',
+            getName: () => 'Basic Data',
+            // getAllAttributes() would also include pcount, which add_constraint
+            // cannot target — a path the model would only ever fail on.
+            getFilterAttributes: () => [
+              { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
+            ],
+            getAllAttributes: () => [
+              { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
+              { getConfigPath: () => 'patient.attributes.pcount', getName: () => 'Patient Count', getType: () => 'num' },
+            ],
+          },
+        ],
+      }
+
+      const attrs = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).filterCards[0]
+        .attributes
+      expect(attrs.map((a: any) => a.attributePath)).toEqual(['patient.attributes.age'])
+    })
+
+    it('classifies a coded catalog attribute (useRefValue) as valueKind "catalog"', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient.interactions.conditionoccurrence',
+            getName: () => 'Conditions',
+            getFilterAttributes: () => [
+              {
+                getConfigPath: () => 'patient.interactions.conditionoccurrence.attributes.condsourcecode',
+                getName: () => 'Condition Source concept code',
+                getType: () => 'text',
+                isCatalogAttribute: () => true,
+              },
+              {
+                getConfigPath: () => 'patient.interactions.conditionoccurrence.attributes.condsourceconceptset',
+                getName: () => 'Condition Source concept set',
+                getType: () => 'conceptSet',
+                isCatalogAttribute: () => false,
+              },
+            ],
+          },
+        ],
+      }
+
+      const parsed = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute())
+      const attrs = parsed.filterCards[0].attributes
+      expect(attrs[0].valueKind).toBe('catalog')
+      expect(attrs[1].valueKind).toBe('conceptSet')
+      expect(parsed.valueKindGuide.catalog).toContain('pa_search_attribute_values')
+      expect(parsed.valueKindGuide.conceptSet).toContain('conceptSetId')
+    })
+
+    it('reports the OMOP domain a concept-set attribute takes, and omits it when unset', async () => {
+      // Without conceptDomain the model reuses whatever concept-set id it is
+      // already holding: an Alzheimer's (Condition) set on a Visit card builds a
+      // cohort that computes and answers the wrong question.
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient.interactions.visit',
+            getName: () => 'Visit',
+            getFilterAttributes: () => [
+              {
+                getConfigPath: () => 'patient.interactions.visit.attributes.visitconceptset',
+                getName: () => 'Encounter Concept set',
+                getType: () => 'conceptSet',
+                getDomainFilter: () => 'Visit',
+              },
+              {
+                getConfigPath: () => 'patient.interactions.visit.attributes.startdate',
+                getName: () => 'Start date',
+                getType: () => 'time',
+                getDomainFilter: () => '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const attrs = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).filterCards[0]
+        .attributes
+      expect(attrs[0]).toMatchObject({ valueKind: 'conceptSet', conceptDomain: 'Visit' })
+      expect(attrs[1]).not.toHaveProperty('conceptDomain')
+      expect(parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).valueKindGuide.conceptSet)
+        .toContain('conceptDomain')
+    })
+
+    it('returns just one card when `card` is given, and the valid paths when it is unknown', async () => {
+      const store = makeStore()
+      const card = (path: string, name: string) => ({
+        getConfigPath: () => path,
+        getName: () => name,
+        getFilterAttributes: () => [
+          { getConfigPath: () => `${path}.attributes.a`, getName: () => 'A', getType: () => 'text' },
+        ],
+      })
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [card('patient', 'Basic Data'), card('patient.interactions.priDiag', 'Diagnoses')],
+      }
+      const tool = byName(createPaTools(store), 'pa_list_filter_options')
+
+      const scoped = parse(await tool.execute({ card: 'patient.interactions.priDiag' }))
+      expect(scoped.filterCards).toHaveLength(1)
+      expect(scoped.filterCards[0].cardConfigPath).toBe('patient.interactions.priDiag')
+
+      const unknown = parse(await tool.execute({ card: 'patient.interactions.nope' }))
+      expect(unknown.filterCards).toEqual([])
+      expect(unknown.error).toContain('patient.interactions.nope')
+      expect(unknown.validCardConfigPaths).toEqual(['patient', 'patient.interactions.priDiag'])
+    })
+
+    it('degrades gracefully when the frontend config is not loaded', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = undefined
+      const res = await byName(createPaTools(store), 'pa_list_filter_options').execute()
+      expect(parse(res)).toEqual({ filterCards: [], error: 'Frontend config not loaded.' })
+    })
+  })
+
+  describe('pa_save_current_cohort', () => {
+    it('defaults method to "post" and returns the bmkId from the dispatch result', async () => {
+      const store = makeStore()
+      store.dispatch.mockResolvedValue({ bmkId: 'srv-generated-42' })
+      const params = { name: 'x' }
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ params })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'post',
+        params,
+        bookmarkId: undefined,
+      })
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'srv-generated-42' })
+    })
+
+    it('falls back to the passed bookmarkId when the result has none (e.g. put/update)', async () => {
+      const store = makeStore()
+      store.dispatch.mockResolvedValue(undefined)
+      const params = { name: 'x' }
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({
+        params,
+        bookmarkId: 'existing-7',
+        method: 'put',
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'put',
+        params,
+        bookmarkId: 'existing-7',
+      })
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'existing-7' })
+    })
+
+    it('builds an insert payload from live state, refreshes the list, and adopts the saved bookmark', async () => {
+      const savedRecord = { bmkId: 'new-1', bookmarkname: 'Female Sinusitis', bookmark: '{}' }
+      const store = makeStore()
+      store.getters.getActiveBookmark = { bookmarkname: 'New cohort', isNew: true }
+      store.dispatch.mockImplementation((type: string, payload: any) => {
+        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'insert') return Promise.resolve({ bmkId: 'new-1' })
+        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'loadAll') {
+          store.getters.getBookmarks = [savedRecord]
+        }
+        return Promise.resolve(undefined)
+      })
+
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ name: 'Female Sinusitis' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'post',
+        params: {
+          cmd: 'insert',
+          bookmarkname: 'Female Sinusitis',
+          bookmark: JSON.stringify(store.getters.getBookmarksData),
+          shareBookmark: false,
+        },
+        bookmarkId: undefined,
+      })
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', savedRecord)
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'new-1' })
+    })
+
+    it('builds an update payload (cmd:update) when a bookmarkId is given', async () => {
+      const store = makeStore()
+      store.dispatch.mockResolvedValue(undefined)
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({
+        bookmarkId: 'existing-9',
+        share: true,
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'put',
+        params: { cmd: 'update', bookmark: JSON.stringify(store.getters.getBookmarksData), shareBookmark: true },
+        bookmarkId: 'existing-9',
+      })
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'existing-9' })
+    })
+
+    it('refuses to save an empty cohort without dispatching', async () => {
+      const store = makeStore()
+      store.getters.getBookmarksData = {}
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ name: 'Empty' })
+
+      expect(parse(res)).toEqual({ saved: false, error: 'Current cohort is empty — build filters before saving.' })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('requires a name to insert a brand-new cohort', async () => {
+      const store = makeStore()
+      store.getters.getActiveBookmark = { bookmarkname: 'New cohort', isNew: true }
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({})
+
+      expect(parse(res)).toEqual({ saved: false, error: 'Provide a name to save a new cohort.' })
+    })
+  })
+
+  describe('pa_new_cohort', () => {
+    it('resets the active bookmark + chart and switches to the builder view', async () => {
+      const store = makeStore()
+      const showBuilder = vi.fn()
+      const res = await byName(createPaTools(store, { showBuilder }), 'pa_new_cohort').execute({ name: 'My Cohort' })
+
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'My Cohort', isNew: true })
+      expect(store.dispatch).toHaveBeenCalledWith('resetChart')
+      expect(showBuilder).toHaveBeenCalledOnce()
+      expect(parse(res)).toEqual({ created: true, name: 'My Cohort' })
+    })
+
+    it('defaults the name and works without a showBuilder hook', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_new_cohort').execute()
+
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
+      expect(parse(res)).toEqual({ created: true, name: 'New cohort' })
+    })
+  })
+
+  describe('pa_search_attribute_values', () => {
+    it('delegates to loadValuesForAttributePath and returns the values with counts', async () => {
+      const store = makeStore()
+      const values = [{ value: '461', text: 'Acute sinusitis', display_value: 'Acute sinusitis (461)' }]
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.interactions.priDiag.attributes.icd10',
+        query: 'sinusitis',
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadValuesForAttributePath', {
+        attributePathUid: 'patient.interactions.priDiag.attributes.icd10',
+        searchQuery: 'sinusitis',
+        attributeType: 'text',
+      })
+      // A small clean result: no truncation, no note, counts reported.
+      expect(parse(res)).toEqual({
+        attributePath: 'patient.interactions.priDiag.attributes.icd10',
+        query: 'sinusitis',
+        matchedVia: 'search',
+        total: 1,
+        returned: 1,
+        truncated: false,
+        values,
+      })
+      // The search hit, so the domain is never re-read.
+      expect(store.dispatch).toHaveBeenCalledOnce()
+    })
+
+    it('caps a large result to `limit`, flags truncation, and returns a routing note', async () => {
+      const store = makeStore()
+      // 1,602 tokens (the gemfibrozil case) — the flood the cap protects against.
+      const values = Array.from({ length: 1602 }, (_, i) => ({ value: String(i), text: `gemfibrozil ${i}` }))
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.interactions.drugexposure.attributes.drugconceptcode',
+        query: 'gemfibrozil',
+        limit: 25,
+      })
+
+      const parsed = parse(res)
+      expect(parsed.total).toBe(1602)
+      expect(parsed.returned).toBe(25)
+      expect(parsed.values).toHaveLength(25)
+      expect(parsed.truncated).toBe(true)
+      expect(parsed.note).toContain('concept set with descendants')
+    })
+
+    it('clamps limit to MAX_VALUE_LIMIT (200)', async () => {
+      const store = makeStore()
+      const values = Array.from({ length: 500 }, (_, i) => ({ value: String(i), text: `t${i}` }))
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'p.attr',
+        query: 'x',
+        limit: 10000,
+      })
+      expect(parse(res).returned).toBe(200)
+    })
+
+    it('surfaces loadedStatus TOO_MANY_RESULTS so the model narrows instead of concluding "absent"', async () => {
+      const store = makeStore()
+      store.dispatch.mockImplementation((type: string) =>
+        // 204 → the store records TOO_MANY_RESULTS and returns an empty list.
+        type === 'loadValuesForAttributePath' ? Promise.resolve([]) : Promise.resolve(undefined)
+      )
+      store.getters.getDomainValues = () => ({ loadedStatus: 'TOO_MANY_RESULTS', values: [] })
+
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'p.attr',
+        query: 'aspirin',
+      })
+      const parsed = parse(res)
+      expect(parsed.loadedStatus).toBe('TOO_MANY_RESULTS')
+      expect(parsed.total).toBe(0)
+      expect(parsed.note).toContain('TOO_MANY_RESULTS')
+      expect(parsed.note).toContain('Narrow the query')
+    })
+
+    it('errors without dispatching when attributePath is missing', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({ attributePath: '', query: '' })
+
+      expect(parse(res)).toEqual({
+        values: [],
+        error: 'Provide an attributePath (from pa_list_filter_options).',
+      })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    // The "build me a cohort of women…" regression. The /values search runs in the
+    // database (case- and token-sensitive), so the English word misses the stored
+    // token and the assistant used to report the value as absent and ask the user
+    // for a synonym. A miss now costs one extra request and resolves itself.
+    describe('a zero-hit search falls back to the attribute domain', () => {
+      // Mock /values the way the backend behaves: an exact, case-sensitive token
+      // match, and the full list when searchQuery is empty.
+      const makeValuesStore = (domain: any[]) => {
+        const store = makeStore()
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string, payload: any) => {
+          if (type !== 'loadValuesForAttributePath') return Promise.resolve(undefined)
+          const q = payload.searchQuery
+          if (!q) return Promise.resolve(domain)
+          return Promise.resolve(domain.filter(v => v.text.includes(q) || v.value.includes(q)))
+        })
+        return store
+      }
+      const GENDER = [
+        { value: '8532', text: 'Female', display_value: 'Female' },
+        { value: '8507', text: 'Male', display_value: 'Male' },
+      ]
+
+      it('matches case-insensitively against the full list when the search misses', async () => {
+        const store = makeValuesStore(GENDER)
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'patient.attributes.gender',
+          query: 'female',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('domain-scan')
+        expect(parsed.values).toEqual([GENDER[0]])
+        expect(parsed.domainTotal).toBe(2)
+        expect(parsed.note).toContain('never proof a value is absent')
+        // The stale "loaded with zero values" cache is busted before re-reading,
+        // or the store would serve it back instead of fetching the full domain.
+        expect(store.commit).toHaveBeenCalledWith('DOMAIN_SET_VALUES', {
+          attributePath: 'patient.attributes.gender',
+          data: { values: [], isLoaded: false, isLoading: false },
+        })
+      })
+
+      it('resolves a demographic synonym ("women" → the stored "F") on exact tokens only', async () => {
+        const store = makeValuesStore([
+          { value: 'F', text: 'F', display_value: 'F' },
+          { value: 'M', text: 'M', display_value: 'M' },
+          // Would be a false positive if synonyms matched as substrings ("f").
+          { value: 'UNK', text: 'Info not available', display_value: 'Info not available' },
+        ])
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'patient.attributes.gender',
+          query: 'women',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('domain-scan')
+        expect(parsed.values).toEqual([{ value: 'F', text: 'F', display_value: 'F' }])
+      })
+
+      it('returns the COMPLETE value list when nothing matches, instead of "not found"', async () => {
+        const store = makeValuesStore(GENDER)
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'patient.attributes.gender',
+          query: 'nonbinary',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('domain')
+        expect(parsed.values).toEqual(GENDER)
+        expect(parsed.domainTotal).toBe(2)
+        expect(parsed.note).toContain('COMPLETE value list')
+        expect(parsed.note).toContain('do NOT ask the user to suggest a synonym')
+      })
+
+      it('retries other casings when the domain is too large to enumerate', async () => {
+        const store = makeStore()
+        const hit = [{ value: '461', text: 'Sinusitis' }]
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string, payload: any) =>
+          type === 'loadValuesForAttributePath'
+            ? // Only the title-cased term matches; the unfiltered call returns nothing,
+              // as a /values endpoint that refuses to dump a huge catalog does.
+              Promise.resolve(payload.searchQuery === 'Sinusitis' ? hit : [])
+            : Promise.resolve(undefined)
+        )
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'p.attr',
+          query: 'sinusitis',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('case-variant')
+        expect(parsed.values).toEqual(hit)
+        expect(parsed.note).toContain('case-sensitive')
+      })
+
+      it('does not re-read the domain when the search was merely TOO_MANY_RESULTS', async () => {
+        const store = makeStore()
+        store.dispatch.mockImplementation((type: string) =>
+          type === 'loadValuesForAttributePath' ? Promise.resolve([]) : Promise.resolve(undefined)
+        )
+        store.getters.getDomainValues = () => ({ loadedStatus: 'TOO_MANY_RESULTS', values: [] })
+
+        await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'p.attr',
+          query: 'aspirin',
+        })
+        // "Narrow the query" is already the right answer — enumerating a domain the
+        // endpoint just refused to return would only burn a request.
+        expect(store.dispatch).toHaveBeenCalledOnce()
+      })
+    })
+
+    it('lists the whole domain when `query` is omitted', async () => {
+      const store = makeStore()
+      const domain = [
+        { value: '8532', text: 'Female' },
+        { value: '8507', text: 'Male' },
+      ]
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(domain) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.attributes.gender',
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadValuesForAttributePath', {
+        attributePathUid: 'patient.attributes.gender',
+        searchQuery: '',
+        attributeType: 'text',
+      })
+      // Every unfiltered read busts the cache first: a previous search on this
+      // attribute leaves it cached as loaded-with-its-own-rows, and the store would
+      // serve those back instead of the domain.
+      expect(store.commit).toHaveBeenCalledWith('DOMAIN_SET_VALUES', {
+        attributePath: 'patient.attributes.gender',
+        data: { values: [], isLoaded: false, isLoading: false },
+      })
+      const parsed = parse(res)
+      expect(parsed.matchedVia).toBe('domain')
+      expect(parsed.domainTotal).toBe(2)
+      expect(parsed.values).toEqual(domain)
+      expect(parsed.query).toBeUndefined()
+    })
+
+    // The store cancels an in-flight /values call when a newer one targets the same
+    // attributePath and resolves the loser with `undefined`. Read as "no values",
+    // that is another route to telling the user a value doesn't exist.
+    it('retries once when the store resolves undefined (a superseded request)', async () => {
+      const store = makeStore()
+      const values = [{ value: '8532', text: 'Female' }]
+      let calls = 0
+      store.dispatch.mockImplementation((type: string) => {
+        if (type !== 'loadValuesForAttributePath') return Promise.resolve(undefined)
+        calls += 1
+        return Promise.resolve(calls === 1 ? undefined : values)
+      })
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.attributes.gender',
+        query: 'Female',
+      })
+
+      expect(calls).toBe(2)
+      expect(parse(res).values).toEqual(values)
+    })
+  })
+
+  describe('pa_get_cohort_result', () => {
+    it('returns the matched count, total, chart type and binned chart data', async () => {
+      const store = makeStore()
+      const chartData = {
+        totalPatientCount: 2694,
+        categories: [{ id: 'patient.attributes.age', name: 'Age', binsize: 10 }],
+        measures: [{ id: 'patient.attributes.pcount', name: 'Patient Count' }],
+        data: [{ 'patient.attributes.age': 0, 'patient.attributes.pcount': 12 }],
+      }
+      Object.assign(store.getters, {
+        getCurrentPatientCount: 1275,
+        getTotalPatientCount: 2694,
+        getTotalPatientListCount: 0,
+        getDisplayTotalGuardedPatientCount: false,
+        getActiveChart: 'vb',
+        getResponse: () => ({ data: chartData }),
+      })
+
+      const res = await byName(createPaTools(store), 'pa_get_cohort_result').execute()
+
+      expect(parse(res)).toEqual({
+        currentPatientCount: 1275,
+        totalPatientCount: 2694,
+        chartType: 'vb',
+        chart: {
+          totalPatientCount: 2694,
+          categories: chartData.categories,
+          measures: chartData.measures,
+          data: chartData.data,
+        },
+      })
+    })
+
+    it('uses the guarded total for list/custom charts and null chart when no response data', async () => {
+      const store = makeStore()
+      Object.assign(store.getters, {
+        getCurrentPatientCount: 5,
+        getTotalPatientCount: 99,
+        getTotalPatientListCount: 42,
+        getDisplayTotalGuardedPatientCount: true,
+        getActiveChart: 'list',
+        getResponse: () => ({}),
+      })
+
+      const res = await byName(createPaTools(store), 'pa_get_cohort_result').execute()
+
+      expect(parse(res)).toEqual({ currentPatientCount: 5, totalPatientCount: 42, chartType: 'list', chart: null })
+    })
+  })
+})
+
+describe('registerPaTools', () => {
+  afterEach(() => {
+    delete (document as any).modelContext
+    delete (navigator as any).modelContext
+    vi.restoreAllMocks()
+  })
+
+  it('returns a no-op and warns when modelContext is unavailable', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const cleanup = registerPaTools(makeStore())
+
+    expect(typeof cleanup).toBe('function')
+    expect(warn).toHaveBeenCalledOnce()
+    expect(() => cleanup()).not.toThrow()
+  })
+
+  it('registers every createPaTools tool on document.modelContext and unregisters on cleanup', () => {
+    const unregister = vi.fn()
+    const registerTool = vi.fn((_tool: PaTool) => ({ unregister }))
+    ;(document as any).modelContext = { registerTool }
+    const store = makeStore()
+    const toolCount = createPaTools(store).length
+
+    const cleanup = registerPaTools(store)
+
+    const registeredNames = registerTool.mock.calls.map(c => (c[0] as PaTool).name)
+    expect(registeredNames).toEqual(createPaTools(store).map(t => t.name))
+    expect(registerTool).toHaveBeenCalledTimes(toolCount)
+
+    cleanup()
+    expect(unregister).toHaveBeenCalledTimes(toolCount)
+  })
+
+  it('falls back to navigator.modelContext when document.modelContext is absent', () => {
+    const registerTool = vi.fn(() => ({ unregister: vi.fn() }))
+    ;(navigator as any).modelContext = { registerTool }
+    const store = makeStore()
+
+    registerPaTools(store)
+
+    expect(registerTool).toHaveBeenCalledTimes(createPaTools(store).length)
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -39,20 +39,9 @@ const byName = (tools: PaTool[], name: string): PaTool => {
 const parse = (res: { content: Array<{ text: string }> }) => JSON.parse(res.content[0].text)
 
 describe('createPaTools', () => {
-  it('registers exactly the expected PA tools with required-arg schemas', () => {
+  it('declares a required arg only where a tool genuinely has one', () => {
     const tools = createPaTools(makeStore())
 
-    expect(tools.map(t => t.name)).toEqual([
-      'pa_new_cohort',
-      'pa_get_current_cohort',
-      'pa_list_cohorts',
-      'pa_open_cohort',
-      'pa_apply_cohort_patch',
-      'pa_list_filter_options',
-      'pa_search_attribute_values',
-      'pa_get_cohort_result',
-      'pa_save_current_cohort',
-    ])
     // pa_save_current_cohort has no unconditionally-required input: it builds the
     // payload from live store state given { name } (insert) or { bookmarkId } (update),
     // and still accepts a raw `params` escape hatch — the handler validates the combo.
@@ -378,7 +367,11 @@ describe('createPaTools', () => {
             ],
             getAllAttributes: () => [
               { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
-              { getConfigPath: () => 'patient.attributes.pcount', getName: () => 'Patient Count', getType: () => 'num' },
+              {
+                getConfigPath: () => 'patient.attributes.pcount',
+                getName: () => 'Patient Count',
+                getType: () => 'num',
+              },
             ],
           },
         ],
@@ -422,6 +415,37 @@ describe('createPaTools', () => {
       expect(parsed.valueKindGuide.conceptSet).toContain('conceptSetId')
     })
 
+    it('classifies a useRefText coded column as "catalog" and a time attribute as "date"', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient.interactions.priDiag',
+            getName: () => 'Diagnoses',
+            getFilterAttributes: () => [
+              {
+                // No isCatalogAttribute(): an older config marks a coded column by
+                // displaying its ref text, and that one needs /values just the same.
+                getConfigPath: () => 'patient.interactions.priDiag.attributes.icd10',
+                getName: () => 'ICD-10',
+                getType: () => 'text',
+                oInternalConfigAttribute: { useRefText: true },
+              },
+              {
+                getConfigPath: () => 'patient.interactions.priDiag.attributes.startdate',
+                getName: () => 'Start date',
+                getType: () => 'time',
+              },
+            ],
+          },
+        ],
+      }
+
+      const parsed = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute())
+      expect(parsed.filterCards[0].attributes.map((a: any) => a.valueKind)).toEqual(['catalog', 'date'])
+      expect(parsed.valueKindGuide.date).toContain('from, to')
+    })
+
     it('reports the OMOP domain a concept-set attribute takes, and omits it when unset', async () => {
       // Without conceptDomain the model reuses whatever concept-set id it is
       // already holding: an Alzheimer's (Condition) set on a Visit card builds a
@@ -454,8 +478,9 @@ describe('createPaTools', () => {
         .attributes
       expect(attrs[0]).toMatchObject({ valueKind: 'conceptSet', conceptDomain: 'Visit' })
       expect(attrs[1]).not.toHaveProperty('conceptDomain')
-      expect(parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).valueKindGuide.conceptSet)
-        .toContain('conceptDomain')
+      expect(
+        parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).valueKindGuide.conceptSet
+      ).toContain('conceptDomain')
     })
 
     it('returns just one card when `card` is given, and the valid paths when it is unknown', async () => {
@@ -491,29 +516,26 @@ describe('createPaTools', () => {
   })
 
   describe('pa_save_current_cohort', () => {
-    it('defaults method to "post" and returns the bmkId from the dispatch result', async () => {
+    // The raw `params` back-compat hatch: forwarded verbatim, method defaults to
+    // post, and the saved id comes from the response or falls back to the argument.
+    it('forwards raw params verbatim and resolves the bookmarkId from result or argument', async () => {
       const store = makeStore()
       store.dispatch.mockResolvedValue({ bmkId: 'srv-generated-42' })
       const params = { name: 'x' }
-      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ params })
+      const tool = byName(createPaTools(store), 'pa_save_current_cohort')
 
+      expect(parse(await tool.execute({ params }))).toEqual({ saved: true, bookmarkId: 'srv-generated-42' })
       expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
         method: 'post',
         params,
         bookmarkId: undefined,
       })
-      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'srv-generated-42' })
-    })
+      // Every write refreshes the list, or pa_list_cohorts serves a stale one.
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
 
-    it('falls back to the passed bookmarkId when the result has none (e.g. put/update)', async () => {
-      const store = makeStore()
+      // put/update: the endpoint returns no bmkId, so the passed one stands in.
       store.dispatch.mockResolvedValue(undefined)
-      const params = { name: 'x' }
-      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({
-        params,
-        bookmarkId: 'existing-7',
-        method: 'put',
-      })
+      const res = await tool.execute({ params, bookmarkId: 'existing-7', method: 'put' })
 
       expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
         method: 'put',
@@ -528,7 +550,8 @@ describe('createPaTools', () => {
       const store = makeStore()
       store.getters.getActiveBookmark = { bookmarkname: 'New cohort', isNew: true }
       store.dispatch.mockImplementation((type: string, payload: any) => {
-        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'insert') return Promise.resolve({ bmkId: 'new-1' })
+        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'insert')
+          return Promise.resolve({ bmkId: 'new-1' })
         if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'loadAll') {
           store.getters.getBookmarks = [savedRecord]
         }
@@ -584,6 +607,41 @@ describe('createPaTools', () => {
 
       expect(parse(res)).toEqual({ saved: false, error: 'Provide a name to save a new cohort.' })
     })
+
+    it('refuses an update when there is neither a bookmarkId nor an active saved cohort', async () => {
+      const store = makeStore() // getActiveBookmark is null
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ method: 'put' })
+
+      expect(parse(res)).toEqual({
+        saved: false,
+        error: 'Update requested but no bookmarkId (and no active saved cohort) to update.',
+      })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    // Current behaviour, pinned: with an already-saved cohort active and no args,
+    // this INSERTS a second cohort under the same name rather than updating it —
+    // overwriting requires an explicit bookmarkId or method:"put" (as documented
+    // on the tool). Worth revisiting if a duplicate row ever shows up in the wild.
+    it('falls back to the active cohort name when saving without one', async () => {
+      const store = makeStore()
+      store.getters.getActiveBookmark = { bmkId: 'b1', bookmarkname: 'Elderly Diabetics', isNew: false }
+      store.dispatch.mockResolvedValue(undefined)
+
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({})
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'post',
+        params: {
+          cmd: 'insert',
+          bookmarkname: 'Elderly Diabetics',
+          bookmark: JSON.stringify(store.getters.getBookmarksData),
+          shareBookmark: false,
+        },
+        bookmarkId: undefined,
+      })
+      expect(parse(res)).toEqual({ saved: true })
+    })
   })
 
   describe('pa_new_cohort', () => {
@@ -596,14 +654,14 @@ describe('createPaTools', () => {
       expect(store.dispatch).toHaveBeenCalledWith('resetChart')
       expect(showBuilder).toHaveBeenCalledOnce()
       expect(parse(res)).toEqual({ created: true, name: 'My Cohort' })
-    })
 
-    it('defaults the name and works without a showBuilder hook', async () => {
-      const store = makeStore()
-      const res = await byName(createPaTools(store), 'pa_new_cohort').execute()
+      // No args and no showBuilder hook: the name defaults and the optional hook
+      // is genuinely optional (createPaTools is used without one in tests/bridge).
+      const bare = makeStore()
+      const bareRes = await byName(createPaTools(bare), 'pa_new_cohort').execute()
 
-      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
-      expect(parse(res)).toEqual({ created: true, name: 'New cohort' })
+      expect(bare.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
+      expect(parse(bareRes)).toEqual({ created: true, name: 'New cohort' })
     })
   })
 
@@ -694,7 +752,10 @@ describe('createPaTools', () => {
 
     it('errors without dispatching when attributePath is missing', async () => {
       const store = makeStore()
-      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({ attributePath: '', query: '' })
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: '',
+        query: '',
+      })
 
       expect(parse(res)).toEqual({
         values: [],
@@ -918,6 +979,29 @@ describe('createPaTools', () => {
       const res = await byName(createPaTools(store), 'pa_get_cohort_result').execute()
 
       expect(parse(res)).toEqual({ currentPatientCount: 5, totalPatientCount: 42, chartType: 'list', chart: null })
+    })
+
+    // Without the error surfaced, a failed chart query is indistinguishable from a
+    // cohort that legitimately matched nobody — and the model reports "0 patients".
+    it('surfaces a failed chart query instead of letting it read as an empty cohort', async () => {
+      const store = makeStore()
+      Object.assign(store.getters, {
+        getCurrentPatientCount: 0,
+        getTotalPatientCount: 0,
+        getTotalPatientListCount: 0,
+        getDisplayTotalGuardedPatientCount: false,
+        getActiveChart: 'vb',
+        getResponse: () => ({
+          data: { totalPatientCount: 0, noDataReason: 'NO_DATA', error: 'Request failed with status code 500' },
+        }),
+      })
+
+      const parsed = parse(await byName(createPaTools(store), 'pa_get_cohort_result').execute())
+
+      expect(parsed.chart.error).toBe('Request failed with status code 500')
+      expect(parsed.chart.noDataReason).toBe('NO_DATA')
+      expect(parsed.error).toContain('not a real result')
+      expect(parsed.error).toContain('Request failed with status code 500')
     })
   })
 })

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -839,7 +839,7 @@ describe('createPaTools', () => {
         expect(parsed.note).toContain('do NOT ask the user to suggest a synonym')
       })
 
-      it('retries other casings when the domain is too large to enumerate', async () => {
+      it('retries rewritten queries when the domain is too large to enumerate', async () => {
         const store = makeStore()
         const hit = [{ value: '461', text: 'Sinusitis' }]
         store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
@@ -856,9 +856,54 @@ describe('createPaTools', () => {
         })
 
         const parsed = parse(res)
-        expect(parsed.matchedVia).toBe('case-variant')
+        expect(parsed.matchedVia).toBe('alternate-query')
         expect(parsed.values).toEqual(hit)
         expect(parsed.note).toContain('case-sensitive')
+      })
+
+      // The retry sweep is not casing-only: "ER visit" is not a substring of the
+      // stored "Emergency Room Visit" in ANY casing, so the term's expansions and
+      // its distinctive words have to be searched too. This is the case the
+      // backend resolver handled and this surface did not.
+      it('retries an expanded term, not just other casings', async () => {
+        const store = makeStore()
+        const hit = [{ value: '9203', text: 'Emergency Room Visit' }]
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string, payload: any) =>
+          type === 'loadValuesForAttributePath'
+            ? Promise.resolve(payload.searchQuery === 'Emergency Room Visit' ? hit : [])
+            : Promise.resolve(undefined)
+        )
+
+        const parsed = parse(
+          await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+            attributePath: 'p.attr',
+            query: 'ER visit',
+          })
+        )
+
+        expect(parsed.matchedVia).toBe('alternate-query')
+        expect(parsed.values).toEqual(hit)
+      })
+
+      it('reports matchedVia "none" when neither the search nor any retry matched', async () => {
+        const store = makeStore()
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string) =>
+          type === 'loadValuesForAttributePath' ? Promise.resolve([]) : Promise.resolve(undefined)
+        )
+
+        const parsed = parse(
+          await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+            attributePath: 'p.attr',
+            query: 'telehealth',
+          })
+        )
+
+        // Distinct from "the whole column is below, pick one": nothing could be read
+        // at all, so the next move is a different attributePath.
+        expect(parsed.matchedVia).toBe('none')
+        expect(parsed.note).toContain('different attributePath')
       })
 
       it('does not re-read the domain when the search was merely TOO_MANY_RESULTS', async () => {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/cohortPatch.ts
@@ -1,0 +1,695 @@
+// Deterministic cohort patch applier for the WebMCP `pa_apply_cohort_patch` tool.
+//
+// The LLM emits typed *intent* (PatchOp[]) — never a hand-built bookmark tree —
+// and this applier mutates the IFR already in the Vuex store via the app's own
+// query actions. That reuses the exact validation/normalization the UI uses, so
+// AI-driven edits behave identically to wizard-driven ones.
+import type { Store } from 'vuex'
+import { getFieldAttrKey } from '../utils/dashboardFlowUtils'
+import { applyConstraintValue } from '../utils/applyConstraintValue'
+import {
+  restoreConstraintValue,
+  snapshotConstraintValue,
+  type ConstraintValueSnapshot,
+} from '../utils/constraintValueSnapshot'
+
+export type ConstraintValue =
+  | number
+  | string
+  | { from?: string; to?: string }
+  // conceptSetId may arrive as a number — d2e-mcp create_concept_set returns numeric ids.
+  | { conceptSetId: string | number; includeDescendants?: boolean; displayValue?: string }
+
+export type PatchOp =
+  | { op: 'add_card'; cardConfigPath: string; exclude?: boolean; ref?: string; orWith?: string }
+  | { op: 'add_constraint'; card: string; attributePath: string; value: ConstraintValue; operator?: string }
+  | { op: 'remove_card'; card: string }
+  | { op: 'remove_constraint'; card: string; attributePath: string }
+  | { op: 'set_card_join'; card: string; join: 'AND' | 'OR' }
+
+/** One OR-group of filter cards. Groups are AND-ed with each other. */
+export interface CardGroup {
+  cards: Array<{ filterCardId: string; name: string; exclude?: boolean }>
+}
+
+export interface ApplyCohortPatchResult {
+  applied: boolean
+  createdCards: string[]
+  /**
+   * What each add_constraint actually put on the cohort, read back from the store.
+   * The caller is an LLM that has to report the filters it applied — give it the
+   * committed state to report rather than its own intent.
+   */
+  appliedConstraints?: Array<{ card: string; attributePath: string; value: any }>
+  /** The resulting AND/OR structure: cards within a group are OR-ed, groups AND-ed. */
+  cardGroups?: CardGroup[]
+  error?: string
+}
+
+// A concept-set value is any object carrying a conceptSetId. Accept string OR number:
+// d2e-mcp returns numeric concept-set ids, and a number that slips through to the
+// generic text path gets String()'d into "[object Object]" (a broken filter → count "--").
+const isConceptSetValue = (
+  v: any
+): v is { conceptSetId: string | number; includeDescendants?: boolean; displayValue?: string } =>
+  !!v && typeof v === 'object' && (typeof v.conceptSetId === 'string' || typeof v.conceptSetId === 'number')
+
+// Rollback bookkeeping: created cards are deleted, removed constraints re-created,
+// prior constraint values and the chart's axis selection restored, grouping changes
+// undone. Cards removed by remove_card are the one thing revert cannot put back —
+// see applyCohortPatch.
+interface Rollback {
+  createdCardIds: string[]
+  priorConstraintValues: ConstraintValueSnapshot[]
+  createdConstraints: Array<{ filterCardId: string; constraintId: string }>
+  /**
+   * Constraints this patch DELETED (remove_constraint). Keyed by card + attribute
+   * key rather than by constraint id: the id dies with the constraint, so revert
+   * re-adds it and restores the snapshot onto whatever id the store hands back.
+   */
+  removedConstraints: Array<{ filterCardId: string; key: string; snapshot: ConstraintValueSnapshot }>
+  /** Cards this patch DELETED (remove_card). Not undone; see applyCohortPatch. */
+  removedCardIds: string[]
+  priorAxes: AxisSnapshot[]
+  /**
+   * Grouping (AND/OR) changes, newest last. Undone by applying the inverse
+   * toggle — the same pair of store actions the AND/OR buttons use — because the
+   * container ids change as containers are merged/split, so a recorded id would
+   * be stale by the time revert runs. `card` is the card the toggle acted on;
+   * finding its container again at revert time is what makes the inverse exact.
+   */
+  joinChanges: Array<{ card: string; undo: 'split' | 'merge' }>
+}
+
+interface AxisSnapshot {
+  id: number
+  props: { attributeId: string; filterCardId: string; key: string; binsize?: any }
+}
+
+// The store's deleteFilterCard clears every axis bound to the card id it is given,
+// so a rolled-back add_card takes the chart's axis selection with it. An axis-less
+// cohort is not a cosmetic problem: the bar-chart query then goes out with an empty
+// axisSelection and analytics-svc generates `MeasurePopulation AS (SELECT  FROM …)`,
+// which the DB rejects ("SELECT clause without selection list") — the cohort renders
+// "--" for every later edit until the builder is reset. Snapshot before, restore after.
+const snapshotAxes = (store: Store<any>): AxisSnapshot[] =>
+  ((store.getters.getAllAxes as any[]) ?? []).map((axis, id) => ({
+    id,
+    props: {
+      attributeId: axis?.props?.attributeId ?? '',
+      filterCardId: axis?.props?.filterCardId ?? '',
+      key: axis?.props?.key ?? '',
+      ...(typeof axis?.props?.binsize === 'undefined' ? {} : { binsize: axis.props.binsize }),
+    },
+  }))
+
+// ---------------------------------------------------------------------------
+// AND / OR grouping
+//
+// There is no "operator" field on a filter card. The builder expresses the
+// boolean structure through the SHAPE of the tree (see getIFR in
+// store/modules/query.ts): the cards inside one boolFilterContainer become
+// `BooleanContainers.Or(cards)`, and the containers themselves become
+// `BooleanContainers.And(containers)`. So:
+//
+//   same container   → OR   ("had Alzheimer's OR had sinusitis")
+//   separate containers → AND ("had Alzheimer's AND had sinusitis")
+//
+// `addFilterCard` with no boolFilterContainerId always opens a NEW container,
+// which is why an unqualified add_card is always an AND. To OR two cards they
+// must share a container — that is what add_card's `orWith` and `set_card_join`
+// do, via the same store actions the AND/OR buttons in the UI dispatch.
+// ---------------------------------------------------------------------------
+
+/** The Basic Data card's instance id is its config path (see createFilterCard). */
+const BASIC_DATA_CARD = 'patient'
+
+interface CardLocation {
+  containerId: string
+  /** Position of the container among the root container's children. */
+  containerIndex: number
+  /** Position of the card within its container (0 = first, i.e. no OR before it). */
+  indexInContainer: number
+  cards: string[]
+}
+
+const containerIdsOf = (store: Store<any>): string[] => {
+  const rootId = store.getters.getBoolContainerRoot?.()
+  return store.getters.getBoolContainer?.(rootId)?.props?.boolfiltercontainers ?? []
+}
+
+const cardsInContainer = (store: Store<any>, containerId: string): string[] =>
+  store.getters.getBoolFilterContainer?.(containerId)?.props?.filterCards ?? []
+
+function locateCard(store: Store<any>, filterCardId: string): CardLocation | undefined {
+  const containerIds = containerIdsOf(store)
+  for (let containerIndex = 0; containerIndex < containerIds.length; containerIndex += 1) {
+    const containerId = containerIds[containerIndex]
+    const cards = cardsInContainer(store, containerId)
+    const indexInContainer = cards.indexOf(filterCardId)
+    if (indexInContainer > -1) {
+      return { containerId, containerIndex, indexInContainer, cards }
+    }
+  }
+  return undefined
+}
+
+const isExclusionCard = (store: Store<any>, filterCardId: string): boolean =>
+  !!store.getters.getFilterCard?.(filterCardId)?.props?.excludeFilter
+
+/**
+ * The container a merge would fold into — the store's own rule: the nearest
+ * PRECEDING container of the same inclusion/exclusion kind
+ * (toggleFilterContainerBooleanCondition). Undefined when there is none.
+ */
+function previousContainerFor(store: Store<any>, loc: CardLocation): { id: string; cards: string[] } | undefined {
+  const containerIds = containerIdsOf(store)
+  const wantsExclusion = loc.cards.some(id => isExclusionCard(store, id))
+  for (let i = loc.containerIndex - 1; i >= 0; i -= 1) {
+    const cards = cardsInContainer(store, containerIds[i])
+    if (cards.some(id => isExclusionCard(store, id)) === wantsExclusion) {
+      return { id: containerIds[i], cards }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Guard the one grouping that is always wrong: OR-ing anything with Basic Data.
+ * Basic Data holds the demographics every cohort starts from, so
+ * `Or(patient, conditionOccurrence)` matches every patient the demographics
+ * alone match — the filter silently stops filtering. The UI can't express it
+ * either (BoolFilterContainer hides the 'patient' card from the OR list).
+ */
+function assertNotBasicData(cards: string[], what: string): void {
+  if (cards.includes(BASIC_DATA_CARD)) {
+    throw new Error(
+      `${what} would OR it with the Basic Data card, which matches every patient the demographics match — ` +
+        'the filter would stop filtering. OR interaction cards (Condition Occurrence, Drug Exposure, …) with ' +
+        'each other; demographics stay on Basic Data, which is always AND-ed with the rest.'
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Concept-set domain check
+//
+// Every `conceptSet` attribute is configured with the OMOP domain its concepts
+// must come from (`domainFilter`: "Condition", "Visit", "Drug", …) — that is what
+// the UI's concept-set picker filters the vocabulary by. A set built for one
+// domain matches nothing in another, so the same concept-set id cannot be
+// correct on two attributes whose domains differ.
+//
+// The failure this closes: asked to widen a cohort to "Alzheimer's OR an ER
+// visit", the model added the Visit card correctly and then filled its concept
+// set with the ALZHEIMER'S set it already had in context — it never resolved
+// "ER visit" at all. The cohort still computes, so nothing looks broken; it just
+// answers a different question. Same-domain reuse stays legal (the same
+// Condition set on a primary- and a secondary-diagnosis card is a real cohort).
+// ---------------------------------------------------------------------------
+
+function attributeDomain(store: Store<any>, attributePath: string): string {
+  try {
+    return store.getters.getMriFrontendConfig?.getAttributeByPath?.(attributePath)?.getDomainFilter?.() ?? ''
+  } catch {
+    // A path the config doesn't know is add_constraint's problem to report, not
+    // this check's — an unknown domain simply skips the comparison.
+    return ''
+  }
+}
+
+/**
+ * The first place this concept-set id is already filtered on under a DIFFERENT
+ * domain, or undefined when there is none. Same-domain reuse is legal, and an
+ * attribute whose domain the config doesn't state can't be judged either way.
+ */
+function findConceptSetDomainConflict(
+  store: Store<any>,
+  conceptSetId: string,
+  targetDomain: string
+): { card: string; attributePath: string; domain: string } | undefined {
+  for (const cardId of Object.keys(store.getters.getFilterCards?.() ?? {})) {
+    const constraints: any[] = store.getters.getFilterCardConstraints?.(cardId) ?? []
+    for (const constraint of constraints) {
+      if (constraint?.props?.type !== 'conceptSet') continue
+      const values: any[] = Array.isArray(constraint.props.value) ? constraint.props.value : []
+      if (!values.some(v => String(v?.value) === conceptSetId)) continue
+      const attributePath = constraint.props.attributePath
+      const domain = attributeDomain(store, attributePath)
+      if (domain && domain !== targetDomain) return { card: cardId, attributePath, domain }
+    }
+  }
+  return undefined
+}
+
+function assertConceptSetDomain(store: Store<any>, op: AddConstraintOp, conceptSetId: string): void {
+  const targetDomain = attributeDomain(store, op.attributePath)
+  if (!targetDomain) return
+  const conflict = findConceptSetDomainConflict(store, conceptSetId, targetDomain)
+  if (!conflict) return
+  throw new Error(
+    `Concept set ${conceptSetId} is already filtered on "${conflict.attributePath}" (card "${conflict.card}"), ` +
+      `whose concepts are ${conflict.domain}-domain, but "${op.attributePath}" takes ${targetDomain}-domain ` +
+      `concepts — one concept set cannot be both, so this would filter on the wrong term and match nothing. ` +
+      `Resolve what the user asked for on THIS card into its own value: list_concept_sets / search_concepts for ` +
+      `a ${targetDomain} concept set, or pa_search_attribute_values for a catalog attribute on this card. ` +
+      'Never carry a concept-set id over from a different filter.'
+  )
+}
+
+type AddConstraintOp = Extract<PatchOp, { op: 'add_constraint' }>
+
+// Fields that carry a constraint value but are only meaningful INSIDE `value`.
+// Seeing one at the top level of the op is the tell for the mistake below.
+const MISPLACED_VALUE_KEYS = ['conceptSetId', 'conceptSetIds', 'conceptId', 'conceptIds', 'from', 'to', 'values']
+
+const VALUE_SHAPE_HELP =
+  'Pass value: <number|string> for a basic attribute, { from, to } for a date range, or ' +
+  '{ conceptSetId, includeDescendants? } for a conceptSet attribute. ' +
+  'To clear a filter use remove_constraint, not an empty value.'
+
+/**
+ * Reject an add_constraint that carries nothing to set.
+ *
+ * This is the single most dangerous op shape in the applier: applyConstraintValue
+ * reads an empty value on a text/conceptSet attribute as "clear this filter", so
+ * the patch reports success and leaves a filter card with no constraint — the
+ * cohort then silently keeps every patient the filter was supposed to exclude.
+ * That is a clinical error dressed as a working cohort, so fail loudly instead.
+ */
+function assertHasValue(op: AddConstraintOp): void {
+  const v: any = op.value
+  const isEmpty =
+    typeof v === 'undefined' ||
+    v === null ||
+    (typeof v === 'string' && v.trim() === '') ||
+    (Array.isArray(v) && v.length === 0) ||
+    (typeof v === 'object' && !Array.isArray(v) && Object.keys(v).length === 0)
+  if (!isEmpty) return
+
+  const misplaced = MISPLACED_VALUE_KEYS.filter(k => k in (op as any))
+  throw new Error(
+    `add_constraint for "${op.attributePath}" has no value. ` +
+      (misplaced.length
+        ? `Found ${misplaced.join(', ')} at the top level of the op — ${
+            misplaced.length > 1 ? 'they belong' : 'it belongs'
+          } inside \`value\`. `
+        : '') +
+      VALUE_SHAPE_HELP
+  )
+}
+
+/**
+ * Post-condition for add_constraint: the value is really on the constraint now.
+ *
+ * The input check above catches the shapes we know about; this catches the rest.
+ * Any normalization that quietly resolves to "no value" must fail the patch rather
+ * than leave an empty filter behind and report success.
+ */
+function assertValueLanded(store: Store<any>, filterCardId: string, key: string, op: AddConstraintOp): any {
+  const props = store.getters.getConstraintForAttribute?.({ filterCardId, key })?.props
+  // Date constraints live in fromDate/toDate, everything else in a value array.
+  if (Array.isArray(props?.value) && props.value.length > 0) {
+    return props.value
+  }
+  if (typeof props?.fromDate?.value !== 'undefined' || typeof props?.toDate?.value !== 'undefined') {
+    return { from: props?.fromDate?.value, to: props?.toDate?.value }
+  }
+  throw new Error(
+    `Constraint for "${op.attributePath}" ended up empty after applying ${JSON.stringify(op.value)}. ` +
+      VALUE_SHAPE_HELP
+  )
+}
+
+/**
+ * Apply a list of typed patch ops to the live cohort in `store`.
+ *
+ * Atomic, with one documented exception: if any op fails, everything this patch
+ * added (cards, constraints, values) or regrouped is undone, a constraint it
+ * removed is put back, and the error is rethrown. A card removed by `remove_card`
+ * is NOT restored — re-adding it would mint a new instance id and lose the
+ * constraints that hung off it, and a half-restored card is a worse lie than a
+ * missing one. So put `remove_card` last in a patch, or send it on its own.
+ */
+export async function applyCohortPatch(store: Store<any>, patchOps: PatchOp[]): Promise<ApplyCohortPatchResult> {
+  if (!Array.isArray(patchOps) || patchOps.length === 0) {
+    throw new Error('patchOps must be a non-empty array')
+  }
+  const dispatch = (action: string, payload?: unknown) => store.dispatch(action, payload)
+
+  // ref (local handle from add_card) -> real filterCardId, so later ops can
+  // target a card created earlier in the same patch.
+  const refMap = new Map<string, string>()
+  const rollback: Rollback = {
+    createdCardIds: [],
+    priorConstraintValues: [],
+    createdConstraints: [],
+    removedConstraints: [],
+    removedCardIds: [],
+    priorAxes: snapshotAxes(store),
+    joinChanges: [],
+  }
+
+  const resolveCard = (card: string): string => {
+    const id = refMap.get(card) ?? card
+    const cards = store.getters.getFilterCards?.() ?? {}
+    if (!cards[id]) {
+      throw new Error(`Unknown card "${card}". Create it with add_card or pass a real filterCardId.`)
+    }
+    return id
+  }
+
+  const appliedConstraints: NonNullable<ApplyCohortPatchResult['appliedConstraints']> = []
+
+  await dispatch('holdFireRequest')
+  try {
+    for (const rawOp of patchOps) {
+      await applyOne(dispatch, store, rawOp, refMap, rollback, resolveCard, appliedConstraints)
+    }
+  } catch (err) {
+    await revert(dispatch, rollback, store)
+    await dispatch('releaseFireRequest')
+    throw err instanceof Error ? err : new Error(String(err))
+  }
+
+  // Grouping cards together runs the store's resetAxes, which clears every axis
+  // bound to a card in a container that now holds more than one card. That is
+  // fine when the user clicks the OR button (they can re-pick), but here it
+  // would leave the cohort with an empty axisSelection — analytics-svc then
+  // emits `SELECT  FROM …` and the DB rejects it, so the count reads "--".
+  // Put back only the axes whose card still exists.
+  await restoreClearedAxes(dispatch, store, rollback.priorAxes)
+
+  await dispatch('releaseFireRequest')
+  await dispatch('setFireRequest')
+  await dispatch('refreshPatientCount')
+  return {
+    applied: true,
+    createdCards: [...rollback.createdCardIds],
+    appliedConstraints,
+    cardGroups: describeCardGroups(store),
+  }
+}
+
+/**
+ * The current AND/OR structure, read back from the store after the patch.
+ *
+ * The caller is an LLM that has to tell the user what the cohort now means, and
+ * "OR" is not visible anywhere in `appliedConstraints` — it lives in how the
+ * cards are grouped. Reporting it here is also what lets a follow-up patch
+ * target the right card without re-reading the whole cohort.
+ */
+export function describeCardGroups(store: Store<any>): CardGroup[] {
+  return containerIdsOf(store)
+    .map(containerId => ({
+      // Cards within a group are OR-ed; the groups themselves are AND-ed.
+      cards: cardsInContainer(store, containerId).map(id => ({
+        filterCardId: id,
+        name: store.getters.getFilterCard?.(id)?.props?.name ?? id,
+        ...(isExclusionCard(store, id) ? { exclude: true } : {}),
+      })),
+    }))
+    .filter(group => group.cards.length > 0)
+}
+
+async function restoreClearedAxes(
+  dispatch: (a: string, p?: unknown) => Promise<any>,
+  store: Store<any>,
+  priorAxes: AxisSnapshot[]
+): Promise<void> {
+  const cards = store.getters.getFilterCards?.() ?? {}
+  const current = snapshotAxes(store)
+  for (const axis of priorAxes) {
+    const stillBound = current[axis.id]?.props?.attributeId
+    if (stillBound || !axis.props.attributeId || !cards[axis.props.filterCardId]) continue
+    try {
+      await dispatch('setAxisValue', { id: axis.id, props: axis.props })
+    } catch (e) {
+      console.error('[cohortPatch] restoring axis after grouping change failed', e)
+    }
+  }
+}
+
+async function applyOne(
+  dispatch: (a: string, p?: unknown) => Promise<any>,
+  store: Store<any>,
+  op: PatchOp,
+  refMap: Map<string, string>,
+  rollback: Rollback,
+  resolveCard: (card: string) => string,
+  applied: NonNullable<ApplyCohortPatchResult['appliedConstraints']>
+): Promise<void> {
+  switch (op.op) {
+    case 'add_card': {
+      // Fail fast on a bad path with a recoverable message, instead of a generic
+      // store error (or a silently-malformed card). Skip when config isn't loaded.
+      const config = store.getters.getMriFrontendConfig
+      if (config?.getFilterCards) {
+        const validPaths: string[] = (config.getFilterCards() ?? []).map((c: any) => c.getConfigPath())
+        if (!validPaths.includes(op.cardConfigPath)) {
+          throw new Error(
+            `Unknown cardConfigPath "${op.cardConfigPath}". Use pa_list_filter_options (or the ` +
+              'validFilterOptions returned on this error) for the valid card paths.'
+          )
+        }
+      }
+      // Single-instance cards (Basic Data) must never be added twice. An indexed
+      // card gets an instance id with a trailing number
+      // ("…conditionoccurrence.1"), so a card whose instance id IS the config path
+      // is the singleton — and the store would happily create a SECOND card under
+      // that same id. The IFR then carries "patient" in two bool containers, so
+      // every constraint on it is emitted twice (`age < 100 AND age < 100`) and
+      // deleting either copy clears the chart axes bound to the id that survives.
+      // A model that adds Basic Data before constraining Age/Gender is doing the
+      // reasonable thing; reuse what is already there.
+      const existing = store.getters.getFilterCards?.() ?? {}
+      if (existing[op.cardConfigPath]) {
+        if (op.ref) refMap.set(op.ref, op.cardConfigPath)
+        return
+      }
+      // `orWith` puts the new card in the SAME bool container as an existing one,
+      // which is how the builder represents OR. Without it the store opens a new
+      // container and the card is AND-ed (the default, and the right one for
+      // "sinusitis AND a drug exposure").
+      let boolFilterContainerId: string | undefined
+      if (op.orWith) {
+        const target = resolveCard(op.orWith)
+        assertNotBasicData([target], `add_card orWith:"${op.orWith}"`)
+        const loc = locateCard(store, target)
+        if (!loc) {
+          throw new Error(
+            `add_card orWith:"${op.orWith}" — card "${target}" is not in the cohort's filter tree, so there is ` +
+              'no group to join. Pass the filterCardId of a card that is on the cohort, or an add_card `ref` ' +
+              'created earlier in this same patch.'
+          )
+        }
+        // Not just the target: joining its GROUP ORs the new card with every card
+        // in it, so Basic Data sharing that group is the same silent widening.
+        assertNotBasicData(loc.cards, `add_card orWith:"${op.orWith}"`)
+        if ((op.exclude ?? false) !== isExclusionCard(store, target)) {
+          throw new Error(
+            `add_card orWith:"${op.orWith}" cannot OR an ${op.exclude ? 'exclusion' : 'inclusion'} card with an ` +
+              `${op.exclude ? 'inclusion' : 'exclusion'} one — they are separate sections of the builder. ` +
+              'OR cards of the same kind.'
+          )
+        }
+        boolFilterContainerId = loc.containerId
+      }
+      const filterCardId = (await dispatch('addFilterCard', {
+        configPath: op.cardConfigPath,
+        isExclusion: op.exclude ?? false,
+        ...(boolFilterContainerId ? { boolFilterContainerId } : {}),
+      })) as string
+      rollback.createdCardIds.push(filterCardId)
+      if (op.ref) refMap.set(op.ref, filterCardId)
+      return
+    }
+    case 'set_card_join': {
+      // Change how a card ALREADY on the cohort combines with the card before it.
+      // Both branches dispatch exactly what the AND/OR buttons dispatch, so an
+      // AI-driven regroup and a click produce the same tree.
+      const join = String((op as any).join ?? '').toUpperCase()
+      if (join !== 'AND' && join !== 'OR') {
+        throw new Error(`set_card_join: join must be "AND" or "OR" (got ${JSON.stringify((op as any).join)}).`)
+      }
+      const filterCardId = resolveCard(op.card)
+      if (filterCardId === BASIC_DATA_CARD) {
+        throw new Error(
+          'set_card_join: the Basic Data card is always AND-ed with the rest of the cohort — its demographics ' +
+            'apply to every patient the other cards match. Regroup the interaction cards instead.'
+        )
+      }
+      const loc = locateCard(store, filterCardId)
+      if (!loc) {
+        throw new Error(`set_card_join: card "${op.card}" is not in the cohort's filter tree.`)
+      }
+      if (join === 'OR') {
+        // Already OR-ed with the card before it in the same group: nothing to do.
+        if (loc.indexInContainer > 0) return
+        const prev = previousContainerFor(store, loc)
+        if (!prev) {
+          throw new Error(
+            `set_card_join: "${filterCardId}" is the first filter card, so there is nothing before it to OR it ` +
+              'with. Set the join on the LATER card of the pair.'
+          )
+        }
+        assertNotBasicData(prev.cards, `set_card_join OR on "${filterCardId}"`)
+        // Merges this card's container into the previous one → they share a
+        // container → Or(...) in the IFR.
+        await dispatch('toggleFilterContainerBooleanCondition', {
+          filterContainerId: loc.containerId,
+          parentId: store.getters.getBoolContainerRoot?.(),
+        })
+        rollback.joinChanges.push({ card: filterCardId, undo: 'split' })
+        return
+      }
+      // AND: already the first card of its own group → already AND-ed.
+      if (loc.indexInContainer === 0) return
+      // Splits this card (and any card after it in the group) into a new
+      // container → AND with what precedes it.
+      await dispatch('toggleFilterBooleanCondition', { filterCardId, parentId: loc.containerId })
+      rollback.joinChanges.push({ card: filterCardId, undo: 'merge' })
+      return
+    }
+    case 'add_constraint': {
+      assertHasValue(op)
+      // Before anything is mutated: a concept set that belongs to another
+      // domain is a wrong-cohort bug, not a rendering one.
+      if (isConceptSetValue(op.value)) {
+        assertConceptSetDomain(store, op, String(op.value.conceptSetId))
+      }
+      const filterCardId = resolveCard(op.card)
+      const key = getFieldAttrKey(op.attributePath)
+      let constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      if (constraint) {
+        // Snapshots the date slot as well as `value` — see ConstraintValueSnapshot.
+        rollback.priorConstraintValues.push(snapshotConstraintValue(constraint))
+      } else {
+        const constraintId = (await dispatch('addFilterCardConstraint', { filterCardId, key })) as string
+        rollback.createdConstraints.push({ filterCardId, constraintId })
+        constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      }
+      if (!constraint) {
+        throw new Error(`Could not create constraint for "${op.attributePath}" on card "${op.card}".`)
+      }
+      if (isConceptSetValue(op.value)) {
+        await dispatch('updateConstraintValue', {
+          constraintId: constraint.id,
+          value: [
+            {
+              value: String(op.value.conceptSetId),
+              text: op.value.displayValue ?? String(op.value.conceptSetId),
+              display_value: op.value.displayValue ?? String(op.value.conceptSetId),
+              includeDescendants: op.value.includeDescendants ?? false,
+            },
+          ],
+        })
+      } else {
+        await applyConstraintValue(dispatch, constraint, op.value, op.operator ?? '=')
+      }
+      applied.push({
+        card: filterCardId,
+        attributePath: op.attributePath,
+        value: assertValueLanded(store, filterCardId, key, op),
+      })
+      return
+    }
+    case 'remove_constraint': {
+      const filterCardId = resolveCard(op.card)
+      const key = getFieldAttrKey(op.attributePath)
+      const constraint = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      if (constraint) {
+        // Snapshot before deleting: a later op can still fail the patch, and atomic
+        // has to mean the filter the user had comes back — not merely that nothing
+        // new was added. A dropped filter that survives a failed patch leaves the
+        // cohort permanently wider than the user was told it is.
+        rollback.removedConstraints.push({ filterCardId, key, snapshot: snapshotConstraintValue(constraint) })
+        await dispatch('deleteFilterCardConstraint', { filterCardId, constraintId: constraint.id })
+      }
+      return
+    }
+    case 'remove_card': {
+      const filterCardId = resolveCard(op.card)
+      await dispatch('deleteFilterCard', { filterCardId })
+      rollback.removedCardIds.push(filterCardId)
+      return
+    }
+    default:
+      throw new Error(`Unknown patch op: ${JSON.stringify((op as any).op)}`)
+  }
+}
+
+// Undo a partially-applied patch, mirroring revertFieldChanges in
+// useDashboardFlow: restore prior constraint values, drop constraints and cards
+// created during this patch, and put the chart's axis selection back the way it
+// was. Best-effort — individual failures are swallowed so one bad undo can't
+// mask the original error.
+async function revert(
+  dispatch: (a: string, p?: unknown) => Promise<any>,
+  rollback: Rollback,
+  store: Store<any>
+): Promise<void> {
+  // Grouping first, while the cards this patch created are still present: a
+  // merge/split is expressed in terms of a card's CURRENT container, so undoing
+  // it after the card is gone would have nothing to locate.
+  for (const { card, undo } of rollback.joinChanges.reverse()) {
+    try {
+      const loc = locateCard(store, card)
+      if (!loc) continue
+      if (undo === 'split' && loc.indexInContainer > 0) {
+        await dispatch('toggleFilterBooleanCondition', { filterCardId: card, parentId: loc.containerId })
+      } else if (undo === 'merge' && loc.indexInContainer === 0 && previousContainerFor(store, loc)) {
+        await dispatch('toggleFilterContainerBooleanCondition', {
+          filterContainerId: loc.containerId,
+          parentId: store.getters.getBoolContainerRoot?.(),
+        })
+      }
+    } catch (e) {
+      console.error('[cohortPatch] revert join change failed', e)
+    }
+  }
+  for (const snapshot of rollback.priorConstraintValues.reverse()) {
+    await restoreConstraintValue(dispatch, snapshot)
+  }
+  // Drop what the patch created BEFORE putting back what it removed.
+  for (const { filterCardId, constraintId } of rollback.createdConstraints.reverse()) {
+    try {
+      await dispatch('deleteFilterCardConstraint', { filterCardId, constraintId })
+    } catch (e) {
+      console.error('[cohortPatch] revert deleteFilterCardConstraint failed', e)
+    }
+  }
+  // Put back what remove_constraint took. Before the created cards are deleted
+  // below, so the card a constraint belongs to is still there to re-add it to.
+  for (const { filterCardId, key, snapshot } of rollback.removedConstraints.reverse()) {
+    try {
+      await dispatch('addFilterCardConstraint', { filterCardId, key })
+      const recreated = store.getters.getConstraintForAttribute?.({ filterCardId, key })
+      if (recreated) {
+        await restoreConstraintValue(dispatch, { ...snapshot, constraintId: recreated.id })
+      }
+    } catch (e) {
+      console.error('[cohortPatch] revert remove_constraint failed', e)
+    }
+  }
+  for (const filterCardId of rollback.createdCardIds.reverse()) {
+    try {
+      await dispatch('deleteFilterCard', { filterCardId })
+    } catch (e) {
+      console.error('[cohortPatch] revert deleteFilterCard failed', e)
+    }
+  }
+  // Last: deleteFilterCard above cleared any axis pointing at a card it removed,
+  // so the axis selection is restored after the cards, not before.
+  for (const { id, props } of rollback.priorAxes) {
+    // Except an axis bound to a card remove_card deleted: that card is gone for
+    // good (see applyCohortPatch), and re-pointing the chart at it would send the
+    // query out with a filterCardId the IFR no longer contains.
+    if (props.filterCardId && rollback.removedCardIds.includes(props.filterCardId)) continue
+    try {
+      await dispatch('setAxisValue', { id, props })
+    } catch (e) {
+      console.error('[cohortPatch] revert setAxisValue failed', e)
+    }
+  }
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/paToolBridge.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/paToolBridge.ts
@@ -1,0 +1,96 @@
+// In-page bridge that exposes the PA `pa_*` tools to the portal's AI assistant
+// drawer (React, apps/portal).
+//
+// Why this exists alongside registerPaTools: `document.modelContext.registerTool`
+// hands the tools to the *browser agent* (Chrome's WebMCP surface). It offers no
+// way for other page script to enumerate or invoke them — `modelContextTesting`
+// is a flag-gated test harness, not a production API. The portal drawer runs in
+// the same window but a different single-spa bundle, with no shared module graph,
+// so it needs its own channel. Both surfaces are fed by the SAME createPaTools()
+// array, so a tool never exists on one and not the other.
+//
+// The consumer side of this contract lives in the portal bundle; a change to the
+// registry shape or the change event has to land on both sides together.
+//
+// Shape: a registry object on `window`, not an event round-trip. Consumers must
+// read `window.__d2ePaTools` at call time and never cache it — PA deletes the
+// registry on unmount, so a re-read is what makes "PA went away mid-conversation"
+// return a clean error instead of driving a dead store.
+import type { Store } from 'vuex'
+import { createPaTools, type PaComponentHooks, type PaToolResult } from './webmcpServer'
+
+// Fired whenever the registry appears or disappears (PA mount/unmount). The
+// drawer uses it to enable/disable live cohort editing without polling.
+export const PA_TOOLS_CHANGED_EVENT = 'd2e-pa-tools-changed'
+
+export interface PaToolDescriptor {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+}
+
+export interface PaToolRegistry {
+  // Bump when the shape below changes incompatibly; the portal side refuses a
+  // version it does not understand rather than calling tools blind.
+  version: 1
+  // The dataset PA currently has loaded. The drawer compares it against the
+  // portal's active dataset before letting the model edit — a cohort edited
+  // against a different dataset than the user thinks is a silent clinical error,
+  // not a UI glitch.
+  datasetId: string | null
+  list: () => PaToolDescriptor[]
+  call: (name: string, args?: Record<string, unknown>) => Promise<PaToolResult>
+}
+
+declare global {
+  interface Window {
+    __d2ePaTools?: PaToolRegistry
+  }
+}
+
+function announce(): void {
+  window.dispatchEvent(new CustomEvent(PA_TOOLS_CHANGED_EVENT, { detail: { available: !!window.__d2ePaTools } }))
+}
+
+/**
+ * Publish the PA tools for the portal drawer. Returns a teardown function to
+ * call from beforeUnmount — pair it with registerPaTools' teardown.
+ */
+export function publishPaTools(store: Store<any>, hooks: PaComponentHooks = {}): () => void {
+  const tools = createPaTools(store, hooks)
+
+  const registry: PaToolRegistry = {
+    version: 1,
+    get datasetId() {
+      // A getter, not a snapshot: the user can switch datasets while PA stays
+      // mounted, and a stale id would defeat the mismatch guard it exists for.
+      return store.getters.getSelectedDataset?.id ?? null
+    },
+    list: () =>
+      tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    call: async (name, args) => {
+      const tool = tools.find(t => t.name === name)
+      if (!tool) {
+        throw new Error(`Unknown PA tool "${name}". Available: ${tools.map(t => t.name).join(', ')}.`)
+      }
+      return tool.execute(args)
+    },
+  }
+
+  window.__d2ePaTools = registry
+  announce()
+
+  return () => {
+    // Only clear our own registry: a remount can publish a new one before the
+    // old teardown runs, and deleting that would leave the drawer thinking PA
+    // is gone while it is on screen.
+    if (window.__d2ePaTools === registry) {
+      delete window.__d2ePaTools
+      announce()
+    }
+  }
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/valueResolution.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/valueResolution.ts
@@ -1,0 +1,380 @@
+// Query → stored-value matching for pa_search_attribute_values.
+//
+// A zero-row search is NOT evidence that a value is absent. The /values search runs in
+// the database: a HANA/SQL LIKE is case-sensitive, and it matches the stored
+// token rather than the clinical word for it — so "women" misses "FEMALE". When a
+// search comes back empty, the tool re-reads the attribute's UNFILTERED domain and
+// matches it HERE.
+//
+// ---------------------------------------------------------------------------
+// This is the browser-side twin of the mcp-server's cohortValueResolver.ts,
+// which does the same job for the deep-link surface (the tools that exist when
+// PA is NOT mounted). That file is not in this branch yet. The two cannot share
+// a module — that one is Deno, this one is bundled by Vite, and nothing crosses
+// that boundary in this repo — so they are kept in step by a shared table of
+// query→expected-row vectors that both suites read. Until the backend lands,
+// that table lives in __tests__/valueResolution.test.ts; the header there says
+// where it moves to.
+//
+// Exported names deliberately match the BE file so the two are diffable side by
+// side.
+// ---------------------------------------------------------------------------
+
+/** A row as the /values endpoint returns it. `text`/`display_value` are labels. */
+export interface ValueRow {
+  value?: string | number
+  text?: string
+  display_value?: string
+}
+
+// pa_search_attribute_values caps how many tokens it returns. A coded catalog
+// search (a drug/condition on a non-OMOP dataset) routinely matches thousands of
+// tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form —
+// e.g. "gemfibrozil" resolved to 1,602 tokens — which floods the model's context
+// and makes it guess which one to pick. Return a bounded slice + a count + a
+// routing note instead. Callers can raise `limit` (bounded by MAX) if they truly
+// need the full list.
+export const DEFAULT_VALUE_LIMIT = 50
+export const MAX_VALUE_LIMIT = 200
+
+/**
+ * How the returned rows were arrived at. Reported to the model because "these
+ * are matches", "these are every value the column can take" and "the column
+ * could not be read at all" call for completely different next moves.
+ */
+export type MatchedVia =
+  /** The /values endpoint's own search returned these rows. */
+  | 'search'
+  /** The search found nothing; these matched when we scanned the full list here. */
+  | 'domain-scan'
+  /** The search found nothing until it was retried with a rewritten query. */
+  | 'alternate-query'
+  /** No query, OR nothing matched — these rows ARE the complete value list. */
+  | 'domain'
+  /** Nothing matched and the domain could not be enumerated. */
+  | 'none'
+
+export function normalizeToken(raw: unknown): string {
+  return String(raw ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s._\-/(),]+/g, ' ')
+    .trim()
+}
+
+/**
+ * Interchangeable tokens for the low-cardinality demographic columns every
+ * cohort starts from. A dataset stores sex as "FEMALE", "Female", "F" or a
+ * concept id depending on the backend, and the user says "women".
+ *
+ * Deliberately narrow — demographics and booleans only. Clinical terms are NOT
+ * synonym-expanded: a near-miss concept is a silent clinical error, so those
+ * still route through concept sets / the vocabulary tools.
+ */
+const SYNONYM_GROUPS: string[][] = [
+  ['female', 'f', 'fem', 'woman', 'women', 'girl', 'girls'],
+  ['male', 'm', 'man', 'men', 'boy', 'boys'],
+  ['unknown', 'u', 'unk', 'not known', 'no matching concept'],
+  ['other', 'o'],
+  ['yes', 'y', 'true'],
+  ['no', 'n', 'false'],
+]
+
+/**
+ * Expansions that cannot be derived from the row being matched, because the row
+ * does not spell the abbreviation out in full: a column storing "Intensive Care"
+ * gives you nothing to recover the "U" of ICU from, and "IP"/"OP"/"AMB" are
+ * contractions of a single word rather than initials of several.
+ *
+ * This is a SEED, not the rule. An abbreviation whose expansion IS in the row is
+ * matched structurally by `abbreviates()` below, so unlisted acronyms (NICU,
+ * ASC, LTACH, whatever a given dataset uses) resolve without an entry here. The
+ * seeds also carry the blind-retry path (`alternateQueries`), where there are no
+ * rows to derive anything from — an abbreviation cannot be inverted into a
+ * search term without a lexicon.
+ *
+ * Care settings only: administrative vocabulary, not clinical judgement.
+ * Clinical abbreviations (MI, CA, RA, MS, …) are deliberately absent — those are
+ * genuinely ambiguous, and expanding one to a near-miss concept is a silent
+ * clinical error, so they route through concept sets and the vocabulary tools
+ * where the user gets to confirm what was chosen.
+ */
+const ABBREVIATION_SEEDS: Record<string, string[]> = {
+  er: ['emergency room', 'emergency department', 'emergency'],
+  ed: ['emergency department', 'emergency room', 'emergency'],
+  ip: ['inpatient'],
+  op: ['outpatient'],
+  icu: ['intensive care unit', 'intensive care'],
+  snf: ['skilled nursing facility'],
+  ltc: ['long term care'],
+  amb: ['ambulatory'],
+}
+
+const tokensOf = (s: string): string[] => normalizeToken(s).split(' ').filter(Boolean)
+
+// ---------------------------------------------------------------------------
+// Which words in a query carry signal
+//
+// A word is filler when it fails to tell one row of THIS column from another —
+// which is a property of the column, not of the word. "Visit" is filler in a
+// visit-type column because every row has it, and is the whole answer in a
+// column where one row does. So it is measured on the rows being matched rather
+// than read off a list of words someone thought of in advance.
+// ---------------------------------------------------------------------------
+
+/**
+ * Grammar words. No column anywhere is discriminated by these, so they are the
+ * only words hard-coded.
+ */
+const STOP_WORDS = new Set(['the', 'of', 'and', 'or', 'a', 'an', 'for', 'to', 'with'])
+
+/**
+ * The fallback for when there is no column to learn from: the blind-retry path,
+ * and columns with too few rows for a frequency to mean anything. Rows overrule
+ * these wherever there are enough of them.
+ */
+const SEED_FILLER = new Set([
+  'visit',
+  'visits',
+  'encounter',
+  'encounters',
+  'patient',
+  'patients',
+  'concept',
+  'name',
+  'value',
+])
+
+/** A word this share of the column's rows carry cannot tell you WHICH row. */
+const FILLER_DOCUMENT_FREQUENCY = 0.6
+/** Under this many rows a frequency is noise, so the seeds stand in. */
+const MIN_ROWS_FOR_FREQUENCY = 4
+
+/** How often each word occurs across the rows being ranked. */
+export interface ValueCorpus {
+  size: number
+  /** word -> number of rows containing it */
+  documentFrequency: Map<string, number>
+}
+
+export function buildCorpus(rowTexts: string[][]): ValueCorpus {
+  const documentFrequency = new Map<string, number>()
+  for (const texts of rowTexts) {
+    for (const token of new Set(texts.flatMap(tokensOf))) {
+      documentFrequency.set(token, (documentFrequency.get(token) ?? 0) + 1)
+    }
+  }
+  return { size: rowTexts.length, documentFrequency }
+}
+
+/** Only ever used to LOOSEN a match, never to reject a candidate. */
+function isFiller(token: string, corpus?: ValueCorpus): boolean {
+  if (STOP_WORDS.has(token)) return true
+  if (corpus && corpus.size >= MIN_ROWS_FOR_FREQUENCY) {
+    const df = corpus.documentFrequency.get(token) ?? 0
+    return df / corpus.size >= FILLER_DOCUMENT_FREQUENCY
+  }
+  return SEED_FILLER.has(token)
+}
+
+// ---------------------------------------------------------------------------
+// Abbreviations, derived from the two strings rather than listed
+// ---------------------------------------------------------------------------
+
+/** ["emergency", "room"] -> "er" */
+const initialsOf = (words: string[]): string => words.map(w => w[0]).join('')
+
+/** Value labels are a few words; a runaway input is not. */
+const MAX_ABBREVIATED_WORDS = 5
+
+/**
+ * Does the query read as an abbreviation of the row? Reading the row from its
+ * FIRST word, each query word must consume either the next row word or the
+ * INITIALS of the next two or more — "er visit" is "Emergency Room" followed by
+ * "Visit". At least one word must actually be abbreviated, so a plain
+ * word-subset stays at its own (lower) tier.
+ *
+ * The row may say more at the END than the query does (an acronym rarely covers
+ * a value's trailing "Visit"), but nothing may be skipped before or between:
+ * initials taken from the middle of a row let an acronym claim rows it does not
+ * name — "ICU" would take "Neonatal Intensive Care Unit" — and a near-miss value
+ * is a silent clinical error. Precision over recall: a row this misses is still
+ * shown to the caller, because nothing matching returns the whole column.
+ */
+function abbreviates(queryWords: string[], rowWords: string[]): boolean {
+  if (!queryWords.length || !rowWords.length) return false
+  if (rowWords.length > 12) return false
+
+  const walk = (qi: number, ri: number, abbreviated: boolean): boolean => {
+    if (qi === queryWords.length) return abbreviated
+    if (ri === rowWords.length) return false
+    const word = queryWords[qi]
+    if (word === rowWords[ri] && walk(qi + 1, ri + 1, abbreviated)) return true
+    const span = Math.min(MAX_ABBREVIATED_WORDS, rowWords.length - ri)
+    for (let k = 2; k <= span; k += 1) {
+      if (word === initialsOf(rowWords.slice(ri, ri + k)) && walk(qi + 1, ri + k, true)) return true
+    }
+    return false
+  }
+  return walk(0, 0, false)
+}
+
+/** A code is short and alphabetic; "9201" and "Female" are not codes. */
+const CODE_PATTERN = /^[a-z]{1,4}$/
+
+/**
+ * Is the row the term's CODE? Columns store "F" for Female, "S" for Single,
+ * "ICU" for Intensive Care Unit — the same initials rule read in the other
+ * direction, which is what makes it cover any coded column rather than the
+ * demographic ones a synonym table can enumerate.
+ */
+function isCodeFor(haystack: string, queryWords: string[]): boolean {
+  if (!CODE_PATTERN.test(haystack)) return false
+  if (haystack.length !== queryWords.length) return false
+  // A one- or two-letter query matching a one- or two-letter row is exactness,
+  // not an abbreviation, and it is handled a tier above.
+  if (queryWords.some(w => w.length < 3)) return false
+  return haystack === initialsOf(queryWords)
+}
+
+/**
+ * Everything a query might legitimately be stored as.
+ *
+ * `exact` are matched by equality only — a two-letter synonym like "f" would
+ * substring-match half the column. `phrases` (3+ chars) may also match as a
+ * substring.
+ */
+export interface QueryExpansion {
+  normalized: string
+  /** The words of the query as written, for the abbreviation rules. */
+  queryWords: string[]
+  exact: string[]
+  phrases: string[]
+  /** Distinctive (non-filler) token sets, one per variant. */
+  tokenSets: string[][]
+}
+
+/**
+ * `corpus` is the column being matched against, and is what makes filler a
+ * measurement rather than a guess. Omit it on the blind-retry path, where there
+ * is no column to measure.
+ */
+export function expandQuery(query: string, corpus?: ValueCorpus): QueryExpansion {
+  const normalized = normalizeToken(query)
+  const variants = new Set<string>()
+  if (normalized) variants.add(normalized)
+
+  // Demographic synonyms, whole-query only ("women" -> "female").
+  const group = SYNONYM_GROUPS.find(g => g.includes(normalized))
+  for (const s of group ?? []) variants.add(s)
+
+  // Seeded abbreviations, expanded in place ("er visit" -> "emergency room
+  // visit") and standalone ("emergency room"), so both a phrase match and a
+  // token match can land. Abbreviations the row spells out need no seed — see
+  // `abbreviates`.
+  const tokens = tokensOf(normalized)
+  for (let i = 0; i < tokens.length; i += 1) {
+    for (const expansion of ABBREVIATION_SEEDS[tokens[i]] ?? []) {
+      const replaced = [...tokens]
+      replaced[i] = expansion
+      variants.add(replaced.join(' '))
+      variants.add(expansion)
+    }
+  }
+
+  const all = [...variants]
+  const distinctive = (variant: string): string[] => {
+    const words = tokensOf(variant)
+    const kept = words.filter(t => !isFiller(t, corpus))
+    // A query made entirely of the column's common words still has to reach
+    // something; a weak match beats reporting the value absent.
+    return kept.length ? kept : words
+  }
+
+  return {
+    normalized,
+    queryWords: tokens,
+    exact: all,
+    phrases: all.filter(v => v.length >= 3),
+    tokenSets: all.map(distinctive).filter(ts => ts.length > 0),
+  }
+}
+
+/**
+ * How well a row answers the query. Lower is better; `undefined` is no match.
+ *  0 the row IS the term                  3 every distinctive word is present
+ *  1 the row contains the term            4 some distinctive word is present
+ *  2 the term abbreviates the row, or the row is the term's code
+ */
+export function rankValueRow(row: ValueRow, ex: QueryExpansion): number | undefined {
+  const haystacks = [row?.text, row?.display_value, row?.value].map(normalizeToken).filter(Boolean)
+  if (!haystacks.length) return undefined
+  if (!ex.normalized) return undefined
+
+  if (haystacks.some(h => ex.exact.includes(h))) return 0
+  if (haystacks.some(h => ex.phrases.some(v => h.includes(v)))) return 1
+  if (haystacks.some(h => abbreviates(ex.queryWords, tokensOf(h)) || isCodeFor(h, ex.queryWords))) return 2
+
+  const haystackTokens = haystacks.flatMap(h => h.split(' ').filter(Boolean))
+  const has = (t: string) => haystackTokens.includes(t)
+  if (ex.tokenSets.some(ts => ts.every(has))) return 3
+  if (ex.tokenSets.some(ts => ts.some(t => t.length >= 3 && has(t)))) return 4
+  return undefined
+}
+
+export interface RankedValue {
+  row: ValueRow
+  rank: number
+}
+
+/** Rows that match `query`, best first (stable within a rank). */
+export function rankValues(rows: ValueRow[], query: string): RankedValue[] {
+  const corpus = buildCorpus(
+    rows.map(r => [String(r?.text ?? ''), String(r?.display_value ?? ''), String(r?.value ?? '')])
+  )
+  const ex = expandQuery(query, corpus)
+  return rows
+    .map(row => ({ row, rank: rankValueRow(row, ex) }))
+    .filter((m): m is RankedValue => m.rank !== undefined)
+    .sort((a, b) => a.rank - b.rank)
+}
+
+/** Title case first: stored concept names usually look like "Emergency Room Visit". */
+const casings = (phrase: string): string[] => {
+  const lower = phrase.toLowerCase()
+  const title = lower.replace(/\b[a-z]/g, c => c.toUpperCase())
+  return [...new Set([title, lower, phrase.toUpperCase()])]
+}
+
+/**
+ * Each retry is another call to the values endpoint, so this branch (domain not
+ * enumerable AND the direct search failed) has to stay bounded.
+ */
+export const MAX_ALTERNATE_QUERIES = 9
+
+/**
+ * Queries to retry the endpoint with when the domain can't be enumerated: the
+ * term as written in every casing, then its expansions and distinctive words.
+ * Searching the one distinctive word ("emergency") is what finds a value the
+ * user's phrase ("ER visit") is not a substring of, and the casing sweep covers
+ * a backend whose LIKE is case-sensitive.
+ */
+export function alternateQueries(query: string): string[] {
+  const ex = expandQuery(query)
+  const phrases: string[] = [ex.normalized]
+  const add = (p: string) => {
+    if (p && !phrases.includes(p)) phrases.push(p)
+  }
+  for (const p of ex.phrases) add(p)
+  for (const ts of ex.tokenSets) {
+    for (const t of ts) if (t.length >= 3) add(t)
+  }
+
+  const out = new Set<string>()
+  for (const phrase of phrases) {
+    for (const variant of casings(phrase)) {
+      if (variant !== query) out.add(variant)
+    }
+  }
+  return [...out].slice(0, MAX_ALTERNATE_QUERIES)
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
@@ -5,15 +5,10 @@
 //   Chrome 146–149: navigator.modelContext   (now deprecated)
 //   Chrome 150+:    document.modelContext    (current spec)
 // We try document first, then fall back to navigator for older builds.
+import { nextTick } from 'vue'
 import type { Store } from 'vuex'
 import { applyCohortPatch, describeCardGroups, type PatchOp } from './cohortPatch'
-import {
-  alternateQueries,
-  rankValues,
-  DEFAULT_VALUE_LIMIT,
-  MAX_VALUE_LIMIT,
-  type MatchedVia,
-} from './valueResolution'
+import { alternateQueries, rankValues, DEFAULT_VALUE_LIMIT, MAX_VALUE_LIMIT, type MatchedVia } from './valueResolution'
 
 export interface PaToolResult {
   content: Array<{ type: 'text'; text: string }>
@@ -47,6 +42,13 @@ const textResult = (payload: unknown): PaToolResult => ({
 // twin of the backend's cohortValueResolver.ts (see the note at the top of that
 // file). Keeping it out of here also keeps this file about tool wiring.
 const matchDomainLocally = (rows: any[], query: string): any[] => rankValues(rows, query).map(m => m.row)
+
+// Resolve pa_search_attribute_values' `limit` at run time
+const resolveValueLimit = (raw: unknown): number => {
+  const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : NaN
+  const requested = Number.isFinite(parsed) ? parsed : DEFAULT_VALUE_LIMIT
+  return Math.max(1, Math.min(Math.floor(requested), MAX_VALUE_LIMIT))
+}
 
 // Turn the /values result shape into an actionable hint so the model narrows the
 // query or routes to a concept set, rather than picking one product token (which
@@ -109,7 +111,7 @@ function attributeValuesNote(opts: {
   if (matchedVia === 'none' || total === 0) {
     return (
       `No tokens matched "${query}" — not the search, not the rewritten queries — and this attribute's ` +
-      "unfiltered value list came back empty too, so its domain could not be enumerated. Try a different " +
+      'unfiltered value list came back empty too, so its domain could not be enumerated. Try a different ' +
       'attributePath: a card often exposes both a *source concept code* and a *concept-name* attribute, and ' +
       'the term may live on the other one.'
     )
@@ -288,6 +290,9 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         await store.dispatch('resetChart')
         // Switch list → builder so the chart mounts and the result computes.
         hooks.showBuilder?.()
+        // Snapshot the baseline last, as addNewCohort does
+        await nextTick()
+        store.commit('SET_ACTIVE_BOOKMARK_BASELINE', store.getters.getBookmarksData)
         return textResult({ created: true, name: name || 'New cohort' })
       },
     },
@@ -528,7 +533,7 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         '`valueKindGuide` map and a routing `note`. `valueKind` (numeric | date | conceptSet | catalog | text) ' +
         'keys into valueKindGuide, which says how to supply that add_constraint value — essential on non-OMOP ' +
         '(SAP HANA / LEAF) datasets whose coded filters use source concept codes/concept sets, not OMOP standard ' +
-        'concept ids. Pass `card` (a cardConfigPath) to get just that card\'s attributes; the full catalog is ' +
+        "concept ids. Pass `card` (a cardConfigPath) to get just that card's attributes; the full catalog is " +
         'large, so prefer the scoped call once you know the card. ' +
         'Use these exact paths in pa_apply_cohort_patch patchOps — never invent paths.',
       inputSchema: {
@@ -619,13 +624,15 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         attributePath: string
         query?: string
         attributeType?: string
-        limit?: number
+        // Typed `unknown`, not `number`: this crosses an unvalidated tool boundary,
+        // so resolveValueLimit — not the declared schema — is what makes it a number.
+        limit?: unknown
       }) {
         if (!attributePath) {
           return textResult({ values: [], error: 'Provide an attributePath (from pa_list_filter_options).' })
         }
         const trimmedQuery = typeof query === 'string' ? query.trim() : ''
-        const cap = Math.max(1, Math.min(limit ?? DEFAULT_VALUE_LIMIT, MAX_VALUE_LIMIT))
+        const cap = resolveValueLimit(limit)
 
         const fetchValues = async (searchQuery: string): Promise<{ rows?: any[]; loadedStatus?: string }> => {
           if (!searchQuery) {
@@ -791,7 +798,10 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
           share: { type: 'boolean', description: 'Share the cohort with other users (default false).' },
           bookmarkId: { type: 'string', description: 'Existing cohort id to overwrite (update). Omit to insert.' },
           method: { type: 'string', enum: ['post', 'put'], description: 'post = insert (default), put = update.' },
-          params: { type: 'object', description: 'Advanced/back-compat: raw fireBookmarkQuery params, forwarded verbatim.' },
+          params: {
+            type: 'object',
+            description: 'Advanced/back-compat: raw fireBookmarkQuery params, forwarded verbatim.',
+          },
         },
       },
       async execute({
@@ -852,7 +862,11 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
           httpMethod = 'post'
         }
 
-        const res = await store.dispatch('fireBookmarkQuery', { method: httpMethod, params: builtParams, bookmarkId: targetId })
+        const res = await store.dispatch('fireBookmarkQuery', {
+          method: httpMethod,
+          params: builtParams,
+          bookmarkId: targetId,
+        })
         const savedId = res?.bmkId ?? targetId
 
         // Mirror the in-app dialogs: reload the list so the row is visible, then

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
@@ -1,0 +1,953 @@
+// Chrome flag #enable-webmcp-testing is ON → modelContext is available natively.
+// Do NOT import '@mcp-b/global' polyfill when the flag is enabled.
+//
+// API location by Chrome version:
+//   Chrome 146–149: navigator.modelContext   (now deprecated)
+//   Chrome 150+:    document.modelContext    (current spec)
+// We try document first, then fall back to navigator for older builds.
+import type { Store } from 'vuex'
+import { applyCohortPatch, describeCardGroups, type PatchOp } from './cohortPatch'
+
+export interface PaToolResult {
+  content: Array<{ type: 'text'; text: string }>
+}
+
+export interface PaTool {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  execute: (args?: any) => Promise<PaToolResult>
+}
+
+// Optional hooks the host component (PatientAnalytics.vue) hands in so a tool can
+// drive component-local UI that is NOT in the Vuex store — e.g. switching the
+// saved-cohort list ↔ builder view. Kept optional so createPaTools stays
+// unit-testable with only a mocked store (no component, no browser).
+export interface PaComponentHooks {
+  // Show the cohort builder pane (vs. the saved-cohort list). Functionally
+  // required for a programmatically built cohort to render and compute its
+  // count/chart: the chart-query watcher (getFireRequest → fireQuery) only runs
+  // while the builder — and its chart component — is mounted.
+  showBuilder?: () => void
+}
+
+// Wrap a JSON payload in the MCP text-content envelope every tool returns.
+const textResult = (payload: unknown): PaToolResult => ({
+  content: [{ type: 'text', text: JSON.stringify(payload) }],
+})
+
+// pa_search_attribute_values caps how many tokens it returns. A coded catalog
+// search (a drug/condition on a non-OMOP dataset) routinely matches thousands of
+// tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form —
+// e.g. "gemfibrozil" resolved to 1,602 tokens — which floods the model's context
+// and makes it guess which one to pick. Return a bounded slice + a count + a
+// routing note instead. Callers can raise `limit` (bounded by MAX) if they truly
+// need the full list.
+const DEFAULT_VALUE_LIMIT = 50
+const MAX_VALUE_LIMIT = 200
+
+// How the returned values were arrived at. Reported to the model because
+// "these are matches" and "these are every value the column can take" call for
+// completely different next moves.
+type MatchedVia =
+  /** The /values endpoint's own search returned these rows. */
+  | 'search'
+  /** No query: the attribute's complete (unfiltered) value list. */
+  | 'domain'
+  /** The search found nothing; these matched when we scanned the full list here. */
+  | 'domain-scan'
+  /** The search found nothing until it was retried with a different casing. */
+  | 'case-variant'
+
+// A zero-row search is NOT evidence that a value is absent, and treating it as
+// such is exactly how "build a cohort of women…" ended with the assistant asking
+// the user whether "female" might be spelled some other way. The /values search
+// is executed by the backend (a HANA/SQL LIKE is case-sensitive) and matches the
+// stored token, not the clinical word for it — so "female" misses "Female", and
+// "women" misses "FEMALE" on every backend. When a search comes back empty we
+// re-fetch the attribute's UNFILTERED domain and match it here, where the rules
+// are ours and, for a low-cardinality column, the entire list is visible.
+const normalizeToken = (raw: unknown): string =>
+  String(raw ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s._\-/()]+/g, ' ')
+    .trim()
+
+// Interchangeable tokens for the low-cardinality demographic columns every
+// cohort starts from. A dataset stores sex as "FEMALE", "Female", "F" or a
+// concept id depending on the backend, and the user says "women".
+// Deliberately narrow — demographics and booleans only. Clinical terms are NOT
+// synonym-expanded: a near-miss concept is a silent clinical error, so those
+// still route through concept sets / the vocabulary tools.
+const SYNONYM_GROUPS: string[][] = [
+  ['female', 'f', 'fem', 'woman', 'women', 'girl', 'girls'],
+  ['male', 'm', 'man', 'men', 'boy', 'boys'],
+  ['unknown', 'u', 'unk', 'not known', 'no matching concept'],
+  ['other', 'o'],
+  ['yes', 'y', 'true'],
+  ['no', 'n', 'false'],
+]
+
+const synonymsFor = (query: string): string[] => {
+  const q = normalizeToken(query)
+  const group = SYNONYM_GROUPS.find(g => g.includes(q))
+  return group ? group.filter(s => s !== q) : []
+}
+
+// Rank a candidate row against the query: 0 exact, 1 substring, 2 synonym.
+// undefined = no match. Ranked so an exact "F" outranks a substring hit.
+function matchRank(row: any, query: string, synonyms: string[]): number | undefined {
+  const haystacks = [row?.text, row?.display_value, row?.value].map(normalizeToken).filter(Boolean)
+  if (!haystacks.length) return undefined
+  const q = normalizeToken(query)
+  if (q && haystacks.includes(q)) return 0
+  if (q && haystacks.some(h => h.includes(q))) return 1
+  // Synonyms match on EQUALITY only. As a substring rule, "f" (for female) would
+  // match every token containing the letter f.
+  if (synonyms.some(s => haystacks.includes(s))) return 2
+  return undefined
+}
+
+function matchDomainLocally(rows: any[], query: string): any[] {
+  const synonyms = synonymsFor(query)
+  return rows
+    .map(row => ({ row, rank: matchRank(row, query, synonyms) }))
+    .filter((m): m is { row: any; rank: number } => m.rank !== undefined)
+    .sort((a, b) => a.rank - b.rank)
+    .map(m => m.row)
+}
+
+// Casing variants to retry a failed search with, for attributes whose domain is
+// too large to enumerate (so the domain scan above can't run).
+const caseVariants = (query: string): string[] => {
+  const lower = query.toLowerCase()
+  const upper = query.toUpperCase()
+  const title = lower.replace(/\b[a-z]/g, c => c.toUpperCase())
+  return [...new Set([lower, upper, title])].filter(v => v !== query)
+}
+
+// Turn the /values result shape into an actionable hint so the model narrows the
+// query or routes to a concept set, rather than picking one product token (which
+// is clinically incomplete for "any form of X"), misreading TOO_MANY_RESULTS as
+// "term absent", or — the failure this note set exists to close — asking the user
+// to guess a synonym for a value whose complete list is sitting in the response.
+// The store computes `loadedStatus` (a 204 → TOO_MANY_RESULTS) but its action
+// only returns the value array, so we read it from getDomainValues.
+function attributeValuesNote(opts: {
+  matchedVia: MatchedVia
+  total: number
+  returned: number
+  truncated: boolean
+  loadedStatus?: string
+  query: string
+  matchedQuery: string
+  domainTotal?: number
+}): string | undefined {
+  const { matchedVia, total, returned, truncated, loadedStatus, query, matchedQuery, domainTotal } = opts
+  if (loadedStatus === 'TOO_MANY_RESULTS' && total === 0) {
+    return (
+      `The /values endpoint reported TOO_MANY_RESULTS and returned no rows for "${query}". ` +
+      'Narrow the query (add strength/form/vocabulary words, or a more specific term) so it returns ' +
+      'selectable tokens — do NOT conclude the term is absent from the dataset.'
+    )
+  }
+  if (truncated) {
+    return (
+      `Showing the first ${returned} of ${total} ${matchedVia === 'domain' ? 'values' : 'matching tokens'}. ` +
+      'A broad term can match many tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form — ' +
+      `picking one product token is clinically incomplete for "any form of ${query}". Prefer a concept set with ` +
+      'descendants (backend d2e-mcp) when the dataset supports it, or pick the ingredient/standard-level token ' +
+      '(e.g. an RxNorm ingredient), and narrow the query to disambiguate. Raise `limit` only if you genuinely ' +
+      'need the full list.'
+    )
+  }
+  if (matchedVia === 'domain-scan') {
+    return (
+      `The /values search for "${query}" returned no rows, but scanning this attribute's full value list ` +
+      `(${domainTotal} values) matched ${total}. The endpoint's search is case- and token-sensitive, so an empty ` +
+      'search result is never proof a value is absent. Use the `value` field of the row you want.'
+    )
+  }
+  if (matchedVia === 'case-variant') {
+    return (
+      `"${query}" returned nothing but "${matchedQuery}" matched — the /values search is case-sensitive. ` +
+      'Treat casing, not absence, as the default explanation for an empty search result.'
+    )
+  }
+  if (matchedVia === 'domain' && query) {
+    return (
+      `No value matched "${query}". The rows below are this attribute's COMPLETE value list (${domainTotal} ` +
+      'values), so no further search will find anything else here. Pick the row that expresses ' +
+      `"${query}" — do NOT ask the user to suggest a synonym; the whole list is right here. If genuinely none ` +
+      'fits, this is the wrong attribute (a card often exposes both a *source concept code* and a ' +
+      '*concept-name* attribute) or the filter is not expressible on this dataset — say so explicitly.'
+    )
+  }
+  if (total === 0) {
+    return (
+      `No tokens matched "${query}", and this attribute's unfiltered value list came back empty too, so its ` +
+      'domain could not be enumerated. Try a different attributePath — a card often exposes both a *source ' +
+      'concept code* and a *concept-name* attribute; the term may live on the other one.'
+    )
+  }
+  return undefined
+}
+
+// Classify HOW an attribute's constraint value must be supplied, so the model
+// picks the right add_constraint value shape without guessing — the crux for a
+// non-OMOP (SAP HANA / LEAF) config. Such a config filters conditions/drugs/labs
+// on coded *source concept code* CATALOG attributes (type "text" + useRefValue,
+// resolved via pa_search_attribute_values) and on *concept set* attributes
+// (type "conceptSet", taking a { conceptSetId }) — NOT on OMOP standard concept
+// ids. A bare "text" type alone doesn't tell these apart, so surface the routing.
+function describeAttributeValue(attr: any): string {
+  const type = attr.getType?.()
+  const isCatalog =
+    (typeof attr.isCatalogAttribute === 'function' && attr.isCatalogAttribute()) ||
+    // useRefText-only catalogs (coded columns shown by their ref text) also need /values.
+    !!attr.oInternalConfigAttribute?.useRefText
+  if (type === 'conceptSet') {
+    return 'conceptSet'
+  }
+  if (type === 'num') {
+    return 'numeric'
+  }
+  if (type === 'time' || type === 'datetime') {
+    return 'date'
+  }
+  if (isCatalog) {
+    return 'catalog'
+  }
+  return 'text'
+}
+
+// The valueKind → how-to-supply-the-value legend, sent ONCE per response instead
+// of repeated on every attribute. A dataset can expose 170+ filter attributes, and
+// inlining ~150 chars of identical prose per attribute more than doubled this
+// tool's output (≈60KB → ≈27KB when hoisted). That output lands in the agent
+// transcript, which /agent resends whole on every turn — so it was the single
+// biggest driver of both context burn and the 413 the drawer used to hit.
+const VALUE_KIND_GUIDE: Record<string, string> = {
+  numeric: 'add_constraint value:<number> with operator ("<",">","=",…).',
+  date: 'add_constraint value:{ from, to } (date range).',
+  conceptSet:
+    'add_constraint value:{ conceptSetId } — build/find the concept set with the d2e-mcp concept tools. The ' +
+    "attribute's `conceptDomain` (when present) is the OMOP domain its concepts must come from: a set built " +
+    'for another domain matches nothing, so resolve each term against the domain of the card you are filtering ' +
+    '(a Visit card needs a Visit concept set, not the Condition set from an earlier filter).',
+  catalog:
+    'Coded catalog value — resolve the EXACT stored token with pa_search_attribute_values, then pass its ' +
+    'returned `value`. Dataset-specific: never hardcode or invent the token. For a small enumerated column ' +
+    '(gender, race, ethnicity, status flags) call pa_search_attribute_values with NO `query` to list every ' +
+    'value it can take, and pick from that — do not guess a search term.',
+  text: 'add_constraint value:<string> (free text).',
+}
+
+// The valid filter-card / attribute catalog from the frontend config (SAP-MRI or
+// OMOP alike). Shared by pa_list_filter_options AND used to enrich patch failures,
+// so a bad path is self-correcting from the error alone — no Vue/Pinia scraping.
+// Each attribute carries a `valueKind`; `valueKindGuide` says how to supply each
+// kind's value, so the model routes it correctly on a non-OMOP config.
+function listFilterOptions(store: Store<any>): {
+  filterCards: any[]
+  valueKindGuide?: Record<string, string>
+  note?: string
+  error?: string
+} {
+  const config = store.getters.getMriFrontendConfig
+  if (!config?.getFilterCards) {
+    return { filterCards: [], error: 'Frontend config not loaded.' }
+  }
+  const filterCards = (config.getFilterCards() ?? []).map((card: any) => ({
+    cardConfigPath: card.getConfigPath(),
+    cardName: card.getName(),
+    // getFilterAttributes(), not getAllAttributes(): the latter also includes
+    // measure/category-only attributes that are NOT visible in the filter card, so
+    // add_constraint cannot target them. Listing them padded the payload AND
+    // invited the model to pick a path that always fails.
+    attributes: ((card.getFilterAttributes?.() ?? card.getAllAttributes?.() ?? []) as any[]).map((attr: any) => {
+      // The OMOP domain a conceptSet attribute's concepts must come from
+      // (config `domainFilter`, what the UI picker filters the vocabulary by).
+      // Without it the model happily reuses a Condition set on a Visit card —
+      // a cohort that computes and answers the wrong question.
+      const conceptDomain = attr.getDomainFilter?.()
+      return {
+        attributePath: attr.getConfigPath(),
+        name: attr.getName(),
+        type: attr.getType(),
+        valueKind: describeAttributeValue(attr),
+        ...(conceptDomain ? { conceptDomain } : {}),
+      }
+    }),
+  }))
+  return {
+    filterCards,
+    // Per-attribute how-to lives here, keyed by valueKind — see VALUE_KIND_GUIDE.
+    valueKindGuide: VALUE_KIND_GUIDE,
+    note:
+      'Route each add_constraint value by `valueKind`: numeric→number+operator, date→{from,to}, ' +
+      'conceptSet→{conceptSetId} (build via d2e-mcp), catalog→resolve the exact token with ' +
+      'pa_search_attribute_values first. This dataset may be non-OMOP (SAP HANA / LEAF): its coded ' +
+      'condition/drug/measurement filters use source concept codes or concept sets, not OMOP standard ' +
+      'concept ids — so d2e-mcp search_concepts may return nothing; fall back to catalog/conceptSet paths. ' +
+      'If a measurement/lab card exposes no numeric value attribute here, a value threshold ' +
+      '(e.g. BMI < 18.5) is NOT expressible — use a diagnosis/concept-set instead.',
+  }
+}
+
+// The recovery catalog attached to a FAILED patch. Deliberately NOT the whole
+// catalog: a patch failure is almost always one wrong path, and re-sending every
+// card's attributes on every failure duplicated ~30KB into a transcript that
+// /agent resends in full each turn (two of those and the request blew the body
+// limit). So: every card by path+name — enough to fix a wrong cardConfigPath —
+// plus the attributes of only the card(s) the failing ops actually named, which is
+// what fixes a wrong attributePath.
+function recoveryFilterOptions(store: Store<any>, patchOps: PatchOp[]): any[] {
+  const { filterCards } = listFilterOptions(store)
+  // `card` on a constraint op is a runtime filterCardId, not a config path, so the
+  // usable signal is add_card's cardConfigPath and the card prefix of an
+  // attributePath ("<cardConfigPath>.attributes.<key>").
+  const named = new Set<string>()
+  for (const op of patchOps ?? []) {
+    const cardConfigPath = (op as any).cardConfigPath
+    if (typeof cardConfigPath === 'string') named.add(cardConfigPath)
+    const attributePath = (op as any).attributePath
+    if (typeof attributePath === 'string') named.add(attributePath.split('.attributes.')[0])
+  }
+  return filterCards.map((card: any) =>
+    named.has(card.cardConfigPath)
+      ? card
+      : {
+          cardConfigPath: card.cardConfigPath,
+          cardName: card.cardName,
+          // Attributes omitted to keep the transcript small — ask for them by name.
+          attributeCount: card.attributes.length,
+        }
+  )
+}
+
+// Build the Patient Analytics WebMCP tool definitions against a Vuex store.
+//
+// Exported separately from registerPaTools (which needs a live browser
+// `modelContext`) so the handlers can be unit-tested with a mocked store — no
+// Chrome flag, no bridge, no Claude required. This is verification "layer B":
+// handler ↔ Vuex correctness, where most real bugs live. registerPaTools below
+// is a thin adapter that registers whatever this returns.
+export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): PaTool[] {
+  // Saved cohorts are fetched into the store when PA mounts; be defensive in case
+  // a tool runs before that has happened (or after a store reset).
+  const ensureBookmarksLoaded = async () => {
+    if (!store.getters.getBookmarks?.length) {
+      // Match every in-app caller: the loadAll fetch is a GET (fireBookmarkQuery
+      // otherwise defaults method to 'post').
+      await store.dispatch('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+    }
+  }
+
+  return [
+    {
+      name: 'pa_new_cohort',
+      description:
+        'Start a fresh, empty cohort in the PA builder (the "Create D2E cohort" button) and switch to the ' +
+        'builder view so subsequent edits render live. Call this before pa_apply_cohort_patch when building a ' +
+        'cohort from scratch. PA must already be open — this resets the builder, it cannot navigate to PA if unmounted.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Working name for the new cohort (default "New cohort").' },
+        },
+      },
+      async execute({ name }: { name?: string } = {}) {
+        // Mirror Bookmarks.vue addNewCohort(): a brand-new unsaved active bookmark
+        // (no bmkId, isNew) + a blank IFR/chart from config defaults.
+        store.commit('SET_ACTIVE_BOOKMARK', { bookmarkname: name || 'New cohort', isNew: true })
+        await store.dispatch('resetChart')
+        // Switch list → builder so the chart mounts and the result computes.
+        hooks.showBuilder?.()
+        return textResult({ created: true, name: name || 'New cohort' })
+      },
+    },
+    {
+      name: 'pa_get_current_cohort',
+      description:
+        'Return the active cohort / bookmark definition as JSON, plus `cardGroups`: the filter cards as the ' +
+        'builder groups them. Cards in the SAME group are OR-ed; the groups are AND-ed. Read cardGroups before ' +
+        'editing — it gives you the real filterCardIds to target and tells you whether the cohort currently ' +
+        'means "A and B" or "A or B".',
+      inputSchema: { type: 'object', properties: {} },
+      async execute() {
+        return textResult({
+          bookmarkData: store.getters.getBookmarksData,
+          ifr: store.getters.getBookmarkFromIFR,
+          cardGroups: describeCardGroups(store),
+          cardGroupsNote:
+            'Cards within one group are OR-ed; groups are AND-ed. To add an OR alternative use ' +
+            'add_card with orWith:"<an existing filterCardId in that group>"; to change how two cards already ' +
+            'on the cohort combine use set_card_join on the LATER card.',
+        })
+      },
+    },
+    {
+      name: 'pa_list_cohorts',
+      description:
+        'List the saved cohorts (bookmarks) available in this dataset, as { bmkId, name }. ' +
+        'Pass forceRefresh:true to reload from the server — do this right after pa_save_current_cohort so a ' +
+        'just-saved cohort appears (the default path serves a cached list and can be stale).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          forceRefresh: {
+            type: 'boolean',
+            description: 'Reload the list from the server instead of using the cached one.',
+          },
+        },
+      },
+      async execute({ forceRefresh = false }: { forceRefresh?: boolean } = {}) {
+        if (forceRefresh) {
+          await store.dispatch('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+        } else {
+          await ensureBookmarksLoaded()
+        }
+        const cohorts = (store.getters.getBookmarks ?? []).map((b: any) => ({
+          bmkId: b.bmkId,
+          name: b.bookmarkname,
+        }))
+        return textResult({ cohorts })
+      },
+    },
+    {
+      name: 'pa_open_cohort',
+      description:
+        'Open a saved cohort in the PA builder by name (or exact bmkId) and render it live. ' +
+        'Resolve names with pa_list_cohorts first.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Cohort/bookmark display name' },
+          bmkId: { type: 'string', description: 'Exact bookmark id; takes precedence over name' },
+          chartType: { type: 'string', description: 'Optional target chart type, e.g. "bar"' },
+        },
+      },
+      async execute({ name, bmkId, chartType }: { name?: string; bmkId?: string; chartType?: string }) {
+        if (!name && !bmkId) {
+          return textResult({ opened: false, error: 'Provide a cohort name or bmkId.' })
+        }
+        await ensureBookmarksLoaded()
+        const bookmarks: any[] = store.getters.getBookmarks ?? []
+
+        if (bmkId) {
+          if (!bookmarks.some(b => b.bmkId === bmkId)) {
+            return textResult({ opened: false, error: `No cohort with bmkId "${bmkId}".` })
+          }
+        } else {
+          const matches = bookmarks.filter(b => b.bookmarkname === name)
+          if (matches.length === 0) {
+            return textResult({ opened: false, error: `No cohort named "${name}".` })
+          }
+          if (matches.length > 1) {
+            return textResult({
+              opened: false,
+              ambiguous: matches.map(b => ({ bmkId: b.bmkId, name: b.bookmarkname })),
+            })
+          }
+          bmkId = matches[0].bmkId
+        }
+
+        await store.dispatch('loadbookmarkToState', { bmkId, chartType })
+        // Ensure the builder is visible even when a cohort was already active (the
+        // store's null→set view watcher only fires on the first bookmark).
+        hooks.showBuilder?.()
+        return textResult({ opened: true, bmkId })
+      },
+    },
+    {
+      name: 'pa_apply_cohort_patch',
+      description:
+        'Edit the live cohort. Preferred (and the ONLY way to add/remove a filter): pass `patchOps` — typed intent ' +
+        'applied deterministically in-place (add_card / add_constraint / remove_card / remove_constraint / ' +
+        'set_card_join). Discover valid paths with pa_list_filter_options. AND/OR: cards are AND-ed by default; ' +
+        'to express "A OR B" add the second card with orWith:"<the other card>" (or regroup existing cards with ' +
+        'set_card_join). The result reports `cardGroups` — the grouping that actually landed. Legacy `bookmark`: ' +
+        'a full tree, accepted ONLY from a trusted builder — a hand-authored tree is validated and rejected (it ' +
+        'silently loads the wrong cohort). Never hand-author one.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          patchOps: {
+            type: 'array',
+            description:
+              'Typed patch operations. Each: ' +
+              '{ op:"add_card", cardConfigPath, exclude?, ref?, orWith? } | ' +
+              '{ op:"add_constraint", card, attributePath, value, operator? } | ' +
+              '{ op:"remove_card", card } | { op:"remove_constraint", card, attributePath } | ' +
+              '{ op:"set_card_join", card, join }. ' +
+              'The Basic Data card ("patient") always exists — constrain it directly, never add_card it. ' +
+              'Separate filter cards are AND-ed; two cards are OR-ed by putting them in the same group ' +
+              '(add_card orWith, or set_card_join).',
+            items: {
+              type: 'object',
+              properties: {
+                op: {
+                  type: 'string',
+                  enum: ['add_card', 'add_constraint', 'remove_card', 'remove_constraint', 'set_card_join'],
+                },
+                cardConfigPath: {
+                  type: 'string',
+                  description: 'add_card: the card to add, from pa_list_filter_options.',
+                },
+                exclude: { type: 'boolean', description: 'add_card: make it an exclusion card.' },
+                ref: { type: 'string', description: 'add_card: local handle later ops can use as `card`.' },
+                orWith: {
+                  type: 'string',
+                  description:
+                    'add_card: OR the new card with this existing one (a filterCardId, or a `ref` from earlier ' +
+                    'in this patch) by putting both in the same group — use it for "patients with X OR Y", one ' +
+                    'condition per card. Omit for the default, which AND-s the new card with the rest. Cannot ' +
+                    'reference the Basic Data card, and cannot mix an exclusion card with an inclusion one.',
+                },
+                card: {
+                  type: 'string',
+                  description:
+                    'add_constraint / remove_* / set_card_join: a filterCardId ("patient", ' +
+                    '"…conditionoccurrence.1") or an add_card `ref` from earlier in this same patch.',
+                },
+                join: {
+                  type: 'string',
+                  enum: ['AND', 'OR'],
+                  description:
+                    'set_card_join: how `card` combines with the card before it. "OR" merges it into the ' +
+                    'preceding group, "AND" splits it into its own. Apply it to the LATER card of the pair; the ' +
+                    'first card on the cohort has nothing before it to join with.',
+                },
+                attributePath: {
+                  type: 'string',
+                  description: 'add_constraint / remove_constraint: exact path from pa_list_filter_options.',
+                },
+                value: {
+                  description:
+                    'add_constraint: REQUIRED, and the concept-set id goes HERE, not beside it. ' +
+                    'numeric -> a number (with `operator`); catalog/text -> the exact stored string; ' +
+                    'date -> { from, to }; conceptSet -> { conceptSetId, includeDescendants? } where ' +
+                    'conceptSetId came from create_concept_set / list_concept_sets. An empty or missing ' +
+                    'value is rejected — use remove_constraint to clear a filter.',
+                },
+                operator: { type: 'string', description: 'add_constraint: "=", "<", ">", "<=", ">=". Default "=".' },
+              },
+              required: ['op'],
+            },
+          },
+          bookmark: { type: 'object', description: 'Legacy: parsed bookmark object (back-compat)' },
+          chartType: { type: 'string', description: 'Target chart type, e.g. "bar"' },
+        },
+      },
+      async execute({
+        patchOps,
+        bookmark,
+        chartType,
+      }: {
+        patchOps?: PatchOp[]
+        bookmark?: object
+        chartType?: string
+      }) {
+        if (Array.isArray(patchOps)) {
+          try {
+            const result = await applyCohortPatch(store, patchOps)
+            // Make sure the builder (and its chart) is on screen so the edit renders
+            // and the count/chart query actually runs.
+            hooks.showBuilder?.()
+            return textResult(result)
+          } catch (err) {
+            // Attach the valid paths so a wrong card/attribute path is recoverable
+            // straight from the error — no need to call pa_list_filter_options separately
+            // or scrape the app's internals. Scoped to the cards this patch named
+            // (see recoveryFilterOptions); call pa_list_filter_options({ card }) for
+            // the attributes of any other card.
+            return textResult({
+              applied: false,
+              error: err instanceof Error ? err.message : String(err),
+              validFilterOptions: recoveryFilterOptions(store, patchOps),
+            })
+          }
+        }
+        if (bookmark) {
+          // A hand-authored bookmark tree is the #1 footgun here: loadBookmarkDataToState
+          // clobbers the active bookmark with a "Linked Cohort" stub BEFORE it parses, so
+          // a malformed tree (e.g. a filter card missing `attributes`) throws in
+          // convertBM2IFR and leaves the builder pointing at a broken cohort that then
+          // crashes the chart — while the caller may still think it succeeded.
+          // The parse throws before any IFR mutation, so on failure only the active
+          // bookmark is dirty: snapshot it and restore, leaving state untouched, and
+          // surface the error so the caller uses patchOps instead.
+          const prevActiveBookmark = store.getters.getActiveBookmark
+          try {
+            await store.dispatch('loadBookmarkDataToState', { bookmark, chartType })
+            return textResult({ applied: true })
+          } catch (err) {
+            store.commit('SET_ACTIVE_BOOKMARK', prevActiveBookmark)
+            const detail = err instanceof Error ? err.message || err.name : String(err)
+            return textResult({
+              applied: false,
+              error:
+                `Rejected malformed bookmark (${detail}). Do not hand-author bookmark trees — ` +
+                'edit the live cohort with patchOps (add_card / add_constraint) instead.',
+            })
+          }
+        }
+        return textResult({ applied: false, error: 'Provide patchOps (preferred) or a bookmark object.' })
+      },
+    },
+    {
+      name: 'pa_list_filter_options',
+      description:
+        'List the valid filter cards and attributes for the current dataset as ' +
+        '{ cardConfigPath, cardName, attributes: [{ attributePath, name, type, valueKind, conceptDomain? }] }, plus a ' +
+        '`valueKindGuide` map and a routing `note`. `valueKind` (numeric | date | conceptSet | catalog | text) ' +
+        'keys into valueKindGuide, which says how to supply that add_constraint value — essential on non-OMOP ' +
+        '(SAP HANA / LEAF) datasets whose coded filters use source concept codes/concept sets, not OMOP standard ' +
+        'concept ids. Pass `card` (a cardConfigPath) to get just that card\'s attributes; the full catalog is ' +
+        'large, so prefer the scoped call once you know the card. ' +
+        'Use these exact paths in pa_apply_cohort_patch patchOps — never invent paths.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          card: {
+            type: 'string',
+            description:
+              'Optional cardConfigPath (e.g. "patient.interactions.priDiag") — return only this card, with its ' +
+              'attributes. Omit for the whole catalog.',
+          },
+        },
+      },
+      async execute({ card }: { card?: string } = {}) {
+        const options = listFilterOptions(store)
+        if (!card || options.error) {
+          return textResult(options)
+        }
+        const match = options.filterCards.find((c: any) => c.cardConfigPath === card)
+        if (!match) {
+          // A wrong path is the common case here, so answer it with the thing that
+          // fixes it (the valid paths) rather than an error the model must chase.
+          return textResult({
+            filterCards: [],
+            error: `Unknown card "${card}".`,
+            validCardConfigPaths: options.filterCards.map((c: any) => c.cardConfigPath),
+          })
+        }
+        return textResult({ ...options, filterCards: [match] })
+      },
+    },
+    {
+      name: 'pa_search_attribute_values',
+      description:
+        "Resolve the EXACT stored value token for any categorical/text attribute via the app's /values " +
+        'endpoint — no auth/token handling needed. Use it for demographics too: gender/race/etc. tokens are ' +
+        'dataset-specific (e.g. "FEMALE" vs "Female" vs "F"), so NEVER hardcode them — look them up here. ' +
+        'Also resolves a term like "sinusitis" to selectable diagnosis values. OMIT `query` to list the ' +
+        "attribute's COMPLETE value list — the fastest and most reliable route for a low-cardinality column " +
+        '(gender, race, ethnicity, status flags). Returns { matchedVia, total, returned, truncated, loadedStatus, ' +
+        'domainTotal?, values:[{ value, text, display_value }], note }; pass a returned `value` as an ' +
+        'add_constraint value in pa_apply_cohort_patch. `matchedVia` says what you are looking at: "search"/' +
+        '"domain-scan"/"case-variant" = matches for your query; "domain" = the attribute\'s whole value list ' +
+        '(returned when nothing matched, so you can pick from it). A zero-result search is NEVER proof the value ' +
+        'is absent — this tool already rechecked the full domain for you, so read `note` and decide from the ' +
+        'rows returned instead of asking the user for a synonym. The list is CAPPED (default 50, `limit` to ' +
+        'change) — when `truncated` or loadedStatus is "TOO_MANY_RESULTS", NARROW the query rather than paging: ' +
+        'a broad drug/condition term matches thousands of tokens across code systems and strengths, and one ' +
+        'product token is clinically incomplete. For "any form of X", prefer a concept set with descendants ' +
+        '(backend d2e-mcp). attributePath comes from pa_list_filter_options. This returns raw attribute values, ' +
+        'not a concept-set id.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          attributePath: {
+            type: 'string',
+            description:
+              'Attribute config path from pa_list_filter_options, e.g. "patient.interactions.priDiag.attributes.icd10".',
+          },
+          query: {
+            type: 'string',
+            description:
+              'Search text, e.g. "sinusitis". OMIT it to list every value the attribute can take — do that for ' +
+              'demographics and other small enumerated columns instead of guessing a search term.',
+          },
+          attributeType: {
+            type: 'string',
+            description: 'Optional value-type hint: "text" (default) or "conceptSet".',
+          },
+          limit: {
+            type: 'number',
+            description:
+              `Max values to return (default ${DEFAULT_VALUE_LIMIT}, max ${MAX_VALUE_LIMIT}). Narrow the query ` +
+              'instead of raising this when results span many code systems/strengths.',
+          },
+        },
+        required: ['attributePath'],
+      },
+      async execute({
+        attributePath,
+        query,
+        attributeType,
+        limit,
+      }: {
+        attributePath: string
+        query?: string
+        attributeType?: string
+        limit?: number
+      }) {
+        if (!attributePath) {
+          return textResult({ values: [], error: 'Provide an attributePath (from pa_list_filter_options).' })
+        }
+        const trimmedQuery = typeof query === 'string' ? query.trim() : ''
+        const cap = Math.max(1, Math.min(limit ?? DEFAULT_VALUE_LIMIT, MAX_VALUE_LIMIT))
+
+        const fetchValues = async (searchQuery: string): Promise<{ rows?: any[]; loadedStatus?: string }> => {
+          if (!searchQuery) {
+            // Bust the store's "already loaded" short-circuit before every
+            // unfiltered read. Any earlier search on this attributePath left it
+            // cached as loaded — with that search's (possibly empty) rows — and the
+            // action would serve exactly those back instead of fetching the domain,
+            // turning the fallback below into a no-op that confirms its own miss.
+            store.commit('DOMAIN_SET_VALUES', {
+              attributePath,
+              data: { values: [], isLoaded: false, isLoading: false },
+            })
+          }
+          const rows = await store.dispatch('loadValuesForAttributePath', {
+            attributePathUid: attributePath,
+            searchQuery,
+            attributeType: attributeType ?? 'text',
+          })
+          // The store's action returns only the value array, but it records WHY a
+          // list is empty/short as `loadedStatus` (a 204 → "TOO_MANY_RESULTS").
+          // Read it from the getter so the model can tell "no such token" from
+          // "narrow the query".
+          const loadedStatus: string | undefined = store.getters.getDomainValues?.(attributePath)?.loadedStatus
+          return { rows: Array.isArray(rows) ? rows : undefined, loadedStatus }
+        }
+
+        // The store resolves `undefined` when a newer request for the same
+        // attributePath superseded this one (it cancels the in-flight call and
+        // drops the late response). That is a race, not an empty domain, and
+        // reporting it as "no values" is another way the assistant ends up telling
+        // the user a value doesn't exist. Retry once — the retry is uncontended.
+        const fetchValuesRetrying = async (searchQuery: string) => {
+          const first = await fetchValues(searchQuery)
+          return first.rows ? first : fetchValues(searchQuery)
+        }
+
+        let matchedVia: MatchedVia = trimmedQuery ? 'search' : 'domain'
+        let matchedQuery = trimmedQuery
+        const searched = await fetchValuesRetrying(trimmedQuery)
+        let all: any[] = searched.rows ?? []
+        let loadedStatus = searched.loadedStatus
+        let domainTotal: number | undefined = trimmedQuery ? undefined : all.length
+
+        if (trimmedQuery && all.length === 0 && loadedStatus !== 'TOO_MANY_RESULTS') {
+          const domain = await fetchValuesRetrying('')
+          const domainRows = domain.rows ?? []
+          domainTotal = domainRows.length
+          const localMatches = matchDomainLocally(domainRows, trimmedQuery)
+          if (localMatches.length > 0) {
+            all = localMatches
+            loadedStatus = domain.loadedStatus
+            matchedVia = 'domain-scan'
+          } else if (domainRows.length > 0) {
+            // Hand back the COMPLETE list rather than "not found", so the model can
+            // pick a value (or rule the attribute out) in this same step instead of
+            // asking the user to guess a spelling.
+            all = domainRows
+            loadedStatus = domain.loadedStatus
+            matchedVia = 'domain'
+          } else {
+            // The domain isn't enumerable (too large, or the endpoint only answers
+            // searches), so the scan above can't decide it. Retry the search with
+            // other casings — a backend LIKE is case-sensitive, so "female" can
+            // miss a stored "Female".
+            for (const variant of caseVariants(trimmedQuery)) {
+              const alt = await fetchValuesRetrying(variant)
+              if ((alt.rows?.length ?? 0) > 0) {
+                all = alt.rows as any[]
+                loadedStatus = alt.loadedStatus
+                matchedVia = 'case-variant'
+                matchedQuery = variant
+                break
+              }
+            }
+            if (matchedVia === 'search') loadedStatus = domain.loadedStatus ?? loadedStatus
+          }
+        }
+
+        const total = all.length
+        const values = all.slice(0, cap)
+        const truncated = total > values.length
+        const note = attributeValuesNote({
+          matchedVia,
+          total,
+          returned: values.length,
+          truncated,
+          loadedStatus,
+          query: trimmedQuery,
+          matchedQuery,
+          domainTotal,
+        })
+        return textResult({
+          attributePath,
+          ...(trimmedQuery ? { query: trimmedQuery } : {}),
+          matchedVia,
+          total,
+          returned: values.length,
+          truncated,
+          loadedStatus,
+          ...(domainTotal !== undefined ? { domainTotal } : {}),
+          values,
+          ...(note ? { note } : {}),
+        })
+      },
+    },
+    {
+      name: 'pa_get_cohort_result',
+      description:
+        'Return the LIVE computed RESULT of the current cohort: matched patient count, total, active chart type, ' +
+        'and the binned chart data (categories, measures, per-bin patient counts). Use this to verify what actually ' +
+        'rendered after building/editing — pa_get_current_cohort returns only the definition, not the result. ' +
+        'Requires the builder to be open (pa_new_cohort / pa_open_cohort switch to it) so the chart query has run.',
+      inputSchema: { type: 'object', properties: {} },
+      async execute() {
+        const g = store.getters
+        // getResponse is a getter that returns a function; call it for the raw response.
+        const resp = typeof g.getResponse === 'function' ? g.getResponse() : g.getResponse
+        const chartData = resp?.data
+        const chart = chartData
+          ? {
+              totalPatientCount: chartData.totalPatientCount,
+              categories: chartData.categories,
+              measures: chartData.measures,
+              data: chartData.data,
+              noDataReason: chartData.noDataReason,
+              // Set when the last chart query errored (see fireQuery). Without it a
+              // failed query reads as an empty cohort and the count "--" has no cause.
+              ...(chartData.error ? { error: chartData.error } : {}),
+            }
+          : null
+        return textResult({
+          currentPatientCount: g.getCurrentPatientCount,
+          totalPatientCount: g.getDisplayTotalGuardedPatientCount ? g.getTotalPatientListCount : g.getTotalPatientCount,
+          chartType: g.getActiveChart,
+          chart,
+          ...(chartData?.error
+            ? {
+                error: `The last chart query failed, so the count is not a real result: ${chartData.error}`,
+              }
+            : {}),
+        })
+      },
+    },
+    {
+      name: 'pa_save_current_cohort',
+      description:
+        'Persist the current cohort to bookmark-svc and refresh the saved-cohort list. ' +
+        'New cohort → pass { name } (inserts). Overwrite an existing one → pass { bookmarkId } or method:"put" (updates). ' +
+        'The save payload (cmd / bookmark body / shareBookmark) is built from live store state — you do not construct it. ' +
+        'Advanced/back-compat: a raw `params` object, if provided, is forwarded to fireBookmarkQuery verbatim.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Name for a NEW cohort (insert). Required to insert unless updating or passing raw params.',
+          },
+          share: { type: 'boolean', description: 'Share the cohort with other users (default false).' },
+          bookmarkId: { type: 'string', description: 'Existing cohort id to overwrite (update). Omit to insert.' },
+          method: { type: 'string', enum: ['post', 'put'], description: 'post = insert (default), put = update.' },
+          params: { type: 'object', description: 'Advanced/back-compat: raw fireBookmarkQuery params, forwarded verbatim.' },
+        },
+      },
+      async execute({
+        name,
+        share = false,
+        bookmarkId,
+        method,
+        params,
+      }: {
+        name?: string
+        share?: boolean
+        bookmarkId?: string
+        method?: string
+        params?: any
+      } = {}) {
+        // Reload the list after a write so pa_list_cohorts (and the UI) reflect it —
+        // fireBookmarkQuery does NOT refetch after insert/update on its own.
+        const refreshList = () => store.dispatch('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+
+        // Back-compat: forward a hand-built params object verbatim.
+        if (params) {
+          const res = await store.dispatch('fireBookmarkQuery', { method: method ?? 'post', params, bookmarkId })
+          await refreshList()
+          return textResult({ saved: true, bookmarkId: res?.bmkId ?? bookmarkId })
+        }
+
+        const bookmarkData = store.getters.getBookmarksData
+        if (!bookmarkData || Object.keys(bookmarkData).length === 0) {
+          return textResult({ saved: false, error: 'Current cohort is empty — build filters before saving.' })
+        }
+
+        const active = store.getters.getActiveBookmark
+        const targetId = bookmarkId ?? (method === 'put' ? active?.bmkId : undefined)
+        const isUpdate = method === 'put' || !!targetId
+
+        let builtParams: Record<string, unknown>
+        let httpMethod: string
+        if (isUpdate) {
+          if (!targetId) {
+            return textResult({
+              saved: false,
+              error: 'Update requested but no bookmarkId (and no active saved cohort) to update.',
+            })
+          }
+          builtParams = { cmd: 'update', bookmark: JSON.stringify(bookmarkData), shareBookmark: share }
+          httpMethod = 'put'
+        } else {
+          const cohortName = name ?? (active && !active.isNew ? active.bookmarkname : undefined)
+          if (!cohortName) {
+            return textResult({ saved: false, error: 'Provide a name to save a new cohort.' })
+          }
+          builtParams = {
+            cmd: 'insert',
+            bookmarkname: cohortName,
+            bookmark: JSON.stringify(bookmarkData),
+            shareBookmark: share,
+          }
+          httpMethod = 'post'
+        }
+
+        const res = await store.dispatch('fireBookmarkQuery', { method: httpMethod, params: builtParams, bookmarkId: targetId })
+        const savedId = res?.bmkId ?? targetId
+
+        // Mirror the in-app dialogs: reload the list so the row is visible, then
+        // adopt the saved record as the active bookmark so a follow-up save updates
+        // it instead of inserting a duplicate.
+        await refreshList()
+        if (savedId) {
+          const saved = (store.getters.getBookmarks ?? []).find((b: any) => b.bmkId === savedId)
+          if (saved) store.commit('SET_ACTIVE_BOOKMARK', saved)
+        }
+
+        return textResult({ saved: true, bookmarkId: savedId })
+      },
+    },
+  ]
+}
+
+export function registerPaTools(store: Store<any>, hooks: PaComponentHooks = {}): () => void {
+  const mc = (document as any).modelContext ?? (navigator as any).modelContext
+  if (!mc) {
+    console.warn('[WebMCP] modelContext API not available. Enable chrome://flags/#enable-webmcp-testing (Chrome 146+)')
+    return () => {}
+  }
+
+  const regs: Array<{ unregister?: () => void }> = createPaTools(store, hooks).map(tool => mc.registerTool(tool))
+
+  // Return a cleanup function for beforeUnmount
+  return () => regs.forEach(r => r?.unregister?.())
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
@@ -7,6 +7,13 @@
 // We try document first, then fall back to navigator for older builds.
 import type { Store } from 'vuex'
 import { applyCohortPatch, describeCardGroups, type PatchOp } from './cohortPatch'
+import {
+  alternateQueries,
+  rankValues,
+  DEFAULT_VALUE_LIMIT,
+  MAX_VALUE_LIMIT,
+  type MatchedVia,
+} from './valueResolution'
 
 export interface PaToolResult {
   content: Array<{ type: 'text'; text: string }>
@@ -36,96 +43,10 @@ const textResult = (payload: unknown): PaToolResult => ({
   content: [{ type: 'text', text: JSON.stringify(payload) }],
 })
 
-// pa_search_attribute_values caps how many tokens it returns. A coded catalog
-// search (a drug/condition on a non-OMOP dataset) routinely matches thousands of
-// tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form —
-// e.g. "gemfibrozil" resolved to 1,602 tokens — which floods the model's context
-// and makes it guess which one to pick. Return a bounded slice + a count + a
-// routing note instead. Callers can raise `limit` (bounded by MAX) if they truly
-// need the full list.
-const DEFAULT_VALUE_LIMIT = 50
-const MAX_VALUE_LIMIT = 200
-
-// How the returned values were arrived at. Reported to the model because
-// "these are matches" and "these are every value the column can take" call for
-// completely different next moves.
-type MatchedVia =
-  /** The /values endpoint's own search returned these rows. */
-  | 'search'
-  /** No query: the attribute's complete (unfiltered) value list. */
-  | 'domain'
-  /** The search found nothing; these matched when we scanned the full list here. */
-  | 'domain-scan'
-  /** The search found nothing until it was retried with a different casing. */
-  | 'case-variant'
-
-// A zero-row search is NOT evidence that a value is absent, and treating it as
-// such is exactly how "build a cohort of women…" ended with the assistant asking
-// the user whether "female" might be spelled some other way. The /values search
-// is executed by the backend (a HANA/SQL LIKE is case-sensitive) and matches the
-// stored token, not the clinical word for it — so "female" misses "Female", and
-// "women" misses "FEMALE" on every backend. When a search comes back empty we
-// re-fetch the attribute's UNFILTERED domain and match it here, where the rules
-// are ours and, for a low-cardinality column, the entire list is visible.
-const normalizeToken = (raw: unknown): string =>
-  String(raw ?? '')
-    .trim()
-    .toLowerCase()
-    .replace(/[\s._\-/()]+/g, ' ')
-    .trim()
-
-// Interchangeable tokens for the low-cardinality demographic columns every
-// cohort starts from. A dataset stores sex as "FEMALE", "Female", "F" or a
-// concept id depending on the backend, and the user says "women".
-// Deliberately narrow — demographics and booleans only. Clinical terms are NOT
-// synonym-expanded: a near-miss concept is a silent clinical error, so those
-// still route through concept sets / the vocabulary tools.
-const SYNONYM_GROUPS: string[][] = [
-  ['female', 'f', 'fem', 'woman', 'women', 'girl', 'girls'],
-  ['male', 'm', 'man', 'men', 'boy', 'boys'],
-  ['unknown', 'u', 'unk', 'not known', 'no matching concept'],
-  ['other', 'o'],
-  ['yes', 'y', 'true'],
-  ['no', 'n', 'false'],
-]
-
-const synonymsFor = (query: string): string[] => {
-  const q = normalizeToken(query)
-  const group = SYNONYM_GROUPS.find(g => g.includes(q))
-  return group ? group.filter(s => s !== q) : []
-}
-
-// Rank a candidate row against the query: 0 exact, 1 substring, 2 synonym.
-// undefined = no match. Ranked so an exact "F" outranks a substring hit.
-function matchRank(row: any, query: string, synonyms: string[]): number | undefined {
-  const haystacks = [row?.text, row?.display_value, row?.value].map(normalizeToken).filter(Boolean)
-  if (!haystacks.length) return undefined
-  const q = normalizeToken(query)
-  if (q && haystacks.includes(q)) return 0
-  if (q && haystacks.some(h => h.includes(q))) return 1
-  // Synonyms match on EQUALITY only. As a substring rule, "f" (for female) would
-  // match every token containing the letter f.
-  if (synonyms.some(s => haystacks.includes(s))) return 2
-  return undefined
-}
-
-function matchDomainLocally(rows: any[], query: string): any[] {
-  const synonyms = synonymsFor(query)
-  return rows
-    .map(row => ({ row, rank: matchRank(row, query, synonyms) }))
-    .filter((m): m is { row: any; rank: number } => m.rank !== undefined)
-    .sort((a, b) => a.rank - b.rank)
-    .map(m => m.row)
-}
-
-// Casing variants to retry a failed search with, for attributes whose domain is
-// too large to enumerate (so the domain scan above can't run).
-const caseVariants = (query: string): string[] => {
-  const lower = query.toLowerCase()
-  const upper = query.toUpperCase()
-  const title = lower.replace(/\b[a-z]/g, c => c.toUpperCase())
-  return [...new Set([lower, upper, title])].filter(v => v !== query)
-}
+// Query → stored-value matching lives in ./valueResolution, the browser-side
+// twin of the backend's cohortValueResolver.ts (see the note at the top of that
+// file). Keeping it out of here also keeps this file about tool wiring.
+const matchDomainLocally = (rows: any[], query: string): any[] => rankValues(rows, query).map(m => m.row)
 
 // Turn the /values result shape into an actionable hint so the model narrows the
 // query or routes to a concept set, rather than picking one product token (which
@@ -169,10 +90,11 @@ function attributeValuesNote(opts: {
       'search result is never proof a value is absent. Use the `value` field of the row you want.'
     )
   }
-  if (matchedVia === 'case-variant') {
+  if (matchedVia === 'alternate-query') {
     return (
-      `"${query}" returned nothing but "${matchedQuery}" matched — the /values search is case-sensitive. ` +
-      'Treat casing, not absence, as the default explanation for an empty search result.'
+      `"${query}" returned nothing but "${matchedQuery}" matched — the /values search is case-sensitive and ` +
+      'matches the stored token, not the word for it. Treat a rewritten query, not absence, as the default ' +
+      'explanation for an empty search result. Check the rows are really what you asked for before using one.'
     )
   }
   if (matchedVia === 'domain' && query) {
@@ -184,11 +106,12 @@ function attributeValuesNote(opts: {
       '*concept-name* attribute) or the filter is not expressible on this dataset — say so explicitly.'
     )
   }
-  if (total === 0) {
+  if (matchedVia === 'none' || total === 0) {
     return (
-      `No tokens matched "${query}", and this attribute's unfiltered value list came back empty too, so its ` +
-      'domain could not be enumerated. Try a different attributePath — a card often exposes both a *source ' +
-      'concept code* and a *concept-name* attribute; the term may live on the other one.'
+      `No tokens matched "${query}" — not the search, not the rewritten queries — and this attribute's ` +
+      "unfiltered value list came back empty too, so its domain could not be enumerated. Try a different " +
+      'attributePath: a card often exposes both a *source concept code* and a *concept-name* attribute, and ' +
+      'the term may live on the other one.'
     )
   }
   return undefined
@@ -648,10 +571,13 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         '(gender, race, ethnicity, status flags). Returns { matchedVia, total, returned, truncated, loadedStatus, ' +
         'domainTotal?, values:[{ value, text, display_value }], note }; pass a returned `value` as an ' +
         'add_constraint value in pa_apply_cohort_patch. `matchedVia` says what you are looking at: "search"/' +
-        '"domain-scan"/"case-variant" = matches for your query; "domain" = the attribute\'s whole value list ' +
-        '(returned when nothing matched, so you can pick from it). A zero-result search is NEVER proof the value ' +
-        'is absent — this tool already rechecked the full domain for you, so read `note` and decide from the ' +
-        'rows returned instead of asking the user for a synonym. The list is CAPPED (default 50, `limit` to ' +
+        '"domain-scan"/"alternate-query" = matches for your query (the last one via a rewritten query — check ' +
+        'the rows are really what you asked for); "domain" = the attribute\'s whole value list (returned when ' +
+        'nothing matched, so you can pick from it); "none" = the column could not be read at all, so try a ' +
+        'different attributePath. A zero-result search is NEVER proof the value is absent — this tool already ' +
+        'rechecked the full domain, retried the term\'s casings and its expansions ("ER visit" → "Emergency ' +
+        'Room Visit"), so read `note` and decide from the rows returned instead of asking the user for a ' +
+        'synonym or spelling. The list is CAPPED (default 50, `limit` to ' +
         'change) — when `truncated` or loadedStatus is "TOO_MANY_RESULTS", NARROW the query rather than paging: ' +
         'a broad drug/condition term matches thousands of tokens across code systems and strengths, and one ' +
         'product token is clinically incomplete. For "any form of X", prefer a concept set with descendants ' +
@@ -761,20 +687,25 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
             matchedVia = 'domain'
           } else {
             // The domain isn't enumerable (too large, or the endpoint only answers
-            // searches), so the scan above can't decide it. Retry the search with
-            // other casings — a backend LIKE is case-sensitive, so "female" can
-            // miss a stored "Female".
-            for (const variant of caseVariants(trimmedQuery)) {
+            // searches), so the scan above can't decide it. Retry the search with the
+            // rewritten queries: every casing (a backend LIKE is case-sensitive, so
+            // "female" misses a stored "Female"), then the term's expansions and its
+            // distinctive words — searching "emergency" is what reaches a value that
+            // the user's phrase ("ER visit") is not even a substring of.
+            for (const variant of alternateQueries(trimmedQuery)) {
               const alt = await fetchValuesRetrying(variant)
               if ((alt.rows?.length ?? 0) > 0) {
                 all = alt.rows as any[]
                 loadedStatus = alt.loadedStatus
-                matchedVia = 'case-variant'
+                matchedVia = 'alternate-query'
                 matchedQuery = variant
                 break
               }
             }
-            if (matchedVia === 'search') loadedStatus = domain.loadedStatus ?? loadedStatus
+            if (matchedVia === 'search') {
+              matchedVia = 'none'
+              loadedStatus = domain.loadedStatus ?? loadedStatus
+            }
           }
         }
 

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
@@ -167,6 +167,8 @@ declare var sap
 const myWindow: any = window
 
 import { mapActions, mapGetters } from 'vuex'
+import { registerPaTools } from '@/ai/webmcpServer'
+import { publishPaTools } from '@/ai/paToolBridge'
 import icon from '../lib/ui/app-icon.vue'
 import appButton from '../lib/ui/app-button.vue'
 import appIcon from '../lib/ui/app-icon.vue'
@@ -270,10 +272,22 @@ export default {
     },
   },
   mounted() {
+    const paToolHooks = {
+      // Let pa_new_cohort switch from the saved-cohort list to the builder so a
+      // programmatically built cohort renders and computes its count/chart.
+      showBuilder: () => this.toggleCohorts(false),
+    }
+    // Two consumers, one tool set: an external browser agent via Chrome's
+    // modelContext, and an in-page consumer via the window registry. Both wrap
+    // the same createPaTools() array.
+    this._unregisterPaTools = registerPaTools(this.$store, paToolHooks)
+    this._unpublishPaTools = publishPaTools(this.$store, paToolHooks)
     this.updateMinSplitterWidth()
     window.addEventListener('resize', this.updateMinSplitterWidth)
   },
   beforeUnmount() {
+    this._unregisterPaTools?.()
+    this._unpublishPaTools?.()
     window.removeEventListener('resize', this.updateMinSplitterWidth)
     this.chartBusy = false
   },

--- a/plugins/ui/apps/vue-mri-ui-lib/src/lib/i18n.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/lib/i18n.ts
@@ -368,6 +368,8 @@ export const i18n = {
     MRI_PA_DRILL_DOWN: 'Drill Down',
     MRI_PA_CHART_NO_DATA_DEFAULT_MESSAGE:
       'Data cannot be displayed due to an internal error. Please contact your system administrator.',
+    MRI_PA_CHART_NO_AXIS_SELECTED:
+      'No axis is selected, so there is nothing to aggregate. Choose at least one attribute for an axis.',
     MRI_PA_MENUITEM_INTERACTIONS_GENERAL: 'Basic Data',
     MRI_PA_TITLE_FILTER_SUMMARY: 'Filter Summary',
     MRI_PA_TITLE_FILTER_SUMMARY_TOOLTIP: 'View Filter Summary',

--- a/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/query.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/query.ts
@@ -1063,6 +1063,15 @@ const actions = {
             data: {
               data: [],
               totalPatientCount: 0,
+              // Keep WHY it failed. The chart component renders the reason locally, but the
+              // store response loses it — and an empty result with no reason is
+              // indistinguishable from "no matching patients" for anything that reads the
+              // response back.
+              error:
+                error?.response?.data?.errorMessage ||
+                error?.response?.data?.err ||
+                error?.message ||
+                'The chart query failed.',
             },
           },
         })

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
@@ -59,9 +59,9 @@ describe('applyConstraintValue', () => {
     })
 
     it('rejects an unparseable numeric value', async () => {
-      await expect(
-        applyConstraintValue(dispatch, constraint({}, { type: 'num' }), 'abc')
-      ).rejects.toThrow('Invalid numeric value for Age')
+      await expect(applyConstraintValue(dispatch, constraint({}, { type: 'num' }), 'abc')).rejects.toThrow(
+        'Invalid numeric value for Age'
+      )
       expect(dispatch).not.toHaveBeenCalled()
     })
   })
@@ -152,9 +152,9 @@ describe('applyConstraintValue', () => {
     })
 
     it('rejects when no date value is present', async () => {
-      await expect(
-        applyConstraintValue(dispatch, constraint({}, { type: 'time' }), '')
-      ).rejects.toThrow('Missing date value for Age')
+      await expect(applyConstraintValue(dispatch, constraint({}, { type: 'time' }), '')).rejects.toThrow(
+        'Missing date value for Age'
+      )
       expect(dispatch).not.toHaveBeenCalled()
     })
   })

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
@@ -184,10 +184,26 @@ describe('applyConstraintValue', () => {
       })
     })
 
-    it.each([[null], [undefined], [''], ['   ']])('rejects a missing value (%p)', async input => {
-      await expect(applyConstraintValue(dispatch, constraint(), input)).rejects.toThrow('Missing value for Age')
-      expect(dispatch).not.toHaveBeenCalled()
+    // Regression (#2913): emptying an optional text / concept-set filter clears it
+    // (dispatches an empty value) instead of erroring, so the required-filters modal can
+    // remove a previously-set optional value.
+    it.each([['text'], ['conceptSet']])('clears an empty %s constraint instead of rejecting', async type => {
+      await applyConstraintValue(dispatch, constraint({}, { type }), '')
+      expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', {
+        constraintId: 'constraint-1',
+        value: [],
+      })
     })
+
+    it.each([[null], [undefined], [''], ['   ']])(
+      'rejects a missing value for a non-clearable constraint type (%p)',
+      async input => {
+        await expect(applyConstraintValue(dispatch, constraint({}, { type: 'attribute' }), input)).rejects.toThrow(
+          'Missing value for Age'
+        )
+        expect(dispatch).not.toHaveBeenCalled()
+      }
+    )
 
     it('rejects an unsupported object value instead of stringifying it', async () => {
       await expect(applyConstraintValue(dispatch, constraint(), { foo: 'bar' })).rejects.toThrow(

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/constraintValueSnapshot.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/constraintValueSnapshot.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { snapshotConstraintValue, restoreConstraintValue } from '../constraintValueSnapshot'
+
+describe('constraintValueSnapshot', () => {
+  let dispatch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    dispatch = vi.fn().mockResolvedValue(undefined)
+  })
+
+  it('round-trips a value-only constraint', async () => {
+    const constraint = { id: 'con1', props: { value: [{ op: '>=', value: 65 }] } }
+
+    await restoreConstraintValue(dispatch, snapshotConstraintValue(constraint))
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', {
+      constraintId: 'con1',
+      value: [{ op: '>=', value: 65 }],
+    })
+  })
+
+  // A date constraint keeps no props.value at all, so a snapshot of `value` alone
+  // restores nothing and the edited range silently stays on the cohort.
+  it('round-trips the date slot a date constraint keeps instead of a value', async () => {
+    const from = new Date('2019-01-01')
+    const to = new Date('2019-12-31')
+    const constraint = { id: 'con2', props: { fromDate: { value: from }, toDate: { value: to } } }
+
+    const snapshot = snapshotConstraintValue(constraint)
+    expect(snapshot).toEqual({ constraintId: 'con2', value: undefined, dates: { from, to } })
+
+    await restoreConstraintValue(dispatch, snapshot)
+
+    // isUTC:true is the pass-through branch; isUTC:false would shift the restored
+    // range by the timezone offset on every revert.
+    expect(dispatch).toHaveBeenCalledWith('updateDateConstraintValue', {
+      constraintId: 'con2',
+      fromDateValue: from,
+      toDateValue: to,
+      isUTC: true,
+    })
+    // No value dispatch: the constraint had no value slot to put back.
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  // The cleared state of an optional text/conceptSet filter. Bookkeeping that
+  // restores only truthy values leaves the edit in place instead of clearing it.
+  it('restores a value that was legitimately empty', async () => {
+    await restoreConstraintValue(dispatch, snapshotConstraintValue({ id: 'con3', props: { value: [] } }))
+
+    expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', { constraintId: 'con3', value: [] })
+  })
+
+  it('restores each slot independently when the other one fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    dispatch.mockImplementation((action: string) =>
+      action === 'updateDateConstraintValue' ? Promise.reject(new Error('nope')) : Promise.resolve(undefined)
+    )
+
+    await restoreConstraintValue(dispatch, {
+      constraintId: 'con4',
+      value: ['x'],
+      dates: { from: '', to: '' },
+    })
+
+    // The failed date restore must not swallow the value restore, and must not throw:
+    // the caller is already unwinding a failed edit.
+    expect(dispatch).toHaveBeenCalledWith('updateConstraintValue', { constraintId: 'con4', value: ['x'] })
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/applyConstraintValue.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/applyConstraintValue.ts
@@ -90,6 +90,14 @@ export async function applyConstraintValue(
   }
   const rawValue = rawInput?.value ?? rawInput
   if (rawValue === null || typeof rawValue === 'undefined' || String(rawValue).trim() === '') {
+    // An emptied free-text or concept-set filter is a *clear*, not an error: the
+    // required-filters modal has to be able to remove a value it previously set.
+    if (constraintType === 'text' || constraintType === 'conceptSet') {
+      return dispatch('updateConstraintValue', {
+        constraintId: constraint.id,
+        value: [],
+      })
+    }
     return Promise.reject(new Error(`Missing value for ${constraint.props.name || constraint.id}`))
   }
   // Never String() an object into "[object Object]" — that silently produces a broken
@@ -100,7 +108,7 @@ export async function applyConstraintValue(
     return Promise.reject(
       new Error(
         `Unsupported object value for ${constraint.props.name || constraint.id}: ` +
-          'this constraint expects a scalar value (string or number).'
+          'pass a scalar value (string or number).'
       )
     )
   }

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/constraintValueSnapshot.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/constraintValueSnapshot.ts
@@ -1,0 +1,72 @@
+import type { ConstraintDispatch } from './applyConstraintValue'
+
+/**
+ * A constraint's value as it stood before an edit, so the edit can be undone.
+ *
+ * TWO slots, not one: a date/time constraint carries no `props.value` at all —
+ * its state lives in `props.fromDate.value` / `props.toDate.value` (see
+ * DateConstraintModel and CONSTRAINTS_DATETIME_SET_VALUE) — so bookkeeping that
+ * snapshots only `value` records `undefined` for a date range and then restores
+ * nothing. That is how a widened date window survived a failed edit while the
+ * user was told nothing had been applied.
+ *
+ * Used by the WebMCP cohort-patch applier's rollback. The dashboard wizard's
+ * revertFieldChanges has the same job and the same two slots to put back (see
+ * useDashboardFlow) — the same reason applyConstraintValue is shared.
+ */
+export interface ConstraintValueSnapshot {
+  constraintId: string
+  value: any
+  /** Present only for a constraint that keeps a date range. */
+  dates?: { from: any; to: any }
+}
+
+/** Record a constraint's current value so restoreConstraintValue can put it back. */
+export function snapshotConstraintValue(constraint: any): ConstraintValueSnapshot {
+  const props = constraint?.props
+  return {
+    constraintId: constraint?.id,
+    value: props?.value,
+    ...(props?.fromDate || props?.toDate ? { dates: { from: props?.fromDate?.value, to: props?.toDate?.value } } : {}),
+  }
+}
+
+/**
+ * Put a snapshot back on its constraint (or on `constraintId`'s replacement, if
+ * the caller re-created the constraint and passes the new id).
+ *
+ * Best-effort: each slot is restored independently and a failure is logged rather
+ * than thrown, because the caller is already unwinding a failed edit and one bad
+ * undo must not mask the error that started it.
+ */
+export async function restoreConstraintValue(
+  dispatch: ConstraintDispatch,
+  { constraintId, value, dates }: ConstraintValueSnapshot
+): Promise<void> {
+  if (dates) {
+    try {
+      // isUTC:true is the pass-through branch of updateDateConstraintValue: the
+      // snapshot is already normalized, and the only transform that branch applies
+      // (toUTCEndOfDay on a 'time' attribute) is idempotent on a Date and leaves ''
+      // — an unset constraint — untouched. The isUTC:false branch would shift the
+      // range by the timezone offset on every restore.
+      await dispatch('updateDateConstraintValue', {
+        constraintId,
+        fromDateValue: dates.from,
+        toDateValue: dates.to,
+        isUTC: true,
+      })
+    } catch (e) {
+      console.error('[constraintValueSnapshot] restoring the date range failed', e)
+    }
+  }
+  // `undefined` means the constraint never had a value slot (a date-only
+  // constraint), not that it was empty — an empty array IS a value: the cleared
+  // state of a text/conceptSet filter, which has to be restorable too.
+  if (typeof value === 'undefined') return
+  try {
+    await dispatch('updateConstraintValue', { constraintId, value })
+  } catch (e) {
+    console.error('[constraintValueSnapshot] restoring the value failed', e)
+  }
+}


### PR DESCRIPTION
## **Summary:** : 
This PR adds the `pa_*` **tool surface** for Patient Analytics. 
PR #3000  adds a deterministic cohort-patch *applier* with no caller; this PR adds the callers: 
1. 9 `pa_*` tools built over the app's own Vuex actions, 
2. query→stored-value resolver so a term like *"women"* or *"ER visit"* reaches the token a dataset actually stores,
3. In-page registry so a second consumer in another bundle can reach the same tool set, 
4. `PatientAnalytics.vue` mount/unmount wiring that publishes both surfaces.

Nothing in `develop` consumes either surface, and the browser surface needs a Chrome flag , so **this PR
ships dormant**: on an unflagged browser `registerPaTools` logs a warning and returns a no-op
teardown, and `window.__d2ePaTools` is published but unread until C2 (the portal drawer).

## What changed

| File | Kind | Change |
|---|---|---|
| [webmcpServer.ts](plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts) | **new** | The nine `pa_*` tools (`createPaTools`) + the WebMCP registration adapter (`registerPaTools`)|
| [valueResolution.ts](plugins/ui/apps/vue-mri-ui-lib/src/ai/valueResolution.ts) | **new** | Query → stored-value ranking, query expansion, blind-retry query generation |
| [paToolBridge.ts](plugins/ui/apps/vue-mri-ui-lib/src/ai/paToolBridge.ts) | **new** | `publishPaTools` — versioned `window.__d2ePaTools` registry + `d2e-pa-tools-changed` event  |
| [PatientAnalytics.vue](plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue) | wiring | Register + publish on `mounted`, tear both down on `beforeUnmount` |

## The nine tools

| Tool | Store surface it drives | Notable logic |
|---|---|---|
| `pa_new_cohort` | `SET_ACTIVE_BOOKMARK` + `resetChart` | Mirrors `Bookmarks.vue addNewCohort()`: a new unsaved active bookmark (`isNew: true`, no `bmkId`) plus a blank IFR/chart from config defaults, then `showBuilder()` |
| `pa_get_current_cohort` | `getBookmarksData`, `getBookmarkFromIFR`, `describeCardGroups` | Returns the definition **and** `cardGroups` — the AND/OR structure, which is invisible in the constraint list |
| `pa_list_cohorts` | `fireBookmarkQuery` (`cmd: loadAll`) | `forceRefresh` bypasses the "already loaded" path; the default calls `ensureBookmarksLoaded` |
| `pa_open_cohort` | `loadbookmarkToState` | Name→id resolution with an explicit `ambiguous` result; `showBuilder()` after |
| `pa_apply_cohort_patch` | `applyCohortPatch` (A3) / legacy `loadBookmarkDataToState` | Failure attaches a *scoped* recovery catalog; the legacy path validates and rolls back |
| `pa_list_filter_options` | `getMriFrontendConfig` | `valueKind` classification, hoisted guide, `conceptDomain`, optional `card` scoping |
| `pa_search_attribute_values` | `loadValuesForAttributePath`, `getDomainValues`, `DOMAIN_SET_VALUES` | The five-step escalation ladder — Part 2 |
| `pa_get_cohort_result` | `getResponse`, the patient-count getters, `getActiveChart` | The live *result*, including a failed-query cause |
| `pa_save_current_cohort` | `fireBookmarkQuery` (`insert`/`update`) | Builds the payload from live state; refreshes, then adopts the saved record |

`ensureBookmarksLoaded` dispatches `fireBookmarkQuery` with an explicit `method: 'get'` — every
in-app caller does, because `fireBookmarkQuery` otherwise defaults to `post`, which for
`cmd: loadAll` is the wrong verb.

## Test in browser
| | |
|---|---|
| **Flag URL** | `chrome://flags/#enable-webmcp-testing` |
| **Flag name in the UI** | **WebMCP for testing** |
| **Set it to** | **Enabled**, then click **Relaunch** |
| **Chrome required** | **146+**, and on the **Canary / Dev / Beta** channel — the flag does not exist on Stable yet, where `chrome://flags/#enable-webmcp-testing` simply shows no result |
| **Secure context** | required, but `localhost` counts as one, so plain `http://localhost:<port>` works |

Steps:
1. **Enable the flag** as above and relaunch that Chrome.
2. **Build the PA bundle** so your branch's code is actually served (`bun build-all` in
   `plugins/ui`; the build output is served through the bundled-plugins mount — no copy into
   `d2e-trex` needed).
3. **Open the portal** and log in. 
4. **Mount PA.** Navigate to `Cohorts` and wait for PA to load. The tools are registered in
   `PatientAnalytics.vue`'s `mounted()`, and PA is a single-spa app that mounts only on the PA
   route.
5. **Confirm registration** in the DevTools console of that tab:

   ```js
   await navigator.modelContextTesting.listTools()
   // → the nine pa_* tools
   ```
E.g.
<img width="2559" height="1298" alt="Screenshot 2026-07-29 at 2 45 40 PM" src="https://github.com/user-attachments/assets/0ea551ce-9df6-4010-9c8e-6c6d3a6c6b1e" />



### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)