### PR TITLE
Use native fetch for external OAuth/IdP token requests

### DIFF
--- a/plugins/fhir_functions/fhir-init/src/api/DbCredentialsAPI.ts
+++ b/plugins/fhir_functions/fhir-init/src/api/DbCredentialsAPI.ts
@@ -30,18 +30,28 @@ export class DbCredentialsAPI {
         client_secret: env.IDP__ALP_DATA__CLIENT_SECRET,
       };
 
-      const options = {
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-      };
       const data = Object.keys(params)
         .map(
           (key) =>
             `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`
         )
         .join("&");
-      const result = await post(this.oauthUrl, data, options);
+      // External-capable OAuth gateway — native fetch, not the axios shim.
+      // See trex/plans/2026-07-27-axios-to-fetch-minimal-v3.md
+      const res = await fetch(this.oauthUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: data,
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `OAuth token request failed with status ${res.status}: ${await res.text()}`
+        );
+      }
+      const result = { data: await res.json() };
       this.accessToken = `Bearer ${result.data.access_token}`;
       return this.accessToken;
     } catch (error: any) {
@@ -62,6 +72,8 @@ export class DbCredentialsAPI {
     try {
       this.logger.info("Get database list");
       const options = await this.getRequestConfig();
+      // Internal (services.trex). Intentionally still axios via request-util:
+      // not on the external-HTTPS failure path.
       const url = `${this.baseURL}/trex/db/`;
       const result = await get(url, options);
       return result.data;

--- a/plugins/functions/alp-usermgmt/src/api/OpenIDAPI.ts
+++ b/plugins/functions/alp-usermgmt/src/api/OpenIDAPI.ts
@@ -1,7 +1,5 @@
-import { AxiosResponse } from 'axios'
 import jwt from 'jsonwebtoken'
 import https from 'https'
-import { post } from './request-util'
 
 interface IClientMetadata {
   issuerUrl: string
@@ -43,14 +41,22 @@ export class OpenIDAPI {
       .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
       .join('&')
 
-    let result: AxiosResponse<ITokenResponse> | undefined
+    let result: { data: ITokenResponse } | undefined
     try {
-      result = await post<ITokenResponse>(`${this.issuerUrl}token`, body, {
-        // httpsAgent: this.httpsAgent,
+      // External-capable IdP — bypasses request-util (axios) deliberately.
+      // See trex/plans/2026-07-27-axios-to-fetch-minimal-v3.md
+      const res = await fetch(`${this.issuerUrl}token`, {
+        method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded'
-        }
+        },
+        body,
+        signal: AbortSignal.timeout(30000)
       })
+      if (!res.ok) {
+        throw new Error(`IdP token request failed with status ${res.status}: ${await res.text()}`)
+      }
+      result = { data: (await res.json()) as ITokenResponse }
     } catch (err) {
       console.error('Error when getting client credentials token', err)
     }

--- a/plugins/functions/analytics-svc/src/api/PsConfigServerAPI.ts
+++ b/plugins/functions/analytics-svc/src/api/PsConfigServerAPI.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosRequestConfig } from "axios";
-import https from "https";
 import { env } from "../env";
 export default class PsConfigServerAPI {
     private readonly baseUrl: string;
@@ -42,15 +41,6 @@ export default class PsConfigServerAPI {
             client_secret: env.IDP__ALP_SVC__CLIENT_SECRET,
         };
 
-        const options: AxiosRequestConfig = {
-            headers: {
-                "Content-Type": "application/x-www-form-urlencoded",
-            }
-        };
-        if (env.NODE_ENV === "development") {
-            options.httpsAgent = new https.Agent({ rejectUnauthorized: false });
-        }
-
         const data = Object.keys(params)
             .map(
                 (key) =>
@@ -60,7 +50,20 @@ export default class PsConfigServerAPI {
             )
             .join("&");
 
-        const result = await axios.post(this.oauthUrl, data, options);
+        // External-capable IdP/OAuth endpoint — native fetch, not axios.
+        // See trex/plans/2026-07-27-axios-to-fetch-minimal-v3.md
+        const res = await fetch(this.oauthUrl, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: data,
+            signal: AbortSignal.timeout(30000),
+        });
+        if (!res.ok) {
+            throw new Error(
+                `OAuth token request failed with status ${res.status}: ${await res.text()}`
+            );
+        }
+        const result = { data: await res.json() };
 
         return `Bearer ${result.data.access_token}`;
     }
@@ -73,6 +76,8 @@ export default class PsConfigServerAPI {
             configVersion,
             lang,
         };
+        // Internal service (SERVICE_ROUTES.psConfig). Intentionally still axios:
+        // not on the external-HTTPS failure path.
         const result = await axios.post(
             `${this.baseUrl}/hc/hph/patient/app/services/config.xsjs`,
             body,

--- a/plugins/functions/jobplugins/src/api/OpenIDAPI.ts
+++ b/plugins/functions/jobplugins/src/api/OpenIDAPI.ts
@@ -1,5 +1,4 @@
 import { env, services } from "../env.ts";
-import { post } from "./request-util.ts";
 
 export class OpenIDAPI {
   private readonly baseURL: string;
@@ -20,21 +19,27 @@ export class OpenIDAPI {
     };
 
     try {
-      const options = this.createOptions("GET");
-      const result = await post(`${this.baseURL}/token`, body, options);
+      // External-capable IdP — bypasses request-util (axios) deliberately.
+      // Body stays JSON-encoded, matching the previous createOptions() headers.
+      // See trex/plans/2026-07-27-axios-to-fetch-minimal-v3.md
+      const res = await fetch(`${this.baseURL}/token`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `IdP token request failed with status ${res.status}: ${await res.text()}`
+        );
+      }
+      const result = { data: await res.json() };
       return result.data.access_token;
     } catch (err) {
       console.error("Error when getting client credentials token", err);
       throw err;
     }
-  }
-
-  private createOptions(method: string): RequestInit {
-    return {
-      method,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    };
   }
 }


### PR DESCRIPTION
Axios calls made from inside a trex-runtime worker fail against external HTTPS endpoints with `ECONNRESET` / `socket hang up`. Native `fetch` is unaffected. This migrates only the four call sites whose target host is operator-configurable and can therefore be external HTTPS.

### Root cause

Reproduced deterministically inside a real trex user worker on `supabase-edge-runtime-0.1.0 (compatible with Deno v2.7.14)`, across three runs against two independent hosts:

| Case | Result |
|---|---|
| `fetch` → `https://google.com` | ok `301` (10-40ms) |
| `fetch` → `https://api.github.com/zen` | ok `200` (8-27ms) |
| `axios.get` → both hosts | `ECONNRESET` / `socket hang up` |

9/9 axios failures, 6/6 fetch successes. `fetch` succeeds in the *same worker, same request* immediately before axios fails, which rules out worker teardown, egress policy, DNS and TLS. The cause is axios's Node HTTP adapter over the runtime's `node:http` compat layer.

### What changed

| Plugin | Method |
|---|---|
| analytics-svc | `PsConfigServerAPI.getClientCredentialsToken` |
| alp-usermgmt | `OpenIDAPI.getClientCredentialsToken` |
| jobplugins | `OpenIDAPI.getClientCredentialsToken` |
| fhir-init | `DbCredentialsAPI.getClientCredentialsToken` |

Each preserves its existing payload encoding and error contract:

- **jobplugins keeps its JSON body**; the other three keep `application/x-www-form-urlencoded`.
- alp-usermgmt still swallows failures and returns `undefined`; jobplugins and fhir-init still rethrow; analytics-svc still propagates.

analytics-svc drops its dev-only `rejectUnauthorized: false` — `fetch` has no per-request TLS escape hatch, and the option was inert anyway because the default OAuth endpoint is `http://`.

### What deliberately did *not* change

All other axios usage is retained: the 7 `request-util.ts` shims, `fhir-gateway` (its target is always an internal trex function plugin), `PrefectAPI`, `WebAPIAPI`, `BookmarkSvcProxy`, 21 type-only imports, and all 29 manifest declarations. Those call sites target in-cluster plain HTTP and are not on the failure path. Retained internal calls next to a migrated one are annotated so the asymmetry is not "tidied" later.

### Tests run

**Contract tests — 22 assertions, 0 failures.** Real modules imported and driven against a stub token endpoint, asserting method, `Content-Type`, body shape, and per-site error contract:

- jobplugins 5/5 — POST, `application/json`, JSON body, rethrows on 401
- alp-usermgmt 6/6 — POST, form-urlencoded, swallows 401 → `undefined`
- fhir-init 5/5 — POST, form-urlencoded, rethrows on 401
- analytics-svc 6/6 — POST, form-urlencoded, propagates on 401

**Typecheck — no new errors, net improvement.** `deno check` fails at baseline on these files, so the gate was "no new errors": analytics-svc 2 → 1, jobplugins 7 → 0, alp-usermgmt 0 → 0, fhir-init 0 → 0. The remaining analytics-svc error is pre-existing `TS2339` on the *retained* internal `axios.post`.

Not run: integration tests (login flow, jobplugins flow run, fhir-init bootstrap) — these need a working deployment.

### Notes for reviewers

- `PsConfigServerAPI` may be dead code: `psConfig` is absent from the deployed `SERVICE_ROUTES`, so its constructor throws before the migrated method is reachable. Migrated as-is; deleting the class may be a better follow-up.
- Private-CA HTTPS IdPs remain unaddressed. No process-wide trust is configured (`DENO_CERT` etc. unset), but per-request `ca:` injection was already commented out at every migrated site, so `fetch` is TLS-equivalent here — no regression. Tracked separately.
- Timeout errors change identity from `ECONNABORTED` to `TimeoutError`; verified no caller branches on it.

### Merge Checklist

- [x] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [x] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [x] following best practices in [code review doc](../code_review.md)
