### PR TITLE
[Backport v0.17 beta] Fix clearing optional dashboard filters

### DIFF
--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/CompleteRequiredFiltersModal.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/CompleteRequiredFiltersModal.vue
@@ -154,7 +154,7 @@ import MessageBox from '../MessageBox.vue'
 import appButton from '@/lib/ui/app-button.vue'
 import ConceptSetTypeaheadField from './ConceptSetTypeaheadField.vue'
 import type { WizardFieldDefinition } from '@/utils/dashboardFlowUtils'
-import { isConditionField } from '@/utils/dashboardFlowUtils'
+import { isConditionField, normalizeWizardFieldValueForComparison } from '@/utils/dashboardFlowUtils'
 import InputParser from '@/lib/utils/InputParser'
 import RangeConstraintTokenDefinition from '@/lib/utils/RangeConstraintTokenDefinition'
 import RangeConstraintPatternDefinition from '@/lib/utils/RangeConstraintPatternDefinition'
@@ -460,7 +460,8 @@ function markFieldDirty(fieldId: string) {
   }
 
   // For regular fields
-  const hasChanged = currentValue !== initialValue
+  const hasChanged =
+    normalizeWizardFieldValueForComparison(currentValue) !== normalizeWizardFieldValueForComparison(initialValue)
 
   if (hasChanged) {
     dirtyFields.add(fieldId)

--- a/plugins/ui/apps/vue-mri-ui-lib/src/composables/useDashboardFlow.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/composables/useDashboardFlow.ts
@@ -998,6 +998,12 @@ export function useDashboardFlow(
     }
     const rawValue = rawInput?.value ?? rawInput
     if (rawValue === null || typeof rawValue === 'undefined' || String(rawValue).trim() === '') {
+      if (constraintType === 'text' || constraintType === 'conceptSet') {
+        return dispatch('updateConstraintValue', {
+          constraintId: constraint.id,
+          value: [],
+        })
+      }
       return Promise.reject(new Error(`Missing value for ${constraint.props.name || constraint.id}`))
     }
     const finalDisplayValue = displayValue || rawInput?.displayName || String(rawValue)

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/dashboardFlowUtils.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/dashboardFlowUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { getWizardFlow, isWizardVisibleOnSurface, parseNumericInput, validateRequiredFields } from '../dashboardFlowUtils'
+import {
+  getWizardFlow,
+  isWizardVisibleOnSurface,
+  normalizeWizardFieldValueForComparison,
+  parseNumericInput,
+  validateRequiredFields,
+} from '../dashboardFlowUtils'
 
 const createExpression = (operator: string, value: string | number) => ({
   type: 'Expression' as const,
@@ -212,5 +218,17 @@ describe('wizard metadata helpers', () => {
   it('defaults missing flow to required-fields', () => {
     expect(getWizardFlow({})).toBe('required-fields')
     expect(getWizardFlow({ flow: 'table1-config' })).toBe('table1-config')
+  })
+})
+
+describe('wizard field value helpers', () => {
+  it('treats null, undefined, and an empty string as the same empty form value', () => {
+    expect(normalizeWizardFieldValueForComparison(null)).toBe('')
+    expect(normalizeWizardFieldValueForComparison(undefined)).toBe('')
+    expect(normalizeWizardFieldValueForComparison('')).toBe('')
+  })
+
+  it('preserves non-empty field values', () => {
+    expect(normalizeWizardFieldValueForComparison('FEMALE')).toBe('FEMALE')
   })
 })

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/dashboardFlowUtils.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/dashboardFlowUtils.ts
@@ -100,6 +100,10 @@ export interface RequiredFieldValidationResult {
   breakdown: FieldComparisonBreakdown[]
 }
 
+export function normalizeWizardFieldValueForComparison(value: unknown): unknown {
+  return value === null || typeof value === 'undefined' ? '' : value
+}
+
 function getLastPathSegment(path: string): string {
   const tokens = path.split('.')
   return tokens[tokens.length - 1] || path


### PR DESCRIPTION
## Summary

Backports #2913 to `release/v0.17.0-beta`.

- Normalize empty optional dashboard filter values.
- Clear the filter-card constraint with `[]` when a previously selected optional value is removed.
- Keep required-filter modal state consistent after a field is cleared.

## Why

Selecting and then clearing an optional Cohort Builder wizard field could leave an invalid constraint and show an error. This applies the reviewed fix from #2913 to the v0.17 beta release line.

## User impact

Users can clear optional dashboard filters without encountering the previous error.

## Validation

- `npm --prefix plugins/ui/apps/vue-mri-ui-lib run test:unit -- src/utils/__tests__/dashboardFlowUtils.test.ts` — 13 tests passed.
- `git diff --check origin/release/v0.17.0-beta...HEAD` — passed.
- Backport patch ID matches the merged #2913 squash commit (`c6479368ffc82a9274e39d1a05bee253ad18a81b`).
