### PR TITLE
Fix attrition plot filter name mismatch

### DIFF
--- a/plugins/functions/analytics-svc/src/mri/endpoint/InclusionReportEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/InclusionReportEndpoint.ts
@@ -551,22 +551,18 @@ export class InclusionReportEndpoint extends BaseQueryEngineEndpoint {
             return [];
         }
 
-        let basicDataInclusionReportFilters;
-        if (basicDataFilters.length === 1) {
-            basicDataInclusionReportFilters = [
-                structuredClone(basicDataFiltercard),
+        // Split Basic Data into distinct filtercards, one per constrained attribute.
+        // This must also happen for a single constrained attribute
+        const basicDataInclusionReportFilters = basicDataFilters.map((e) => {
+            // Clone overall structure of Basic Data filter card and replace attributes.content with individual Basic Data attributes.content
+            const basicDataFiltercardClone =
+                structuredClone(basicDataFiltercard);
+            basicDataFiltercardClone.content[0].attributes.content = [
+                structuredClone(e),
             ];
-        } else {
-            // Split Basic Data into distinct filtercards
-            basicDataInclusionReportFilters = basicDataFilters.map((e) => {
-                // Clone overall structure of Basic Data filter card and replace attributes.content with individual Basic Data attributes.content
-                const basicDataFiltercardClone =
-                    structuredClone(basicDataFiltercard);
-                basicDataFiltercardClone.content[0].attributes.content = [e];
 
-                return basicDataFiltercardClone;
-            });
-        }
+            return basicDataFiltercardClone;
+        });
 
         // Update basic data to use dynamically generated interactions.basicdata in cdm config
         basicDataInclusionReportFilters.forEach((e, idx) => {


### PR DESCRIPTION
**Cause**:
When exactly one `Basic Data` attribute has constraints and it isn't the first attribute in the card's attribute list, the `basicDataFilters.length === 1` special case in `splitBasicDataIntoDistinctFiltercards` derives the rule name from cur.attributes.content[0].configPath which is the first `Basic Data filter` in the attributes list, even if it's not filled.

**Fix**:
1. Removed the `basicDataFilters.length === 1` special case so every `Basic Data` card goes through the narrowing map. 
2. Also wrapped `e` in `structuredClone` as the old map branch put the caller's attribute object straight into the clone, so the naming `forEach` below rewrote configPath/instanceID on the incoming mriquery in place.



https://github.com/user-attachments/assets/9bab4301-c4f0-4a6c-ab27-fad27c8b78ed




### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)