### PR TITLE
Add WebMCP tool surface to PA

### DIFF
--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/README.md
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/README.md
@@ -1,0 +1,178 @@
+# `src/ai` — Patient Analytics agent tool surface
+
+The `pa_*` tools that let an AI agent drive the **Patient Analytics (PA)** cohort
+builder: read the live cohort, edit it with typed patch ops, resolve filter values,
+read the computed result, and save.
+
+> This README is for *developers* — what the tools are, how they are wired, how to test and extend them.
+> Behavioural rules for the model belong there (and in each tool's `description`),
+> not here.
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| [`webmcpServer.ts`](./webmcpServer.ts) | The tool definitions. `createPaTools(store, hooks)` builds the array; `registerPaTools` adapts it to the browser's `modelContext`. |
+| [`paToolBridge.ts`](./paToolBridge.ts) | `publishPaTools(store, hooks)` — publishes the same tools on `window.__d2ePaTools` for the portal's in-app assistant drawer. |
+| [`cohortPatch.ts`](./cohortPatch.ts) | `applyCohortPatch` (the typed-patch applier) and `describeCardGroups` (the AND/OR grouping readout). |
+| [`valueResolution.ts`](./valueResolution.ts) | Query → stored-token matching for `pa_search_attribute_values`: `rankValues`, `alternateQueries`, `expandQuery`. Browser-side twin of the backend's `cohortValueResolver.ts`. |
+| [`__tests__/`](./__tests__/) | Vitest suites, one per module. |
+
+## Wiring
+
+Both surfaces are created on `PatientAnalytics.vue` mount and torn down on
+unmount — the tools exist **only while PA is on screen**, and no tool can mount PA:
+
+```ts
+// PatientAnalytics.vue, mounted()
+const paToolHooks = { showBuilder: () => this.toggleCohorts(false) }
+this._unregisterPaTools = registerPaTools(this.$store, paToolHooks)  // browser agent
+this._unpublishPaTools  = publishPaTools(this.$store, paToolHooks)   // portal drawer
+```
+
+**One tool array, two consumers** — a tool can never exist for one and not the other:
+
+1. **External browser agent** (Chrome DevTools MCP / Claude) via WebMCP.
+   `registerPaTools` looks for `document.modelContext`, falling back to
+   `navigator.modelContext` (Chrome 146–149, deprecated). Requires
+   `chrome://flags/#enable-webmcp-testing`; without it the register call warns and
+   no-ops. Do **not** import the `@mcp-b/global` polyfill when the flag is on.
+2. **Portal AI assistant drawer** via the `window.__d2ePaTools` registry
+   (`{ version, datasetId, list(), call() }`). The drawer runs in a different
+   single-spa bundle with no shared module graph, hence a `window` registry rather
+   than an import. Consumers must **re-read the registry at call time** — PA deletes
+   it on unmount, and that re-read is what turns "PA went away mid-conversation"
+   into a clean error instead of a dead store. `PA_TOOLS_CHANGED_EVENT` fires on
+   appear/disappear. Bump `version` on any incompatible shape change; the portal
+   side refuses a version it doesn't understand.
+
+`PaComponentHooks` carries anything that lives in the component rather than Vuex.
+Today that is only `showBuilder()` — functionally required, because the chart-query
+watcher only runs while the builder (and its chart) is mounted, so without it a
+programmatically built cohort never computes a count.
+
+## The tools
+
+All return the MCP envelope `{ content: [{ type: 'text', text: '<json>' }] }`.
+
+| Tool | Args | Returns |
+|---|---|---|
+| `pa_new_cohort` | `name?` | Resets the builder to a blank cohort and switches to the builder view. |
+| `pa_get_current_cohort` | — | `{ bookmarkData, ifr, cardGroups, cardGroupsNote }` — the definition, plus the real `filterCardId`s and the AND/OR grouping. |
+| `pa_list_cohorts` | `forceRefresh?` | `{ cohorts: [{ bmkId, name }] }`. The default path can serve a stale cache — force after a save. |
+| `pa_open_cohort` | `name` \| `bmkId`, `chartType?` | Loads a saved cohort and renders it. Reports `ambiguous` when a name matches several. |
+| `pa_apply_cohort_patch` | `patchOps[]`, `bookmark?` (legacy), `chartType?` | Applies typed ops in place; result carries `appliedConstraints` + `cardGroups`. On failure: `{ applied:false, error, validFilterOptions }`. |
+| `pa_list_filter_options` | `card?` | `{ filterCards:[{ cardConfigPath, cardName, attributes:[{ attributePath, name, type, valueKind, conceptDomain? }] }], valueKindGuide, note }`. |
+| `pa_search_attribute_values` | `attributePath`, `query?`, `attributeType?`, `limit?` | `{ matchedVia, total, returned, truncated, loadedStatus, domainTotal?, values, note? }`. |
+| `pa_get_cohort_result` | — | `{ currentPatientCount, totalPatientCount, chartType, chart }` — the **live computed** result, not the definition. |
+| `pa_save_current_cohort` | `name?`, `share?`, `bookmarkId?`, `method?`, `params?` | Inserts or updates via `fireBookmarkQuery`, refreshes the list, adopts the saved record as active. |
+
+### Patch ops
+
+`pa_apply_cohort_patch` is the only way to add or remove a filter. Ops are typed
+*intent* applied by the app's own store actions — the applier **is** the builder:
+
+```
+{ op:"add_card", cardConfigPath, exclude?, ref?, orWith? }
+{ op:"add_constraint", card, attributePath, value, operator? }
+{ op:"remove_card", card }
+{ op:"remove_constraint", card, attributePath }
+{ op:"set_card_join", card, join:"AND"|"OR" }
+```
+
+Cards in the same group are OR-ed; groups are AND-ed. `orWith` puts a new card in
+an existing card's group; `set_card_join` regroups the **later** card of a pair.
+The Basic Data card (`patient`) always exists — constrain it, never `add_card` it.
+
+The legacy `{ bookmark }` argument takes a full tree and is kept for back-compat
+with backend builders only. A hand-authored tree is rejected and the previous
+active bookmark restored, because `loadBookmarkDataToState` clobbers the active
+bookmark with a stub *before* it parses — a malformed tree used to leave the
+builder pointing at a broken cohort that then crashed the chart.
+
+### `valueKind` routing
+
+`pa_list_filter_options` tags every attribute with a `valueKind` and ships a single
+`valueKindGuide` legend per response. This matters most on non-OMOP (SAP HANA /
+LEAF) datasets, which filter on **source concept codes** and **concept sets**, not
+OMOP standard concept ids — a bare `type:"text"` doesn't distinguish those.
+
+| `valueKind` | How the value is supplied |
+|---|---|
+| `numeric` | `value:<number>` + `operator` |
+| `date` | `value:{ from, to }` |
+| `conceptSet` | `value:{ conceptSetId }`, built via backend `d2e-mcp`; must match the attribute's `conceptDomain` |
+| `catalog` | exact stored token resolved with `pa_search_attribute_values` |
+| `text` | `value:<string>` |
+
+### Value resolution
+
+The `/values` endpoint search runs in the database: it is case-sensitive and
+matches the stored token, not the word for it. So a zero-hit search is never proof
+a value is absent, and `pa_search_attribute_values` compensates in layers before it
+gives up — reported back as `matchedVia`:
+
+| `matchedVia` | Meaning |
+|---|---|
+| `search` | the endpoint's own search matched |
+| `domain-scan` | search was empty; the unfiltered domain was re-read and matched locally (`rankValues`) |
+| `alternate-query` | matched via a rewritten query (`alternateQueries`: casings, expansions, distinctive words) |
+| `domain` | nothing matched — the rows are the attribute's **complete** value list, to pick from |
+| `none` | the column could not be read at all; try a different `attributePath` |
+
+Two subtleties worth knowing before you touch this path:
+
+- Before every unfiltered read the handler commits `DOMAIN_SET_VALUES … isLoaded:false`.
+  An earlier search leaves the attribute cached as loaded with *that search's*
+  (possibly empty) rows, and the store would serve them back — turning the domain
+  fallback into a no-op that confirms its own miss.
+- The store resolves `undefined` when a newer request for the same `attributePath`
+  supersedes an in-flight one. That's a race, not an empty domain, so
+  `fetchValuesRetrying` retries once (the retry is uncontended).
+
+`limit` defaults to `DEFAULT_VALUE_LIMIT` (50), capped at `MAX_VALUE_LIMIT` (200),
+and is re-validated at run time by `resolveValueLimit` — it crosses an unvalidated
+tool boundary, so the declared schema is not what makes it a number.
+
+## Payload budget
+
+Tool output lands in the agent transcript, which is resent **in full on every
+turn** — so payload size is a correctness concern, not just a cost one. Two
+deliberate designs:
+
+- The `valueKindGuide` legend is sent once per response instead of inlined per
+  attribute. A dataset can expose 170+ filter attributes; hoisting the ~150 chars
+  took `pa_list_filter_options` from ≈60 KB to ≈27 KB.
+- A failed patch attaches `recoveryFilterOptions`, not the whole catalog: every card
+  by path + name, plus the attributes of only the card(s) the failing ops named.
+  Re-sending everything duplicated ~30 KB per failure, and two of those blew the
+  drawer's request body limit.
+
+Only `getFilterAttributes()` is listed, never `getAllAttributes()` — the latter
+includes measure/category-only attributes that `add_constraint` cannot target.
+
+## Testing
+
+```bash
+cd plugins/ui/apps/vue-mri-ui-lib
+yarn test:unit                    # or: npx vitest run src/ai
+```
+
+`createPaTools` is exported separately from `registerPaTools` precisely so the
+handlers can be tested against a **mocked Vuex store** — no Chrome flag, no
+`modelContext`, no browser. That handler ↔ Vuex layer is where the real bugs live;
+`registerPaTools` is a thin adapter over whatever the array contains.
+
+## Adding or changing a tool
+
+1. Add it to the array returned by `createPaTools` — both consumers pick it up.
+2. Write the `description` for the model, not for a developer: state when to call
+   it, what the fields mean, and the failure it should avoid. These descriptions are
+   the primary behavioural contract and are long on purpose.
+3. Make failures self-correcting — return the thing that fixes the error (valid
+   paths, the complete value list) rather than a message the model must chase.
+4. Add a case to [`__tests__/webmcpServer.test.ts`](./__tests__/webmcpServer.test.ts).
+5. Changing the registry shape or the change event in `paToolBridge.ts` requires the
+   portal-side consumer to land together with it; bump `PaToolRegistry.version`.

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/paToolBridge.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/paToolBridge.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { publishPaTools, PA_TOOLS_CHANGED_EVENT } from '../paToolBridge'
+import { createPaTools } from '../webmcpServer'
+
+// Same minimal Vuex stand-in as webmcpServer.test.ts, plus getSelectedDataset —
+// the bridge surfaces the loaded dataset so the drawer can refuse to edit a
+// cohort belonging to a different dataset than the one the user is looking at.
+const makeStore = (datasetId: string | null = 'ds-1') => ({
+  getters: {
+    getBookmarksData: { name: 'Elderly Diabetics', cards: ['c1'] },
+    getBookmarkFromIFR: { filter: { age: { min: 65 } } },
+    getBookmarks: [],
+    getActiveBookmark: null,
+    getSelectedDataset: datasetId === null ? undefined : { id: datasetId },
+  },
+  dispatch: vi.fn().mockResolvedValue(undefined),
+  commit: vi.fn(),
+})
+
+const registry = () => {
+  const reg = window.__d2ePaTools
+  if (!reg) throw new Error('registry not published')
+  return reg
+}
+
+describe('publishPaTools', () => {
+  afterEach(() => {
+    delete window.__d2ePaTools
+    vi.restoreAllMocks()
+  })
+
+  it('publishes a descriptor for every createPaTools tool', () => {
+    const store: any = makeStore()
+
+    publishPaTools(store)
+
+    const names = registry()
+      .list()
+      .map(t => t.name)
+    expect(names).toEqual(createPaTools(store).map(t => t.name))
+    expect(registry().version).toBe(1)
+    // Descriptors must carry what a model needs to call the tool.
+    for (const descriptor of registry().list()) {
+      expect(descriptor.description).toBeTruthy()
+      expect(descriptor.inputSchema).toBeTruthy()
+    }
+  })
+
+  it('announces availability on publish and on teardown', () => {
+    const seen: boolean[] = []
+    const listener = (e: Event) => seen.push((e as CustomEvent).detail.available)
+    window.addEventListener(PA_TOOLS_CHANGED_EVENT, listener)
+
+    const teardown = publishPaTools(makeStore() as any)
+    teardown()
+
+    window.removeEventListener(PA_TOOLS_CHANGED_EVENT, listener)
+    expect(seen).toEqual([true, false])
+  })
+
+  it('reads datasetId live rather than snapshotting it', () => {
+    const store: any = makeStore('ds-1')
+    publishPaTools(store)
+    expect(registry().datasetId).toBe('ds-1')
+
+    // The user switched datasets while PA stayed mounted.
+    store.getters.getSelectedDataset = { id: 'ds-2' }
+    expect(registry().datasetId).toBe('ds-2')
+  })
+
+  it('reports a null datasetId when no dataset is loaded', () => {
+    publishPaTools(makeStore(null) as any)
+    expect(registry().datasetId).toBeNull()
+  })
+
+  it('executes a tool through call() and returns its MCP result envelope', async () => {
+    const store: any = makeStore()
+    publishPaTools(store)
+
+    const result = await registry().call('pa_get_current_cohort')
+
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      bookmarkData: store.getters.getBookmarksData,
+      ifr: store.getters.getBookmarkFromIFR,
+    })
+  })
+
+  it('passes arguments through to the tool handler', async () => {
+    const store: any = makeStore()
+    publishPaTools(store)
+
+    await registry().call('pa_new_cohort', { name: 'Cohort X' })
+
+    expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', {
+      bookmarkname: 'Cohort X',
+      isNew: true,
+    })
+  })
+
+  it('rejects an unknown tool with the available names', async () => {
+    publishPaTools(makeStore() as any)
+
+    await expect(registry().call('pa_not_a_tool')).rejects.toThrow(/Unknown PA tool "pa_not_a_tool".*pa_new_cohort/s)
+  })
+
+  it('removes the registry on teardown', () => {
+    const teardown = publishPaTools(makeStore() as any)
+    teardown()
+    expect(window.__d2ePaTools).toBeUndefined()
+  })
+
+  // A remount can publish before the outgoing instance tears down. The stale
+  // teardown must not remove the live registry — that would leave the drawer
+  // believing PA is gone while it is on screen.
+  it('teardown of a superseded registry leaves the newer one in place', () => {
+    const staleTeardown = publishPaTools(makeStore() as any)
+    publishPaTools(makeStore('ds-2') as any)
+
+    staleTeardown()
+
+    expect(window.__d2ePaTools).toBeDefined()
+    expect(registry().datasetId).toBe('ds-2')
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/valueResolution.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/valueResolution.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest'
+import { alternateQueries, rankValues, MAX_ALTERNATE_QUERIES, type ValueRow } from '../valueResolution'
+
+// The rules are written as query → expected-rows vectors rather than as assertions
+// about the implementation, because the same table has to hold for a SECOND
+// implementation: the mcp-server resolver that answers the deep-link surface (the
+// cohort tools that exist when PA is not mounted). The two cannot share a module —
+// that one is Deno, this one is bundled by Vite, and nothing crosses that boundary
+// in this repo — so a shared table is what keeps them in step.
+//
+// The vectors live here for now because that resolver is not in this branch. When it
+// lands, MOVE this table to
+// plugins/functions/mcp-server/src/lib/__fixtures__/value-resolution-vectors.json
+// and have both suites read it: while the rules exist in only one suite, a ranking
+// change can improve one surface and silently leave the other behind — which is
+// exactly what had happened (the backend resolved "ER visit" and these tools did not).
+//
+// THE RULES, best match first. Each is a property of the two strings or of the
+// column, not a list of terms someone thought of, so they hold on a dataset nobody
+// here has seen:
+//   0  the row IS the term            after casing and demographic-synonym expansion
+//   1  the row CONTAINS the term      as a substring, 3+ characters
+//   2  the term ABBREVIATES the row   read from the row's FIRST word, each query word
+//                                     consuming either the next row word or the
+//                                     initials of the next several
+//      …or the row IS the term's CODE the same initials rule read the other way
+//                                     ('F' <- Female)
+//   3  every DISTINCTIVE word is present
+//   4  some distinctive word is present
+//
+// A word is distinctive when it separates one row of THIS column from another —
+// measured as the share of rows carrying it (>= 60%, over columns of 4+ rows, is
+// filler). Below that the rules fall back to a small seeded list, because a frequency
+// over two rows means nothing.
+//
+// Two things stay seeded and cannot be derived: demographic synonyms ("women" ->
+// "female"; no structure gets you there) and abbreviations whose expansion is NOT in
+// the row ("ICU" where the column says "Intensive Care"). The seeds also drive the
+// blind-retry path, which has no rows to measure — an abbreviation cannot be inverted
+// into a search term without a lexicon.
+
+/**
+ * `rows` use a neutral shape { value, label }; the backend suite maps the same table
+ * onto its own row type. Row counts matter: a case written with two rows is testing
+ * the seeded fallback, not the measured rule.
+ */
+interface RankingVector {
+  name: string
+  /** Why the case exists. Documentation — no assertion reads it. */
+  why?: string
+  query: string
+  rows: Array<{ value: string; label: string }>
+  /** The `value` of every row that must match, best first. Empty = nothing may match. */
+  expectedOrder: string[]
+}
+
+/** The retry queries used when the attribute's domain cannot be enumerated. */
+interface AlternateQueryVector {
+  name: string
+  why?: string
+  query: string
+  mustInclude?: string[]
+  mustNotInclude?: string[]
+  maxLength?: number
+}
+
+const RANKING_VECTORS: RankingVector[] = [
+  {
+    name: 'an exact token beats a longer value that merely contains it',
+    query: 'F',
+    rows: [
+      { value: 'FEMALE_RELATIVE', label: 'Female relative' },
+      { value: 'F', label: 'Female' },
+    ],
+    expectedOrder: ['F', 'FEMALE_RELATIVE'],
+  },
+  {
+    name: 'casing alone never hides a value',
+    why: 'The /values search runs a case-sensitive LIKE in the database.',
+    query: 'female',
+    rows: [{ value: '8532', label: 'FEMALE' }],
+    expectedOrder: ['8532'],
+  },
+  {
+    name: 'the value column is matched too, not only the label',
+    query: 'sinusitis',
+    rows: [{ value: 'Acute sinusitis', label: '' }],
+    expectedOrder: ['Acute sinusitis'],
+  },
+  {
+    name: 'a demographic synonym resolves to the stored token',
+    why:
+      'The user says "women"; the column stores "F". Never ask the user how their data spells it. ' +
+      'Not derivable — this one is seeded.',
+    query: 'women',
+    rows: [
+      { value: 'M', label: 'Male' },
+      { value: 'F', label: 'Female' },
+    ],
+    expectedOrder: ['F'],
+  },
+
+  {
+    name: 'a term reaches a row it is not a substring of, by abbreviating it',
+    why: 'The reported failure: the /values search found nothing and the assistant reported the value absent.',
+    query: 'ER Visit',
+    rows: [
+      { value: '9203', label: 'Emergency Room Visit' },
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: '9202', label: 'Outpatient Visit' },
+    ],
+    expectedOrder: ['9203'],
+  },
+  {
+    name: 'an acronym no list contains still reaches its expansion',
+    why:
+      'The point of deriving the rule: NICU is in no table here, and neither will be whatever a given dataset ' +
+      'uses (ASC, LTACH, PCP). The initials must come out of the row itself.',
+    query: 'NICU',
+    rows: [
+      { value: '581379', label: 'Neonatal Intensive Care Unit' },
+      { value: '32037', label: 'Intensive Care Unit' },
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: '8717', label: 'Nursing Home' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'initials are read from the START of the row, never from inside it',
+    why:
+      'Precision over recall, the same trade this module makes everywhere: reading initials from anywhere ' +
+      'inside a row lets an acronym claim rows it does not name, and a near-miss value is a silent clinical ' +
+      'error. A row an acronym does not reach is still shown — nothing matching returns the whole column.',
+    query: 'ASC',
+    rows: [
+      { value: '581379', label: 'Ambulatory Surgical Center' },
+      { value: '8940', label: 'Hospital Ambulatory Surgical Center' },
+      { value: '9201', label: 'Inpatient Visit' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'a seeded abbreviation covers an expansion the row does not spell out',
+    why:
+      'The column says "Intensive Care"; there is no "U" in the row to derive the U of ICU from. This is why ' +
+      'the seed list still exists.',
+    query: 'ICU',
+    rows: [
+      { value: '32037', label: 'Intensive Care' },
+      { value: '9201', label: 'Inpatient Visit' },
+    ],
+    expectedOrder: ['32037'],
+  },
+  {
+    name: "a coded column is reached by the term's own initials",
+    why:
+      'Not a demographics rule: marital status, discharge status and yes/no flags are all stored as bare ' +
+      "letters, and no synonym table can enumerate them. The row's code has to be derived FROM the term.",
+    query: 'single',
+    rows: [
+      { value: 'S', label: 'S' },
+      { value: 'M', label: 'M' },
+      { value: 'W', label: 'W' },
+      { value: 'D', label: 'D' },
+    ],
+    expectedOrder: ['S'],
+  },
+
+  {
+    name: 'a word nearly every row carries stops discriminating',
+    why: '"Visit" cannot tell you which visit type is meant when four rows in five say it.',
+    query: 'intensive care visit',
+    rows: [
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: '9202', label: 'Outpatient Visit' },
+      { value: '9203', label: 'Emergency Room Visit' },
+      { value: '581379', label: 'Inpatient Intensive Care' },
+      { value: '262', label: 'Emergency Room and Inpatient Visit' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'the same word still discriminates in a column that does not repeat it',
+    why:
+      'The converse, and the reason filler is measured rather than listed: here "visit" is what separates one ' +
+      'row from the other, so the row carrying it must rank first.',
+    query: 'emergency visit',
+    rows: [
+      { value: '9203', label: 'Emergency Room Visit' },
+      { value: '8870', label: 'Emergency Room - Hospital' },
+      { value: '4021', label: 'Operating Room' },
+      { value: '32037', label: 'Intensive Care' },
+      { value: '8717', label: 'Nursing Home' },
+    ],
+    expectedOrder: ['9203', '8870'],
+  },
+  {
+    name: 'a column too short to measure falls back to the seeded filler words',
+    why:
+      'Two rows is not a frequency. Without the fallback "visit" would count as distinctive and the target ' +
+      'row, which lacks it, would drop below a row that has nothing else in common.',
+    query: 'intensive care visit',
+    rows: [
+      { value: '581379', label: 'Inpatient Intensive Care' },
+      { value: '9202', label: 'Outpatient Visit' },
+    ],
+    expectedOrder: ['581379'],
+  },
+  {
+    name: 'a row sharing only one distinctive word ranks below the phrase matches',
+    query: 'emergency room',
+    rows: [
+      { value: '8870', label: 'Emergency Room - Hospital' },
+      { value: '9203', label: 'Emergency Room and Inpatient Visit' },
+      { value: '4021', label: 'Operating Room' },
+    ],
+    expectedOrder: ['8870', '9203', '4021'],
+  },
+
+  {
+    name: 'an unrelated term matches nothing rather than something close',
+    why: 'A near-miss clinical concept is a silent clinical error; better to return the whole column.',
+    query: 'diabetes',
+    rows: [
+      { value: '9201', label: 'Inpatient Visit' },
+      { value: 'F', label: 'Female' },
+    ],
+    expectedOrder: [],
+  },
+  {
+    name: 'an empty query matches nothing (the caller asks for the whole domain instead)',
+    query: '',
+    rows: [{ value: 'F', label: 'Female' }],
+    expectedOrder: [],
+  },
+]
+
+const ALTERNATE_QUERY_VECTORS: AlternateQueryVector[] = [
+  {
+    name: 'a phrase the endpoint cannot match is retried by its expansions',
+    why: 'Title case first: a stored concept name usually looks like "Emergency Room Visit".',
+    query: 'ER visit',
+    mustInclude: ['Emergency Room Visit', 'Emergency Room', 'ER VISIT'],
+    mustNotInclude: ['visit', 'Visit', 'VISIT'],
+  },
+  {
+    name: 'casings are swept for a case-sensitive LIKE',
+    query: 'female',
+    mustInclude: ['Female', 'FEMALE'],
+  },
+  {
+    name: 'bounded, so a failed search cannot fan out into many endpoint calls',
+    query: 'acute upper respiratory infection of the intensive care unit',
+    maxLength: 9,
+  },
+]
+
+// The neutral { value, label } row shape onto what the /values endpoint returns.
+const toValueRow = ({ value, label }: { value: string; label: string }): ValueRow => ({
+  value,
+  text: label,
+  display_value: label,
+})
+
+describe('valueResolution — the contract shared with the backend resolver', () => {
+  it.each(RANKING_VECTORS)('$name', ({ query, rows, expectedOrder }) => {
+    const ranked = rankValues(rows.map(toValueRow), query).map(m => String(m.row.value))
+    expect(ranked).toEqual(expectedOrder)
+  })
+
+  it.each(ALTERNATE_QUERY_VECTORS)('$name', ({ query, mustInclude, mustNotInclude, maxLength }) => {
+    const queries = alternateQueries(query)
+    for (const expected of mustInclude ?? []) expect(queries).toContain(expected)
+    for (const forbidden of mustNotInclude ?? []) expect(queries).not.toContain(forbidden)
+    expect(queries.length).toBeLessThanOrEqual(maxLength ?? MAX_ALTERNATE_QUERIES)
+  })
+})
+
+// Browser-side specifics, not part of the shared contract.
+describe('valueResolution', () => {
+  it('never returns the query itself as an alternate — it has already been tried', () => {
+    expect(alternateQueries('Female')).not.toContain('Female')
+  })
+
+  it('ignores a row with no label and no value', () => {
+    expect(rankValues([{ value: '', text: '', display_value: '' }], 'female')).toEqual([])
+  })
+
+  // A two-letter synonym as a substring rule would match half the column ("f" is
+  // in "Left foot"), so short variants are matched by equality only.
+  it('does not substring-match a short synonym', () => {
+    const ranked = rankValues([{ value: 'LF', text: 'Left foot', display_value: 'Left foot' }], 'female')
+    expect(ranked).toEqual([])
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -663,6 +663,29 @@ describe('createPaTools', () => {
       expect(bare.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
       expect(parse(bareRes)).toEqual({ created: true, name: 'New cohort' })
     })
+
+    it('captures the post-reset baseline so an untouched new cohort reports clean', async () => {
+      const store = makeStore()
+      // resetChart replaces the live cohort definition, so the baseline has to be the
+      // RESET state and not the cohort that was open before — which is why
+      // Bookmarks.vue addNewCohort() snapshots after `await this.reset()` + $nextTick.
+      store.dispatch.mockImplementation((type: string) => {
+        if (type === 'resetChart') store.getters.getBookmarksData = { name: 'New cohort', cards: [] }
+        return Promise.resolve(undefined)
+      })
+
+      await byName(createPaTools(store), 'pa_new_cohort').execute({ name: 'New cohort' })
+
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK_BASELINE', { name: 'New cohort', cards: [] })
+      // Order matters: SET_ACTIVE_BOOKMARK clears activeBookmarkBaseline, and a new
+      // cohort has no saved `.bookmark` JSON to fall back on — so a baseline captured
+      // first (or not at all) leaves getCurrentBookmarkHasChanges reporting a
+      // zero-edit cohort as dirty, firing the unsaved-changes navigation guard.
+      expect(store.commit.mock.calls.map((c: any[]) => c[0])).toEqual([
+        'SET_ACTIVE_BOOKMARK',
+        'SET_ACTIVE_BOOKMARK_BASELINE',
+      ])
+    })
   })
 
   describe('pa_search_attribute_values', () => {
@@ -729,6 +752,36 @@ describe('createPaTools', () => {
         limit: 10000,
       })
       expect(parse(res).returned).toBe(200)
+    })
+
+    // inputSchema says `limit` is a number, but nothing enforces that at run time:
+    // neither registerTool nor paToolBridge.call() validates arguments against the
+    // schema, so whatever the model emitted arrives verbatim. A quoted number must
+    // still cap, and a non-numeric one must fall back — the old
+    // `Math.min(limit ?? DEFAULT, MAX)` made the cap NaN, and `slice(0, NaN)` is [],
+    // so the tool reported "returned: 0" for a search that had 500 matches.
+    it.each([
+      ['a numeric string', '25', 25],
+      ['a non-numeric string', 'twenty', 50],
+      ['a blank string', '   ', 50],
+      ['null', null, 50],
+      ['a NaN-y object', {}, 50],
+    ])('coerces %s limit rather than capping to zero rows', async (_label, limit, expected) => {
+      const store = makeStore()
+      const values = Array.from({ length: 500 }, (_, i) => ({ value: String(i), text: `t${i}` }))
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'p.attr',
+        query: 'x',
+        limit,
+      })
+
+      const parsed = parse(res)
+      expect(parsed.returned).toBe(expected)
+      expect(parsed.values).toHaveLength(expected)
+      expect(parsed.total).toBe(500)
     })
 
     it('surfaces loadedStatus TOO_MANY_RESULTS so the model narrows instead of concluding "absent"', async () => {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -1,0 +1,968 @@
+import { vi } from 'vitest'
+import { createPaTools, registerPaTools, PaTool } from '../webmcpServer'
+
+// A minimal Vuex-store stand-in. Only the surface the handlers touch is mocked:
+// a few getters and dispatch. This is verification "layer B" — handler ↔ Vuex
+// correctness — with no browser / modelContext in play.
+//
+// `bookmarks` seeds getters.getBookmarks (saved-cohort records shaped like the
+// real store: { bmkId, bookmarkname, ... }). `loadAllResult`, when set, is what
+// getBookmarks becomes after a `fireBookmarkQuery({cmd:'loadAll'})` dispatch —
+// so we can exercise the "list not loaded yet" branch realistically.
+const makeStore = ({ bookmarks = [], loadAllResult }: { bookmarks?: any[]; loadAllResult?: any[] } = {}) => {
+  const store: any = {
+    getters: {
+      getBookmarksData: { name: 'Elderly Diabetics', cards: ['c1'] },
+      getBookmarkFromIFR: { filter: { age: { min: 65 } } },
+      getBookmarks: bookmarks,
+      getActiveBookmark: null,
+    },
+    dispatch: vi.fn(),
+    commit: vi.fn(),
+  }
+  store.dispatch.mockImplementation((type: string, payload: any) => {
+    if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'loadAll' && loadAllResult) {
+      store.getters.getBookmarks = loadAllResult
+    }
+    return Promise.resolve(undefined)
+  })
+  return store
+}
+
+const byName = (tools: PaTool[], name: string): PaTool => {
+  const tool = tools.find(t => t.name === name)
+  if (!tool) throw new Error(`tool ${name} not registered`)
+  return tool
+}
+
+// Every handler returns { content: [{ type: 'text', text: <json> }] }.
+const parse = (res: { content: Array<{ text: string }> }) => JSON.parse(res.content[0].text)
+
+describe('createPaTools', () => {
+  it('registers exactly the expected PA tools with required-arg schemas', () => {
+    const tools = createPaTools(makeStore())
+
+    expect(tools.map(t => t.name)).toEqual([
+      'pa_new_cohort',
+      'pa_get_current_cohort',
+      'pa_list_cohorts',
+      'pa_open_cohort',
+      'pa_apply_cohort_patch',
+      'pa_list_filter_options',
+      'pa_search_attribute_values',
+      'pa_get_cohort_result',
+      'pa_save_current_cohort',
+    ])
+    // pa_save_current_cohort has no unconditionally-required input: it builds the
+    // payload from live store state given { name } (insert) or { bookmarkId } (update),
+    // and still accepts a raw `params` escape hatch — the handler validates the combo.
+    expect((byName(tools, 'pa_save_current_cohort').inputSchema as any).required).toBeUndefined()
+    // pa_search_attribute_values requires only the attribute: omitting `query`
+    // lists the column's complete value domain, which is the reliable route for a
+    // low-cardinality attribute (gender/race) where a word search can false-negative.
+    expect((byName(tools, 'pa_search_attribute_values').inputSchema as any).required).toEqual(['attributePath'])
+  })
+
+  describe('pa_get_current_cohort', () => {
+    it('serializes the live bookmark getters — the value only the running store has', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_get_current_cohort').execute()
+
+      expect(parse(res)).toMatchObject({
+        bookmarkData: store.getters.getBookmarksData,
+        ifr: store.getters.getBookmarkFromIFR,
+        // The AND/OR grouping: cards within a group are OR-ed, groups AND-ed.
+        // Empty here because this store has no bool-container tree.
+        cardGroups: [],
+      })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pa_list_cohorts', () => {
+    it('returns the saved cohorts as { bmkId, name } without refetching when already loaded', async () => {
+      const store = makeStore({
+        bookmarks: [
+          { bmkId: 'b1', bookmarkname: 'Elderly Diabetics', bookmark: '{}' },
+          { bmkId: 'b2', bookmarkname: 'Young Smokers', bookmark: '{}' },
+        ],
+      })
+      const res = await byName(createPaTools(store), 'pa_list_cohorts').execute()
+
+      expect(parse(res)).toEqual({
+        cohorts: [
+          { bmkId: 'b1', name: 'Elderly Diabetics' },
+          { bmkId: 'b2', name: 'Young Smokers' },
+        ],
+      })
+      expect(store.dispatch).not.toHaveBeenCalledWith('fireBookmarkQuery', expect.anything())
+    })
+
+    it('fetches the list via fireBookmarkQuery(loadAll) when the store is empty', async () => {
+      const store = makeStore({
+        bookmarks: [],
+        loadAllResult: [{ bmkId: 'b9', bookmarkname: 'Loaded Later', bookmark: '{}' }],
+      })
+      const res = await byName(createPaTools(store), 'pa_list_cohorts').execute()
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+      expect(parse(res)).toEqual({ cohorts: [{ bmkId: 'b9', name: 'Loaded Later' }] })
+    })
+
+    it('forceRefresh reloads via loadAll even when the list is already populated (fixes staleness)', async () => {
+      const store = makeStore({
+        bookmarks: [{ bmkId: 'b1', bookmarkname: 'Old', bookmark: '{}' }],
+        loadAllResult: [
+          { bmkId: 'b1', bookmarkname: 'Old', bookmark: '{}' },
+          { bmkId: 'b2', bookmarkname: 'Just Saved', bookmark: '{}' },
+        ],
+      })
+      const res = await byName(createPaTools(store), 'pa_list_cohorts').execute({ forceRefresh: true })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+      expect(parse(res)).toEqual({
+        cohorts: [
+          { bmkId: 'b1', name: 'Old' },
+          { bmkId: 'b2', name: 'Just Saved' },
+        ],
+      })
+    })
+  })
+
+  describe('pa_open_cohort', () => {
+    const cohorts = [
+      { bmkId: 'b1', bookmarkname: 'Elderly Diabetics', bookmark: '{}' },
+      { bmkId: 'b2', bookmarkname: 'Young Smokers', bookmark: '{}' },
+      { bmkId: 'b3', bookmarkname: 'Dupe', bookmark: '{}' },
+      { bmkId: 'b4', bookmarkname: 'Dupe', bookmark: '{}' },
+    ]
+
+    it('resolves a unique name to its bmkId and loads it into the builder', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ name: 'Young Smokers' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadbookmarkToState', { bmkId: 'b2', chartType: undefined })
+      expect(parse(res)).toEqual({ opened: true, bmkId: 'b2' })
+    })
+
+    it('opens by explicit bmkId (with chartType) when provided', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ bmkId: 'b1', chartType: 'bar' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadbookmarkToState', { bmkId: 'b1', chartType: 'bar' })
+      expect(parse(res)).toEqual({ opened: true, bmkId: 'b1' })
+    })
+
+    it('returns an error and does not load when the name is unknown', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ name: 'Nonexistent' })
+
+      expect(parse(res)).toEqual({ opened: false, error: 'No cohort named "Nonexistent".' })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadbookmarkToState', expect.anything())
+    })
+
+    it('returns the candidates (and does not load) when a name is ambiguous', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ name: 'Dupe' })
+
+      expect(parse(res)).toEqual({
+        opened: false,
+        ambiguous: [
+          { bmkId: 'b3', name: 'Dupe' },
+          { bmkId: 'b4', name: 'Dupe' },
+        ],
+      })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadbookmarkToState', expect.anything())
+    })
+
+    it('errors when a bmkId does not exist', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({ bmkId: 'nope' })
+
+      expect(parse(res)).toEqual({ opened: false, error: 'No cohort with bmkId "nope".' })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadbookmarkToState', expect.anything())
+    })
+
+    it('errors when neither name nor bmkId is given', async () => {
+      const store = makeStore({ bookmarks: cohorts })
+      const res = await byName(createPaTools(store), 'pa_open_cohort').execute({})
+
+      expect(parse(res)).toEqual({ opened: false, error: 'Provide a cohort name or bmkId.' })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pa_apply_cohort_patch', () => {
+    it('dispatches loadBookmarkDataToState with the bookmark + chartType', async () => {
+      const store = makeStore()
+      const bookmark = { filter: { some: 'filter' } }
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({ bookmark, chartType: 'bar' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadBookmarkDataToState', { bookmark, chartType: 'bar' })
+      expect(parse(res)).toEqual({ applied: true })
+    })
+
+    it('routes patchOps through the deterministic applier (no legacy bookmark dispatch)', async () => {
+      const store = makeStore()
+      // Minimal store surface applyCohortPatch touches for a single add_card.
+      store.getters.getFilterCards = () => ({ fc1: {} })
+      store.dispatch.mockImplementation((type: string) => {
+        if (type === 'addFilterCard') return Promise.resolve('fc1')
+        return Promise.resolve(undefined)
+      })
+
+      const patchOps = [{ op: 'add_card', cardConfigPath: 'patient.interactions.priDiag' }]
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({ patchOps })
+
+      expect(store.dispatch).toHaveBeenCalledWith('addFilterCard', {
+        configPath: 'patient.interactions.priDiag',
+        isExclusion: false,
+      })
+      expect(store.dispatch).not.toHaveBeenCalledWith('loadBookmarkDataToState', expect.anything())
+      expect(parse(res)).toEqual({
+        applied: true,
+        createdCards: ['fc1'],
+        appliedConstraints: [],
+        // No bool-container tree on this minimal store, so nothing to group.
+        cardGroups: [],
+      })
+    })
+
+    it('returns applied:false with an error when neither patchOps nor bookmark is given', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({})
+
+      expect(parse(res)).toEqual({ applied: false, error: 'Provide patchOps (preferred) or a bookmark object.' })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('attaches the valid filter catalog when a patch fails, so a bad path is self-correcting', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          { getConfigPath: () => 'patient', getName: () => 'Basic Data', getFilterAttributes: () => [] },
+        ],
+      }
+      // Force the applier to throw (addFilterCard rejects).
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'addFilterCard' ? Promise.reject(new Error('boom')) : Promise.resolve(undefined)
+      )
+
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({
+        patchOps: [{ op: 'add_card', cardConfigPath: 'patient' }],
+      })
+
+      const parsed = parse(res)
+      expect(parsed.applied).toBe(false)
+      expect(parsed.validFilterOptions).toEqual([{ cardConfigPath: 'patient', cardName: 'Basic Data', attributes: [] }])
+    })
+
+    it('scopes the failure catalog to the cards the patch named, listing the rest by path only', async () => {
+      const store = makeStore()
+      const card = (path: string, name: string) => ({
+        getConfigPath: () => path,
+        getName: () => name,
+        getFilterAttributes: () => [
+          { getConfigPath: () => `${path}.attributes.a`, getName: () => 'A', getType: () => 'text' },
+        ],
+      })
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [card('patient', 'Basic Data'), card('patient.interactions.priDiag', 'Diagnoses')],
+      }
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'addFilterCardConstraint' ? Promise.reject(new Error('boom')) : Promise.resolve(undefined)
+      )
+      store.getters.getFilterCards = () => ({ fc1: {} })
+
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({
+        patchOps: [
+          { op: 'add_constraint', card: 'fc1', attributePath: 'patient.interactions.priDiag.attributes.a', value: 'x' },
+        ],
+      })
+
+      const parsed = parse(res)
+      expect(parsed.applied).toBe(false)
+      // The named card keeps its attributes (that's what fixes a bad attributePath);
+      // every other card is path + name + a count, so the whole catalog is not
+      // duplicated into the transcript on every failed patch.
+      expect(parsed.validFilterOptions).toEqual([
+        { cardConfigPath: 'patient', cardName: 'Basic Data', attributeCount: 1 },
+        {
+          cardConfigPath: 'patient.interactions.priDiag',
+          cardName: 'Diagnoses',
+          attributes: [
+            { attributePath: 'patient.interactions.priDiag.attributes.a', name: 'A', type: 'text', valueKind: 'text' },
+          ],
+        },
+      ])
+    })
+
+    it('rejects a malformed bookmark, restores the active cohort, and steers to patchOps', async () => {
+      const store = makeStore()
+      const prevActive = { bmkId: 'test-1', bookmarkname: 'test', isNew: false }
+      store.getters.getActiveBookmark = prevActive
+      // loadBookmarkDataToState clobbers the active bookmark, then rejects on the bad tree.
+      store.dispatch.mockImplementation((type: string) => {
+        if (type === 'loadBookmarkDataToState') {
+          const e: any = new Error('')
+          e.name = 'InvalidArgumentException'
+          return Promise.reject(e)
+        }
+        return Promise.resolve(undefined)
+      })
+
+      const res = await byName(createPaTools(store), 'pa_apply_cohort_patch').execute({
+        // filter card missing `attributes` — the shape that threw in the wild
+        bookmark: { filter: { cards: { type: 'FilterCard' } } },
+      })
+
+      const parsed = parse(res)
+      expect(parsed.applied).toBe(false)
+      expect(parsed.error).toContain('patchOps')
+      // the failed load left a broken active bookmark; the tool restores the prior one
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', prevActive)
+    })
+  })
+
+  describe('pa_list_filter_options', () => {
+    it('maps the frontend config filter cards + attributes to a flat catalog', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient',
+            getName: () => 'Basic Data',
+            getFilterAttributes: () => [
+              { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
+            ],
+          },
+        ],
+      }
+
+      const res = await byName(createPaTools(store), 'pa_list_filter_options').execute()
+
+      const parsed = parse(res)
+      expect(parsed.filterCards).toEqual([
+        {
+          cardConfigPath: 'patient',
+          cardName: 'Basic Data',
+          attributes: [
+            {
+              attributePath: 'patient.attributes.age',
+              name: 'Age',
+              type: 'num',
+              valueKind: 'numeric',
+            },
+          ],
+        },
+      ])
+      // How-to prose is hoisted into a single guide keyed by valueKind rather than
+      // repeated per attribute — the catalog is resent in the agent transcript on
+      // every turn, and inlining it doubled the payload.
+      expect(parsed.valueKindGuide.numeric).toContain('operator')
+      // the routing note steers value shape on non-OMOP configs
+      expect(parsed.note).toContain('valueKind')
+    })
+
+    it('lists only filter-card attributes, not measure/category-only ones', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient',
+            getName: () => 'Basic Data',
+            // getAllAttributes() would also include pcount, which add_constraint
+            // cannot target — a path the model would only ever fail on.
+            getFilterAttributes: () => [
+              { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
+            ],
+            getAllAttributes: () => [
+              { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
+              { getConfigPath: () => 'patient.attributes.pcount', getName: () => 'Patient Count', getType: () => 'num' },
+            ],
+          },
+        ],
+      }
+
+      const attrs = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).filterCards[0]
+        .attributes
+      expect(attrs.map((a: any) => a.attributePath)).toEqual(['patient.attributes.age'])
+    })
+
+    it('classifies a coded catalog attribute (useRefValue) as valueKind "catalog"', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient.interactions.conditionoccurrence',
+            getName: () => 'Conditions',
+            getFilterAttributes: () => [
+              {
+                getConfigPath: () => 'patient.interactions.conditionoccurrence.attributes.condsourcecode',
+                getName: () => 'Condition Source concept code',
+                getType: () => 'text',
+                isCatalogAttribute: () => true,
+              },
+              {
+                getConfigPath: () => 'patient.interactions.conditionoccurrence.attributes.condsourceconceptset',
+                getName: () => 'Condition Source concept set',
+                getType: () => 'conceptSet',
+                isCatalogAttribute: () => false,
+              },
+            ],
+          },
+        ],
+      }
+
+      const parsed = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute())
+      const attrs = parsed.filterCards[0].attributes
+      expect(attrs[0].valueKind).toBe('catalog')
+      expect(attrs[1].valueKind).toBe('conceptSet')
+      expect(parsed.valueKindGuide.catalog).toContain('pa_search_attribute_values')
+      expect(parsed.valueKindGuide.conceptSet).toContain('conceptSetId')
+    })
+
+    it('reports the OMOP domain a concept-set attribute takes, and omits it when unset', async () => {
+      // Without conceptDomain the model reuses whatever concept-set id it is
+      // already holding: an Alzheimer's (Condition) set on a Visit card builds a
+      // cohort that computes and answers the wrong question.
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient.interactions.visit',
+            getName: () => 'Visit',
+            getFilterAttributes: () => [
+              {
+                getConfigPath: () => 'patient.interactions.visit.attributes.visitconceptset',
+                getName: () => 'Encounter Concept set',
+                getType: () => 'conceptSet',
+                getDomainFilter: () => 'Visit',
+              },
+              {
+                getConfigPath: () => 'patient.interactions.visit.attributes.startdate',
+                getName: () => 'Start date',
+                getType: () => 'time',
+                getDomainFilter: () => '',
+              },
+            ],
+          },
+        ],
+      }
+
+      const attrs = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).filterCards[0]
+        .attributes
+      expect(attrs[0]).toMatchObject({ valueKind: 'conceptSet', conceptDomain: 'Visit' })
+      expect(attrs[1]).not.toHaveProperty('conceptDomain')
+      expect(parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).valueKindGuide.conceptSet)
+        .toContain('conceptDomain')
+    })
+
+    it('returns just one card when `card` is given, and the valid paths when it is unknown', async () => {
+      const store = makeStore()
+      const card = (path: string, name: string) => ({
+        getConfigPath: () => path,
+        getName: () => name,
+        getFilterAttributes: () => [
+          { getConfigPath: () => `${path}.attributes.a`, getName: () => 'A', getType: () => 'text' },
+        ],
+      })
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [card('patient', 'Basic Data'), card('patient.interactions.priDiag', 'Diagnoses')],
+      }
+      const tool = byName(createPaTools(store), 'pa_list_filter_options')
+
+      const scoped = parse(await tool.execute({ card: 'patient.interactions.priDiag' }))
+      expect(scoped.filterCards).toHaveLength(1)
+      expect(scoped.filterCards[0].cardConfigPath).toBe('patient.interactions.priDiag')
+
+      const unknown = parse(await tool.execute({ card: 'patient.interactions.nope' }))
+      expect(unknown.filterCards).toEqual([])
+      expect(unknown.error).toContain('patient.interactions.nope')
+      expect(unknown.validCardConfigPaths).toEqual(['patient', 'patient.interactions.priDiag'])
+    })
+
+    it('degrades gracefully when the frontend config is not loaded', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = undefined
+      const res = await byName(createPaTools(store), 'pa_list_filter_options').execute()
+      expect(parse(res)).toEqual({ filterCards: [], error: 'Frontend config not loaded.' })
+    })
+  })
+
+  describe('pa_save_current_cohort', () => {
+    it('defaults method to "post" and returns the bmkId from the dispatch result', async () => {
+      const store = makeStore()
+      store.dispatch.mockResolvedValue({ bmkId: 'srv-generated-42' })
+      const params = { name: 'x' }
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ params })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'post',
+        params,
+        bookmarkId: undefined,
+      })
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'srv-generated-42' })
+    })
+
+    it('falls back to the passed bookmarkId when the result has none (e.g. put/update)', async () => {
+      const store = makeStore()
+      store.dispatch.mockResolvedValue(undefined)
+      const params = { name: 'x' }
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({
+        params,
+        bookmarkId: 'existing-7',
+        method: 'put',
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'put',
+        params,
+        bookmarkId: 'existing-7',
+      })
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'existing-7' })
+    })
+
+    it('builds an insert payload from live state, refreshes the list, and adopts the saved bookmark', async () => {
+      const savedRecord = { bmkId: 'new-1', bookmarkname: 'Female Sinusitis', bookmark: '{}' }
+      const store = makeStore()
+      store.getters.getActiveBookmark = { bookmarkname: 'New cohort', isNew: true }
+      store.dispatch.mockImplementation((type: string, payload: any) => {
+        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'insert') return Promise.resolve({ bmkId: 'new-1' })
+        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'loadAll') {
+          store.getters.getBookmarks = [savedRecord]
+        }
+        return Promise.resolve(undefined)
+      })
+
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ name: 'Female Sinusitis' })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'post',
+        params: {
+          cmd: 'insert',
+          bookmarkname: 'Female Sinusitis',
+          bookmark: JSON.stringify(store.getters.getBookmarksData),
+          shareBookmark: false,
+        },
+        bookmarkId: undefined,
+      })
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', savedRecord)
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'new-1' })
+    })
+
+    it('builds an update payload (cmd:update) when a bookmarkId is given', async () => {
+      const store = makeStore()
+      store.dispatch.mockResolvedValue(undefined)
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({
+        bookmarkId: 'existing-9',
+        share: true,
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'put',
+        params: { cmd: 'update', bookmark: JSON.stringify(store.getters.getBookmarksData), shareBookmark: true },
+        bookmarkId: 'existing-9',
+      })
+      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'existing-9' })
+    })
+
+    it('refuses to save an empty cohort without dispatching', async () => {
+      const store = makeStore()
+      store.getters.getBookmarksData = {}
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ name: 'Empty' })
+
+      expect(parse(res)).toEqual({ saved: false, error: 'Current cohort is empty — build filters before saving.' })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    it('requires a name to insert a brand-new cohort', async () => {
+      const store = makeStore()
+      store.getters.getActiveBookmark = { bookmarkname: 'New cohort', isNew: true }
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({})
+
+      expect(parse(res)).toEqual({ saved: false, error: 'Provide a name to save a new cohort.' })
+    })
+  })
+
+  describe('pa_new_cohort', () => {
+    it('resets the active bookmark + chart and switches to the builder view', async () => {
+      const store = makeStore()
+      const showBuilder = vi.fn()
+      const res = await byName(createPaTools(store, { showBuilder }), 'pa_new_cohort').execute({ name: 'My Cohort' })
+
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'My Cohort', isNew: true })
+      expect(store.dispatch).toHaveBeenCalledWith('resetChart')
+      expect(showBuilder).toHaveBeenCalledOnce()
+      expect(parse(res)).toEqual({ created: true, name: 'My Cohort' })
+    })
+
+    it('defaults the name and works without a showBuilder hook', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_new_cohort').execute()
+
+      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
+      expect(parse(res)).toEqual({ created: true, name: 'New cohort' })
+    })
+  })
+
+  describe('pa_search_attribute_values', () => {
+    it('delegates to loadValuesForAttributePath and returns the values with counts', async () => {
+      const store = makeStore()
+      const values = [{ value: '461', text: 'Acute sinusitis', display_value: 'Acute sinusitis (461)' }]
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.interactions.priDiag.attributes.icd10',
+        query: 'sinusitis',
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadValuesForAttributePath', {
+        attributePathUid: 'patient.interactions.priDiag.attributes.icd10',
+        searchQuery: 'sinusitis',
+        attributeType: 'text',
+      })
+      // A small clean result: no truncation, no note, counts reported.
+      expect(parse(res)).toEqual({
+        attributePath: 'patient.interactions.priDiag.attributes.icd10',
+        query: 'sinusitis',
+        matchedVia: 'search',
+        total: 1,
+        returned: 1,
+        truncated: false,
+        values,
+      })
+      // The search hit, so the domain is never re-read.
+      expect(store.dispatch).toHaveBeenCalledOnce()
+    })
+
+    it('caps a large result to `limit`, flags truncation, and returns a routing note', async () => {
+      const store = makeStore()
+      // 1,602 tokens (the gemfibrozil case) — the flood the cap protects against.
+      const values = Array.from({ length: 1602 }, (_, i) => ({ value: String(i), text: `gemfibrozil ${i}` }))
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.interactions.drugexposure.attributes.drugconceptcode',
+        query: 'gemfibrozil',
+        limit: 25,
+      })
+
+      const parsed = parse(res)
+      expect(parsed.total).toBe(1602)
+      expect(parsed.returned).toBe(25)
+      expect(parsed.values).toHaveLength(25)
+      expect(parsed.truncated).toBe(true)
+      expect(parsed.note).toContain('concept set with descendants')
+    })
+
+    it('clamps limit to MAX_VALUE_LIMIT (200)', async () => {
+      const store = makeStore()
+      const values = Array.from({ length: 500 }, (_, i) => ({ value: String(i), text: `t${i}` }))
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(values) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'p.attr',
+        query: 'x',
+        limit: 10000,
+      })
+      expect(parse(res).returned).toBe(200)
+    })
+
+    it('surfaces loadedStatus TOO_MANY_RESULTS so the model narrows instead of concluding "absent"', async () => {
+      const store = makeStore()
+      store.dispatch.mockImplementation((type: string) =>
+        // 204 → the store records TOO_MANY_RESULTS and returns an empty list.
+        type === 'loadValuesForAttributePath' ? Promise.resolve([]) : Promise.resolve(undefined)
+      )
+      store.getters.getDomainValues = () => ({ loadedStatus: 'TOO_MANY_RESULTS', values: [] })
+
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'p.attr',
+        query: 'aspirin',
+      })
+      const parsed = parse(res)
+      expect(parsed.loadedStatus).toBe('TOO_MANY_RESULTS')
+      expect(parsed.total).toBe(0)
+      expect(parsed.note).toContain('TOO_MANY_RESULTS')
+      expect(parsed.note).toContain('Narrow the query')
+    })
+
+    it('errors without dispatching when attributePath is missing', async () => {
+      const store = makeStore()
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({ attributePath: '', query: '' })
+
+      expect(parse(res)).toEqual({
+        values: [],
+        error: 'Provide an attributePath (from pa_list_filter_options).',
+      })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    // The "build me a cohort of women…" regression. The /values search runs in the
+    // database (case- and token-sensitive), so the English word misses the stored
+    // token and the assistant used to report the value as absent and ask the user
+    // for a synonym. A miss now costs one extra request and resolves itself.
+    describe('a zero-hit search falls back to the attribute domain', () => {
+      // Mock /values the way the backend behaves: an exact, case-sensitive token
+      // match, and the full list when searchQuery is empty.
+      const makeValuesStore = (domain: any[]) => {
+        const store = makeStore()
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string, payload: any) => {
+          if (type !== 'loadValuesForAttributePath') return Promise.resolve(undefined)
+          const q = payload.searchQuery
+          if (!q) return Promise.resolve(domain)
+          return Promise.resolve(domain.filter(v => v.text.includes(q) || v.value.includes(q)))
+        })
+        return store
+      }
+      const GENDER = [
+        { value: '8532', text: 'Female', display_value: 'Female' },
+        { value: '8507', text: 'Male', display_value: 'Male' },
+      ]
+
+      it('matches case-insensitively against the full list when the search misses', async () => {
+        const store = makeValuesStore(GENDER)
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'patient.attributes.gender',
+          query: 'female',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('domain-scan')
+        expect(parsed.values).toEqual([GENDER[0]])
+        expect(parsed.domainTotal).toBe(2)
+        expect(parsed.note).toContain('never proof a value is absent')
+        // The stale "loaded with zero values" cache is busted before re-reading,
+        // or the store would serve it back instead of fetching the full domain.
+        expect(store.commit).toHaveBeenCalledWith('DOMAIN_SET_VALUES', {
+          attributePath: 'patient.attributes.gender',
+          data: { values: [], isLoaded: false, isLoading: false },
+        })
+      })
+
+      it('resolves a demographic synonym ("women" → the stored "F") on exact tokens only', async () => {
+        const store = makeValuesStore([
+          { value: 'F', text: 'F', display_value: 'F' },
+          { value: 'M', text: 'M', display_value: 'M' },
+          // Would be a false positive if synonyms matched as substrings ("f").
+          { value: 'UNK', text: 'Info not available', display_value: 'Info not available' },
+        ])
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'patient.attributes.gender',
+          query: 'women',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('domain-scan')
+        expect(parsed.values).toEqual([{ value: 'F', text: 'F', display_value: 'F' }])
+      })
+
+      it('returns the COMPLETE value list when nothing matches, instead of "not found"', async () => {
+        const store = makeValuesStore(GENDER)
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'patient.attributes.gender',
+          query: 'nonbinary',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('domain')
+        expect(parsed.values).toEqual(GENDER)
+        expect(parsed.domainTotal).toBe(2)
+        expect(parsed.note).toContain('COMPLETE value list')
+        expect(parsed.note).toContain('do NOT ask the user to suggest a synonym')
+      })
+
+      it('retries other casings when the domain is too large to enumerate', async () => {
+        const store = makeStore()
+        const hit = [{ value: '461', text: 'Sinusitis' }]
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string, payload: any) =>
+          type === 'loadValuesForAttributePath'
+            ? // Only the title-cased term matches; the unfiltered call returns nothing,
+              // as a /values endpoint that refuses to dump a huge catalog does.
+              Promise.resolve(payload.searchQuery === 'Sinusitis' ? hit : [])
+            : Promise.resolve(undefined)
+        )
+        const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'p.attr',
+          query: 'sinusitis',
+        })
+
+        const parsed = parse(res)
+        expect(parsed.matchedVia).toBe('case-variant')
+        expect(parsed.values).toEqual(hit)
+        expect(parsed.note).toContain('case-sensitive')
+      })
+
+      it('does not re-read the domain when the search was merely TOO_MANY_RESULTS', async () => {
+        const store = makeStore()
+        store.dispatch.mockImplementation((type: string) =>
+          type === 'loadValuesForAttributePath' ? Promise.resolve([]) : Promise.resolve(undefined)
+        )
+        store.getters.getDomainValues = () => ({ loadedStatus: 'TOO_MANY_RESULTS', values: [] })
+
+        await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+          attributePath: 'p.attr',
+          query: 'aspirin',
+        })
+        // "Narrow the query" is already the right answer — enumerating a domain the
+        // endpoint just refused to return would only burn a request.
+        expect(store.dispatch).toHaveBeenCalledOnce()
+      })
+    })
+
+    it('lists the whole domain when `query` is omitted', async () => {
+      const store = makeStore()
+      const domain = [
+        { value: '8532', text: 'Female' },
+        { value: '8507', text: 'Male' },
+      ]
+      store.dispatch.mockImplementation((type: string) =>
+        type === 'loadValuesForAttributePath' ? Promise.resolve(domain) : Promise.resolve(undefined)
+      )
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.attributes.gender',
+      })
+
+      expect(store.dispatch).toHaveBeenCalledWith('loadValuesForAttributePath', {
+        attributePathUid: 'patient.attributes.gender',
+        searchQuery: '',
+        attributeType: 'text',
+      })
+      // Every unfiltered read busts the cache first: a previous search on this
+      // attribute leaves it cached as loaded-with-its-own-rows, and the store would
+      // serve those back instead of the domain.
+      expect(store.commit).toHaveBeenCalledWith('DOMAIN_SET_VALUES', {
+        attributePath: 'patient.attributes.gender',
+        data: { values: [], isLoaded: false, isLoading: false },
+      })
+      const parsed = parse(res)
+      expect(parsed.matchedVia).toBe('domain')
+      expect(parsed.domainTotal).toBe(2)
+      expect(parsed.values).toEqual(domain)
+      expect(parsed.query).toBeUndefined()
+    })
+
+    // The store cancels an in-flight /values call when a newer one targets the same
+    // attributePath and resolves the loser with `undefined`. Read as "no values",
+    // that is another route to telling the user a value doesn't exist.
+    it('retries once when the store resolves undefined (a superseded request)', async () => {
+      const store = makeStore()
+      const values = [{ value: '8532', text: 'Female' }]
+      let calls = 0
+      store.dispatch.mockImplementation((type: string) => {
+        if (type !== 'loadValuesForAttributePath') return Promise.resolve(undefined)
+        calls += 1
+        return Promise.resolve(calls === 1 ? undefined : values)
+      })
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: 'patient.attributes.gender',
+        query: 'Female',
+      })
+
+      expect(calls).toBe(2)
+      expect(parse(res).values).toEqual(values)
+    })
+  })
+
+  describe('pa_get_cohort_result', () => {
+    it('returns the matched count, total, chart type and binned chart data', async () => {
+      const store = makeStore()
+      const chartData = {
+        totalPatientCount: 2694,
+        categories: [{ id: 'patient.attributes.age', name: 'Age', binsize: 10 }],
+        measures: [{ id: 'patient.attributes.pcount', name: 'Patient Count' }],
+        data: [{ 'patient.attributes.age': 0, 'patient.attributes.pcount': 12 }],
+      }
+      Object.assign(store.getters, {
+        getCurrentPatientCount: 1275,
+        getTotalPatientCount: 2694,
+        getTotalPatientListCount: 0,
+        getDisplayTotalGuardedPatientCount: false,
+        getActiveChart: 'vb',
+        getResponse: () => ({ data: chartData }),
+      })
+
+      const res = await byName(createPaTools(store), 'pa_get_cohort_result').execute()
+
+      expect(parse(res)).toEqual({
+        currentPatientCount: 1275,
+        totalPatientCount: 2694,
+        chartType: 'vb',
+        chart: {
+          totalPatientCount: 2694,
+          categories: chartData.categories,
+          measures: chartData.measures,
+          data: chartData.data,
+        },
+      })
+    })
+
+    it('uses the guarded total for list/custom charts and null chart when no response data', async () => {
+      const store = makeStore()
+      Object.assign(store.getters, {
+        getCurrentPatientCount: 5,
+        getTotalPatientCount: 99,
+        getTotalPatientListCount: 42,
+        getDisplayTotalGuardedPatientCount: true,
+        getActiveChart: 'list',
+        getResponse: () => ({}),
+      })
+
+      const res = await byName(createPaTools(store), 'pa_get_cohort_result').execute()
+
+      expect(parse(res)).toEqual({ currentPatientCount: 5, totalPatientCount: 42, chartType: 'list', chart: null })
+    })
+  })
+})
+
+describe('registerPaTools', () => {
+  afterEach(() => {
+    delete (document as any).modelContext
+    delete (navigator as any).modelContext
+    vi.restoreAllMocks()
+  })
+
+  it('returns a no-op and warns when modelContext is unavailable', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const cleanup = registerPaTools(makeStore())
+
+    expect(typeof cleanup).toBe('function')
+    expect(warn).toHaveBeenCalledOnce()
+    expect(() => cleanup()).not.toThrow()
+  })
+
+  it('registers every createPaTools tool on document.modelContext and unregisters on cleanup', () => {
+    const unregister = vi.fn()
+    const registerTool = vi.fn((_tool: PaTool) => ({ unregister }))
+    ;(document as any).modelContext = { registerTool }
+    const store = makeStore()
+    const toolCount = createPaTools(store).length
+
+    const cleanup = registerPaTools(store)
+
+    const registeredNames = registerTool.mock.calls.map(c => (c[0] as PaTool).name)
+    expect(registeredNames).toEqual(createPaTools(store).map(t => t.name))
+    expect(registerTool).toHaveBeenCalledTimes(toolCount)
+
+    cleanup()
+    expect(unregister).toHaveBeenCalledTimes(toolCount)
+  })
+
+  it('falls back to navigator.modelContext when document.modelContext is absent', () => {
+    const registerTool = vi.fn(() => ({ unregister: vi.fn() }))
+    ;(navigator as any).modelContext = { registerTool }
+    const store = makeStore()
+
+    registerPaTools(store)
+
+    expect(registerTool).toHaveBeenCalledTimes(createPaTools(store).length)
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -39,20 +39,9 @@ const byName = (tools: PaTool[], name: string): PaTool => {
 const parse = (res: { content: Array<{ text: string }> }) => JSON.parse(res.content[0].text)
 
 describe('createPaTools', () => {
-  it('registers exactly the expected PA tools with required-arg schemas', () => {
+  it('declares a required arg only where a tool genuinely has one', () => {
     const tools = createPaTools(makeStore())
 
-    expect(tools.map(t => t.name)).toEqual([
-      'pa_new_cohort',
-      'pa_get_current_cohort',
-      'pa_list_cohorts',
-      'pa_open_cohort',
-      'pa_apply_cohort_patch',
-      'pa_list_filter_options',
-      'pa_search_attribute_values',
-      'pa_get_cohort_result',
-      'pa_save_current_cohort',
-    ])
     // pa_save_current_cohort has no unconditionally-required input: it builds the
     // payload from live store state given { name } (insert) or { bookmarkId } (update),
     // and still accepts a raw `params` escape hatch — the handler validates the combo.
@@ -378,7 +367,11 @@ describe('createPaTools', () => {
             ],
             getAllAttributes: () => [
               { getConfigPath: () => 'patient.attributes.age', getName: () => 'Age', getType: () => 'num' },
-              { getConfigPath: () => 'patient.attributes.pcount', getName: () => 'Patient Count', getType: () => 'num' },
+              {
+                getConfigPath: () => 'patient.attributes.pcount',
+                getName: () => 'Patient Count',
+                getType: () => 'num',
+              },
             ],
           },
         ],
@@ -422,6 +415,37 @@ describe('createPaTools', () => {
       expect(parsed.valueKindGuide.conceptSet).toContain('conceptSetId')
     })
 
+    it('classifies a useRefText coded column as "catalog" and a time attribute as "date"', async () => {
+      const store = makeStore()
+      store.getters.getMriFrontendConfig = {
+        getFilterCards: () => [
+          {
+            getConfigPath: () => 'patient.interactions.priDiag',
+            getName: () => 'Diagnoses',
+            getFilterAttributes: () => [
+              {
+                // No isCatalogAttribute(): an older config marks a coded column by
+                // displaying its ref text, and that one needs /values just the same.
+                getConfigPath: () => 'patient.interactions.priDiag.attributes.icd10',
+                getName: () => 'ICD-10',
+                getType: () => 'text',
+                oInternalConfigAttribute: { useRefText: true },
+              },
+              {
+                getConfigPath: () => 'patient.interactions.priDiag.attributes.startdate',
+                getName: () => 'Start date',
+                getType: () => 'time',
+              },
+            ],
+          },
+        ],
+      }
+
+      const parsed = parse(await byName(createPaTools(store), 'pa_list_filter_options').execute())
+      expect(parsed.filterCards[0].attributes.map((a: any) => a.valueKind)).toEqual(['catalog', 'date'])
+      expect(parsed.valueKindGuide.date).toContain('from, to')
+    })
+
     it('reports the OMOP domain a concept-set attribute takes, and omits it when unset', async () => {
       // Without conceptDomain the model reuses whatever concept-set id it is
       // already holding: an Alzheimer's (Condition) set on a Visit card builds a
@@ -454,8 +478,9 @@ describe('createPaTools', () => {
         .attributes
       expect(attrs[0]).toMatchObject({ valueKind: 'conceptSet', conceptDomain: 'Visit' })
       expect(attrs[1]).not.toHaveProperty('conceptDomain')
-      expect(parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).valueKindGuide.conceptSet)
-        .toContain('conceptDomain')
+      expect(
+        parse(await byName(createPaTools(store), 'pa_list_filter_options').execute()).valueKindGuide.conceptSet
+      ).toContain('conceptDomain')
     })
 
     it('returns just one card when `card` is given, and the valid paths when it is unknown', async () => {
@@ -491,29 +516,26 @@ describe('createPaTools', () => {
   })
 
   describe('pa_save_current_cohort', () => {
-    it('defaults method to "post" and returns the bmkId from the dispatch result', async () => {
+    // The raw `params` back-compat hatch: forwarded verbatim, method defaults to
+    // post, and the saved id comes from the response or falls back to the argument.
+    it('forwards raw params verbatim and resolves the bookmarkId from result or argument', async () => {
       const store = makeStore()
       store.dispatch.mockResolvedValue({ bmkId: 'srv-generated-42' })
       const params = { name: 'x' }
-      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ params })
+      const tool = byName(createPaTools(store), 'pa_save_current_cohort')
 
+      expect(parse(await tool.execute({ params }))).toEqual({ saved: true, bookmarkId: 'srv-generated-42' })
       expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
         method: 'post',
         params,
         bookmarkId: undefined,
       })
-      expect(parse(res)).toEqual({ saved: true, bookmarkId: 'srv-generated-42' })
-    })
+      // Every write refreshes the list, or pa_list_cohorts serves a stale one.
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
 
-    it('falls back to the passed bookmarkId when the result has none (e.g. put/update)', async () => {
-      const store = makeStore()
+      // put/update: the endpoint returns no bmkId, so the passed one stands in.
       store.dispatch.mockResolvedValue(undefined)
-      const params = { name: 'x' }
-      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({
-        params,
-        bookmarkId: 'existing-7',
-        method: 'put',
-      })
+      const res = await tool.execute({ params, bookmarkId: 'existing-7', method: 'put' })
 
       expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
         method: 'put',
@@ -528,7 +550,8 @@ describe('createPaTools', () => {
       const store = makeStore()
       store.getters.getActiveBookmark = { bookmarkname: 'New cohort', isNew: true }
       store.dispatch.mockImplementation((type: string, payload: any) => {
-        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'insert') return Promise.resolve({ bmkId: 'new-1' })
+        if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'insert')
+          return Promise.resolve({ bmkId: 'new-1' })
         if (type === 'fireBookmarkQuery' && payload?.params?.cmd === 'loadAll') {
           store.getters.getBookmarks = [savedRecord]
         }
@@ -584,6 +607,41 @@ describe('createPaTools', () => {
 
       expect(parse(res)).toEqual({ saved: false, error: 'Provide a name to save a new cohort.' })
     })
+
+    it('refuses an update when there is neither a bookmarkId nor an active saved cohort', async () => {
+      const store = makeStore() // getActiveBookmark is null
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({ method: 'put' })
+
+      expect(parse(res)).toEqual({
+        saved: false,
+        error: 'Update requested but no bookmarkId (and no active saved cohort) to update.',
+      })
+      expect(store.dispatch).not.toHaveBeenCalled()
+    })
+
+    // Current behaviour, pinned: with an already-saved cohort active and no args,
+    // this INSERTS a second cohort under the same name rather than updating it —
+    // overwriting requires an explicit bookmarkId or method:"put" (as documented
+    // on the tool). Worth revisiting if a duplicate row ever shows up in the wild.
+    it('falls back to the active cohort name when saving without one', async () => {
+      const store = makeStore()
+      store.getters.getActiveBookmark = { bmkId: 'b1', bookmarkname: 'Elderly Diabetics', isNew: false }
+      store.dispatch.mockResolvedValue(undefined)
+
+      const res = await byName(createPaTools(store), 'pa_save_current_cohort').execute({})
+
+      expect(store.dispatch).toHaveBeenCalledWith('fireBookmarkQuery', {
+        method: 'post',
+        params: {
+          cmd: 'insert',
+          bookmarkname: 'Elderly Diabetics',
+          bookmark: JSON.stringify(store.getters.getBookmarksData),
+          shareBookmark: false,
+        },
+        bookmarkId: undefined,
+      })
+      expect(parse(res)).toEqual({ saved: true })
+    })
   })
 
   describe('pa_new_cohort', () => {
@@ -596,14 +654,14 @@ describe('createPaTools', () => {
       expect(store.dispatch).toHaveBeenCalledWith('resetChart')
       expect(showBuilder).toHaveBeenCalledOnce()
       expect(parse(res)).toEqual({ created: true, name: 'My Cohort' })
-    })
 
-    it('defaults the name and works without a showBuilder hook', async () => {
-      const store = makeStore()
-      const res = await byName(createPaTools(store), 'pa_new_cohort').execute()
+      // No args and no showBuilder hook: the name defaults and the optional hook
+      // is genuinely optional (createPaTools is used without one in tests/bridge).
+      const bare = makeStore()
+      const bareRes = await byName(createPaTools(bare), 'pa_new_cohort').execute()
 
-      expect(store.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
-      expect(parse(res)).toEqual({ created: true, name: 'New cohort' })
+      expect(bare.commit).toHaveBeenCalledWith('SET_ACTIVE_BOOKMARK', { bookmarkname: 'New cohort', isNew: true })
+      expect(parse(bareRes)).toEqual({ created: true, name: 'New cohort' })
     })
   })
 
@@ -694,7 +752,10 @@ describe('createPaTools', () => {
 
     it('errors without dispatching when attributePath is missing', async () => {
       const store = makeStore()
-      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({ attributePath: '', query: '' })
+      const res = await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+        attributePath: '',
+        query: '',
+      })
 
       expect(parse(res)).toEqual({
         values: [],
@@ -918,6 +979,29 @@ describe('createPaTools', () => {
       const res = await byName(createPaTools(store), 'pa_get_cohort_result').execute()
 
       expect(parse(res)).toEqual({ currentPatientCount: 5, totalPatientCount: 42, chartType: 'list', chart: null })
+    })
+
+    // Without the error surfaced, a failed chart query is indistinguishable from a
+    // cohort that legitimately matched nobody — and the model reports "0 patients".
+    it('surfaces a failed chart query instead of letting it read as an empty cohort', async () => {
+      const store = makeStore()
+      Object.assign(store.getters, {
+        getCurrentPatientCount: 0,
+        getTotalPatientCount: 0,
+        getTotalPatientListCount: 0,
+        getDisplayTotalGuardedPatientCount: false,
+        getActiveChart: 'vb',
+        getResponse: () => ({
+          data: { totalPatientCount: 0, noDataReason: 'NO_DATA', error: 'Request failed with status code 500' },
+        }),
+      })
+
+      const parsed = parse(await byName(createPaTools(store), 'pa_get_cohort_result').execute())
+
+      expect(parsed.chart.error).toBe('Request failed with status code 500')
+      expect(parsed.chart.noDataReason).toBe('NO_DATA')
+      expect(parsed.error).toContain('not a real result')
+      expect(parsed.error).toContain('Request failed with status code 500')
     })
   })
 })

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/__tests__/webmcpServer.test.ts
@@ -839,7 +839,7 @@ describe('createPaTools', () => {
         expect(parsed.note).toContain('do NOT ask the user to suggest a synonym')
       })
 
-      it('retries other casings when the domain is too large to enumerate', async () => {
+      it('retries rewritten queries when the domain is too large to enumerate', async () => {
         const store = makeStore()
         const hit = [{ value: '461', text: 'Sinusitis' }]
         store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
@@ -856,9 +856,54 @@ describe('createPaTools', () => {
         })
 
         const parsed = parse(res)
-        expect(parsed.matchedVia).toBe('case-variant')
+        expect(parsed.matchedVia).toBe('alternate-query')
         expect(parsed.values).toEqual(hit)
         expect(parsed.note).toContain('case-sensitive')
+      })
+
+      // The retry sweep is not casing-only: "ER visit" is not a substring of the
+      // stored "Emergency Room Visit" in ANY casing, so the term's expansions and
+      // its distinctive words have to be searched too. This is the case the
+      // backend resolver handled and this surface did not.
+      it('retries an expanded term, not just other casings', async () => {
+        const store = makeStore()
+        const hit = [{ value: '9203', text: 'Emergency Room Visit' }]
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string, payload: any) =>
+          type === 'loadValuesForAttributePath'
+            ? Promise.resolve(payload.searchQuery === 'Emergency Room Visit' ? hit : [])
+            : Promise.resolve(undefined)
+        )
+
+        const parsed = parse(
+          await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+            attributePath: 'p.attr',
+            query: 'ER visit',
+          })
+        )
+
+        expect(parsed.matchedVia).toBe('alternate-query')
+        expect(parsed.values).toEqual(hit)
+      })
+
+      it('reports matchedVia "none" when neither the search nor any retry matched', async () => {
+        const store = makeStore()
+        store.getters.getDomainValues = () => ({ loadedStatus: 'HAS_RESULTS', values: [] })
+        store.dispatch.mockImplementation((type: string) =>
+          type === 'loadValuesForAttributePath' ? Promise.resolve([]) : Promise.resolve(undefined)
+        )
+
+        const parsed = parse(
+          await byName(createPaTools(store), 'pa_search_attribute_values').execute({
+            attributePath: 'p.attr',
+            query: 'telehealth',
+          })
+        )
+
+        // Distinct from "the whole column is below, pick one": nothing could be read
+        // at all, so the next move is a different attributePath.
+        expect(parsed.matchedVia).toBe('none')
+        expect(parsed.note).toContain('different attributePath')
       })
 
       it('does not re-read the domain when the search was merely TOO_MANY_RESULTS', async () => {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/paToolBridge.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/paToolBridge.ts
@@ -1,0 +1,96 @@
+// In-page bridge that exposes the PA `pa_*` tools to the portal's AI assistant
+// drawer (React, apps/portal).
+//
+// Why this exists alongside registerPaTools: `document.modelContext.registerTool`
+// hands the tools to the *browser agent* (Chrome's WebMCP surface). It offers no
+// way for other page script to enumerate or invoke them — `modelContextTesting`
+// is a flag-gated test harness, not a production API. The portal drawer runs in
+// the same window but a different single-spa bundle, with no shared module graph,
+// so it needs its own channel. Both surfaces are fed by the SAME createPaTools()
+// array, so a tool never exists on one and not the other.
+//
+// The consumer side of this contract lives in the portal bundle; a change to the
+// registry shape or the change event has to land on both sides together.
+//
+// Shape: a registry object on `window`, not an event round-trip. Consumers must
+// read `window.__d2ePaTools` at call time and never cache it — PA deletes the
+// registry on unmount, so a re-read is what makes "PA went away mid-conversation"
+// return a clean error instead of driving a dead store.
+import type { Store } from 'vuex'
+import { createPaTools, type PaComponentHooks, type PaToolResult } from './webmcpServer'
+
+// Fired whenever the registry appears or disappears (PA mount/unmount). The
+// drawer uses it to enable/disable live cohort editing without polling.
+export const PA_TOOLS_CHANGED_EVENT = 'd2e-pa-tools-changed'
+
+export interface PaToolDescriptor {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+}
+
+export interface PaToolRegistry {
+  // Bump when the shape below changes incompatibly; the portal side refuses a
+  // version it does not understand rather than calling tools blind.
+  version: 1
+  // The dataset PA currently has loaded. The drawer compares it against the
+  // portal's active dataset before letting the model edit — a cohort edited
+  // against a different dataset than the user thinks is a silent clinical error,
+  // not a UI glitch.
+  datasetId: string | null
+  list: () => PaToolDescriptor[]
+  call: (name: string, args?: Record<string, unknown>) => Promise<PaToolResult>
+}
+
+declare global {
+  interface Window {
+    __d2ePaTools?: PaToolRegistry
+  }
+}
+
+function announce(): void {
+  window.dispatchEvent(new CustomEvent(PA_TOOLS_CHANGED_EVENT, { detail: { available: !!window.__d2ePaTools } }))
+}
+
+/**
+ * Publish the PA tools for the portal drawer. Returns a teardown function to
+ * call from beforeUnmount — pair it with registerPaTools' teardown.
+ */
+export function publishPaTools(store: Store<any>, hooks: PaComponentHooks = {}): () => void {
+  const tools = createPaTools(store, hooks)
+
+  const registry: PaToolRegistry = {
+    version: 1,
+    get datasetId() {
+      // A getter, not a snapshot: the user can switch datasets while PA stays
+      // mounted, and a stale id would defeat the mismatch guard it exists for.
+      return store.getters.getSelectedDataset?.id ?? null
+    },
+    list: () =>
+      tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    call: async (name, args) => {
+      const tool = tools.find(t => t.name === name)
+      if (!tool) {
+        throw new Error(`Unknown PA tool "${name}". Available: ${tools.map(t => t.name).join(', ')}.`)
+      }
+      return tool.execute(args)
+    },
+  }
+
+  window.__d2ePaTools = registry
+  announce()
+
+  return () => {
+    // Only clear our own registry: a remount can publish a new one before the
+    // old teardown runs, and deleting that would leave the drawer thinking PA
+    // is gone while it is on screen.
+    if (window.__d2ePaTools === registry) {
+      delete window.__d2ePaTools
+      announce()
+    }
+  }
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/valueResolution.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/valueResolution.ts
@@ -1,0 +1,380 @@
+// Query → stored-value matching for pa_search_attribute_values.
+//
+// A zero-row search is NOT evidence that a value is absent. The /values search runs in
+// the database: a HANA/SQL LIKE is case-sensitive, and it matches the stored
+// token rather than the clinical word for it — so "women" misses "FEMALE". When a
+// search comes back empty, the tool re-reads the attribute's UNFILTERED domain and
+// matches it HERE.
+//
+// ---------------------------------------------------------------------------
+// This is the browser-side twin of the mcp-server's cohortValueResolver.ts,
+// which does the same job for the deep-link surface (the tools that exist when
+// PA is NOT mounted). That file is not in this branch yet. The two cannot share
+// a module — that one is Deno, this one is bundled by Vite, and nothing crosses
+// that boundary in this repo — so they are kept in step by a shared table of
+// query→expected-row vectors that both suites read. Until the backend lands,
+// that table lives in __tests__/valueResolution.test.ts; the header there says
+// where it moves to.
+//
+// Exported names deliberately match the BE file so the two are diffable side by
+// side.
+// ---------------------------------------------------------------------------
+
+/** A row as the /values endpoint returns it. `text`/`display_value` are labels. */
+export interface ValueRow {
+  value?: string | number
+  text?: string
+  display_value?: string
+}
+
+// pa_search_attribute_values caps how many tokens it returns. A coded catalog
+// search (a drug/condition on a non-OMOP dataset) routinely matches thousands of
+// tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form —
+// e.g. "gemfibrozil" resolved to 1,602 tokens — which floods the model's context
+// and makes it guess which one to pick. Return a bounded slice + a count + a
+// routing note instead. Callers can raise `limit` (bounded by MAX) if they truly
+// need the full list.
+export const DEFAULT_VALUE_LIMIT = 50
+export const MAX_VALUE_LIMIT = 200
+
+/**
+ * How the returned rows were arrived at. Reported to the model because "these
+ * are matches", "these are every value the column can take" and "the column
+ * could not be read at all" call for completely different next moves.
+ */
+export type MatchedVia =
+  /** The /values endpoint's own search returned these rows. */
+  | 'search'
+  /** The search found nothing; these matched when we scanned the full list here. */
+  | 'domain-scan'
+  /** The search found nothing until it was retried with a rewritten query. */
+  | 'alternate-query'
+  /** No query, OR nothing matched — these rows ARE the complete value list. */
+  | 'domain'
+  /** Nothing matched and the domain could not be enumerated. */
+  | 'none'
+
+export function normalizeToken(raw: unknown): string {
+  return String(raw ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s._\-/(),]+/g, ' ')
+    .trim()
+}
+
+/**
+ * Interchangeable tokens for the low-cardinality demographic columns every
+ * cohort starts from. A dataset stores sex as "FEMALE", "Female", "F" or a
+ * concept id depending on the backend, and the user says "women".
+ *
+ * Deliberately narrow — demographics and booleans only. Clinical terms are NOT
+ * synonym-expanded: a near-miss concept is a silent clinical error, so those
+ * still route through concept sets / the vocabulary tools.
+ */
+const SYNONYM_GROUPS: string[][] = [
+  ['female', 'f', 'fem', 'woman', 'women', 'girl', 'girls'],
+  ['male', 'm', 'man', 'men', 'boy', 'boys'],
+  ['unknown', 'u', 'unk', 'not known', 'no matching concept'],
+  ['other', 'o'],
+  ['yes', 'y', 'true'],
+  ['no', 'n', 'false'],
+]
+
+/**
+ * Expansions that cannot be derived from the row being matched, because the row
+ * does not spell the abbreviation out in full: a column storing "Intensive Care"
+ * gives you nothing to recover the "U" of ICU from, and "IP"/"OP"/"AMB" are
+ * contractions of a single word rather than initials of several.
+ *
+ * This is a SEED, not the rule. An abbreviation whose expansion IS in the row is
+ * matched structurally by `abbreviates()` below, so unlisted acronyms (NICU,
+ * ASC, LTACH, whatever a given dataset uses) resolve without an entry here. The
+ * seeds also carry the blind-retry path (`alternateQueries`), where there are no
+ * rows to derive anything from — an abbreviation cannot be inverted into a
+ * search term without a lexicon.
+ *
+ * Care settings only: administrative vocabulary, not clinical judgement.
+ * Clinical abbreviations (MI, CA, RA, MS, …) are deliberately absent — those are
+ * genuinely ambiguous, and expanding one to a near-miss concept is a silent
+ * clinical error, so they route through concept sets and the vocabulary tools
+ * where the user gets to confirm what was chosen.
+ */
+const ABBREVIATION_SEEDS: Record<string, string[]> = {
+  er: ['emergency room', 'emergency department', 'emergency'],
+  ed: ['emergency department', 'emergency room', 'emergency'],
+  ip: ['inpatient'],
+  op: ['outpatient'],
+  icu: ['intensive care unit', 'intensive care'],
+  snf: ['skilled nursing facility'],
+  ltc: ['long term care'],
+  amb: ['ambulatory'],
+}
+
+const tokensOf = (s: string): string[] => normalizeToken(s).split(' ').filter(Boolean)
+
+// ---------------------------------------------------------------------------
+// Which words in a query carry signal
+//
+// A word is filler when it fails to tell one row of THIS column from another —
+// which is a property of the column, not of the word. "Visit" is filler in a
+// visit-type column because every row has it, and is the whole answer in a
+// column where one row does. So it is measured on the rows being matched rather
+// than read off a list of words someone thought of in advance.
+// ---------------------------------------------------------------------------
+
+/**
+ * Grammar words. No column anywhere is discriminated by these, so they are the
+ * only words hard-coded.
+ */
+const STOP_WORDS = new Set(['the', 'of', 'and', 'or', 'a', 'an', 'for', 'to', 'with'])
+
+/**
+ * The fallback for when there is no column to learn from: the blind-retry path,
+ * and columns with too few rows for a frequency to mean anything. Rows overrule
+ * these wherever there are enough of them.
+ */
+const SEED_FILLER = new Set([
+  'visit',
+  'visits',
+  'encounter',
+  'encounters',
+  'patient',
+  'patients',
+  'concept',
+  'name',
+  'value',
+])
+
+/** A word this share of the column's rows carry cannot tell you WHICH row. */
+const FILLER_DOCUMENT_FREQUENCY = 0.6
+/** Under this many rows a frequency is noise, so the seeds stand in. */
+const MIN_ROWS_FOR_FREQUENCY = 4
+
+/** How often each word occurs across the rows being ranked. */
+export interface ValueCorpus {
+  size: number
+  /** word -> number of rows containing it */
+  documentFrequency: Map<string, number>
+}
+
+export function buildCorpus(rowTexts: string[][]): ValueCorpus {
+  const documentFrequency = new Map<string, number>()
+  for (const texts of rowTexts) {
+    for (const token of new Set(texts.flatMap(tokensOf))) {
+      documentFrequency.set(token, (documentFrequency.get(token) ?? 0) + 1)
+    }
+  }
+  return { size: rowTexts.length, documentFrequency }
+}
+
+/** Only ever used to LOOSEN a match, never to reject a candidate. */
+function isFiller(token: string, corpus?: ValueCorpus): boolean {
+  if (STOP_WORDS.has(token)) return true
+  if (corpus && corpus.size >= MIN_ROWS_FOR_FREQUENCY) {
+    const df = corpus.documentFrequency.get(token) ?? 0
+    return df / corpus.size >= FILLER_DOCUMENT_FREQUENCY
+  }
+  return SEED_FILLER.has(token)
+}
+
+// ---------------------------------------------------------------------------
+// Abbreviations, derived from the two strings rather than listed
+// ---------------------------------------------------------------------------
+
+/** ["emergency", "room"] -> "er" */
+const initialsOf = (words: string[]): string => words.map(w => w[0]).join('')
+
+/** Value labels are a few words; a runaway input is not. */
+const MAX_ABBREVIATED_WORDS = 5
+
+/**
+ * Does the query read as an abbreviation of the row? Reading the row from its
+ * FIRST word, each query word must consume either the next row word or the
+ * INITIALS of the next two or more — "er visit" is "Emergency Room" followed by
+ * "Visit". At least one word must actually be abbreviated, so a plain
+ * word-subset stays at its own (lower) tier.
+ *
+ * The row may say more at the END than the query does (an acronym rarely covers
+ * a value's trailing "Visit"), but nothing may be skipped before or between:
+ * initials taken from the middle of a row let an acronym claim rows it does not
+ * name — "ICU" would take "Neonatal Intensive Care Unit" — and a near-miss value
+ * is a silent clinical error. Precision over recall: a row this misses is still
+ * shown to the caller, because nothing matching returns the whole column.
+ */
+function abbreviates(queryWords: string[], rowWords: string[]): boolean {
+  if (!queryWords.length || !rowWords.length) return false
+  if (rowWords.length > 12) return false
+
+  const walk = (qi: number, ri: number, abbreviated: boolean): boolean => {
+    if (qi === queryWords.length) return abbreviated
+    if (ri === rowWords.length) return false
+    const word = queryWords[qi]
+    if (word === rowWords[ri] && walk(qi + 1, ri + 1, abbreviated)) return true
+    const span = Math.min(MAX_ABBREVIATED_WORDS, rowWords.length - ri)
+    for (let k = 2; k <= span; k += 1) {
+      if (word === initialsOf(rowWords.slice(ri, ri + k)) && walk(qi + 1, ri + k, true)) return true
+    }
+    return false
+  }
+  return walk(0, 0, false)
+}
+
+/** A code is short and alphabetic; "9201" and "Female" are not codes. */
+const CODE_PATTERN = /^[a-z]{1,4}$/
+
+/**
+ * Is the row the term's CODE? Columns store "F" for Female, "S" for Single,
+ * "ICU" for Intensive Care Unit — the same initials rule read in the other
+ * direction, which is what makes it cover any coded column rather than the
+ * demographic ones a synonym table can enumerate.
+ */
+function isCodeFor(haystack: string, queryWords: string[]): boolean {
+  if (!CODE_PATTERN.test(haystack)) return false
+  if (haystack.length !== queryWords.length) return false
+  // A one- or two-letter query matching a one- or two-letter row is exactness,
+  // not an abbreviation, and it is handled a tier above.
+  if (queryWords.some(w => w.length < 3)) return false
+  return haystack === initialsOf(queryWords)
+}
+
+/**
+ * Everything a query might legitimately be stored as.
+ *
+ * `exact` are matched by equality only — a two-letter synonym like "f" would
+ * substring-match half the column. `phrases` (3+ chars) may also match as a
+ * substring.
+ */
+export interface QueryExpansion {
+  normalized: string
+  /** The words of the query as written, for the abbreviation rules. */
+  queryWords: string[]
+  exact: string[]
+  phrases: string[]
+  /** Distinctive (non-filler) token sets, one per variant. */
+  tokenSets: string[][]
+}
+
+/**
+ * `corpus` is the column being matched against, and is what makes filler a
+ * measurement rather than a guess. Omit it on the blind-retry path, where there
+ * is no column to measure.
+ */
+export function expandQuery(query: string, corpus?: ValueCorpus): QueryExpansion {
+  const normalized = normalizeToken(query)
+  const variants = new Set<string>()
+  if (normalized) variants.add(normalized)
+
+  // Demographic synonyms, whole-query only ("women" -> "female").
+  const group = SYNONYM_GROUPS.find(g => g.includes(normalized))
+  for (const s of group ?? []) variants.add(s)
+
+  // Seeded abbreviations, expanded in place ("er visit" -> "emergency room
+  // visit") and standalone ("emergency room"), so both a phrase match and a
+  // token match can land. Abbreviations the row spells out need no seed — see
+  // `abbreviates`.
+  const tokens = tokensOf(normalized)
+  for (let i = 0; i < tokens.length; i += 1) {
+    for (const expansion of ABBREVIATION_SEEDS[tokens[i]] ?? []) {
+      const replaced = [...tokens]
+      replaced[i] = expansion
+      variants.add(replaced.join(' '))
+      variants.add(expansion)
+    }
+  }
+
+  const all = [...variants]
+  const distinctive = (variant: string): string[] => {
+    const words = tokensOf(variant)
+    const kept = words.filter(t => !isFiller(t, corpus))
+    // A query made entirely of the column's common words still has to reach
+    // something; a weak match beats reporting the value absent.
+    return kept.length ? kept : words
+  }
+
+  return {
+    normalized,
+    queryWords: tokens,
+    exact: all,
+    phrases: all.filter(v => v.length >= 3),
+    tokenSets: all.map(distinctive).filter(ts => ts.length > 0),
+  }
+}
+
+/**
+ * How well a row answers the query. Lower is better; `undefined` is no match.
+ *  0 the row IS the term                  3 every distinctive word is present
+ *  1 the row contains the term            4 some distinctive word is present
+ *  2 the term abbreviates the row, or the row is the term's code
+ */
+export function rankValueRow(row: ValueRow, ex: QueryExpansion): number | undefined {
+  const haystacks = [row?.text, row?.display_value, row?.value].map(normalizeToken).filter(Boolean)
+  if (!haystacks.length) return undefined
+  if (!ex.normalized) return undefined
+
+  if (haystacks.some(h => ex.exact.includes(h))) return 0
+  if (haystacks.some(h => ex.phrases.some(v => h.includes(v)))) return 1
+  if (haystacks.some(h => abbreviates(ex.queryWords, tokensOf(h)) || isCodeFor(h, ex.queryWords))) return 2
+
+  const haystackTokens = haystacks.flatMap(h => h.split(' ').filter(Boolean))
+  const has = (t: string) => haystackTokens.includes(t)
+  if (ex.tokenSets.some(ts => ts.every(has))) return 3
+  if (ex.tokenSets.some(ts => ts.some(t => t.length >= 3 && has(t)))) return 4
+  return undefined
+}
+
+export interface RankedValue {
+  row: ValueRow
+  rank: number
+}
+
+/** Rows that match `query`, best first (stable within a rank). */
+export function rankValues(rows: ValueRow[], query: string): RankedValue[] {
+  const corpus = buildCorpus(
+    rows.map(r => [String(r?.text ?? ''), String(r?.display_value ?? ''), String(r?.value ?? '')])
+  )
+  const ex = expandQuery(query, corpus)
+  return rows
+    .map(row => ({ row, rank: rankValueRow(row, ex) }))
+    .filter((m): m is RankedValue => m.rank !== undefined)
+    .sort((a, b) => a.rank - b.rank)
+}
+
+/** Title case first: stored concept names usually look like "Emergency Room Visit". */
+const casings = (phrase: string): string[] => {
+  const lower = phrase.toLowerCase()
+  const title = lower.replace(/\b[a-z]/g, c => c.toUpperCase())
+  return [...new Set([title, lower, phrase.toUpperCase()])]
+}
+
+/**
+ * Each retry is another call to the values endpoint, so this branch (domain not
+ * enumerable AND the direct search failed) has to stay bounded.
+ */
+export const MAX_ALTERNATE_QUERIES = 9
+
+/**
+ * Queries to retry the endpoint with when the domain can't be enumerated: the
+ * term as written in every casing, then its expansions and distinctive words.
+ * Searching the one distinctive word ("emergency") is what finds a value the
+ * user's phrase ("ER visit") is not a substring of, and the casing sweep covers
+ * a backend whose LIKE is case-sensitive.
+ */
+export function alternateQueries(query: string): string[] {
+  const ex = expandQuery(query)
+  const phrases: string[] = [ex.normalized]
+  const add = (p: string) => {
+    if (p && !phrases.includes(p)) phrases.push(p)
+  }
+  for (const p of ex.phrases) add(p)
+  for (const ts of ex.tokenSets) {
+    for (const t of ts) if (t.length >= 3) add(t)
+  }
+
+  const out = new Set<string>()
+  for (const phrase of phrases) {
+    for (const variant of casings(phrase)) {
+      if (variant !== query) out.add(variant)
+    }
+  }
+  return [...out].slice(0, MAX_ALTERNATE_QUERIES)
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
@@ -5,15 +5,10 @@
 //   Chrome 146–149: navigator.modelContext   (now deprecated)
 //   Chrome 150+:    document.modelContext    (current spec)
 // We try document first, then fall back to navigator for older builds.
+import { nextTick } from 'vue'
 import type { Store } from 'vuex'
 import { applyCohortPatch, describeCardGroups, type PatchOp } from './cohortPatch'
-import {
-  alternateQueries,
-  rankValues,
-  DEFAULT_VALUE_LIMIT,
-  MAX_VALUE_LIMIT,
-  type MatchedVia,
-} from './valueResolution'
+import { alternateQueries, rankValues, DEFAULT_VALUE_LIMIT, MAX_VALUE_LIMIT, type MatchedVia } from './valueResolution'
 
 export interface PaToolResult {
   content: Array<{ type: 'text'; text: string }>
@@ -47,6 +42,13 @@ const textResult = (payload: unknown): PaToolResult => ({
 // twin of the backend's cohortValueResolver.ts (see the note at the top of that
 // file). Keeping it out of here also keeps this file about tool wiring.
 const matchDomainLocally = (rows: any[], query: string): any[] => rankValues(rows, query).map(m => m.row)
+
+// Resolve pa_search_attribute_values' `limit` at run time
+const resolveValueLimit = (raw: unknown): number => {
+  const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' && raw.trim() !== '' ? Number(raw) : NaN
+  const requested = Number.isFinite(parsed) ? parsed : DEFAULT_VALUE_LIMIT
+  return Math.max(1, Math.min(Math.floor(requested), MAX_VALUE_LIMIT))
+}
 
 // Turn the /values result shape into an actionable hint so the model narrows the
 // query or routes to a concept set, rather than picking one product token (which
@@ -109,7 +111,7 @@ function attributeValuesNote(opts: {
   if (matchedVia === 'none' || total === 0) {
     return (
       `No tokens matched "${query}" — not the search, not the rewritten queries — and this attribute's ` +
-      "unfiltered value list came back empty too, so its domain could not be enumerated. Try a different " +
+      'unfiltered value list came back empty too, so its domain could not be enumerated. Try a different ' +
       'attributePath: a card often exposes both a *source concept code* and a *concept-name* attribute, and ' +
       'the term may live on the other one.'
     )
@@ -288,6 +290,9 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         await store.dispatch('resetChart')
         // Switch list → builder so the chart mounts and the result computes.
         hooks.showBuilder?.()
+        // Snapshot the baseline last, as addNewCohort does
+        await nextTick()
+        store.commit('SET_ACTIVE_BOOKMARK_BASELINE', store.getters.getBookmarksData)
         return textResult({ created: true, name: name || 'New cohort' })
       },
     },
@@ -528,7 +533,7 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         '`valueKindGuide` map and a routing `note`. `valueKind` (numeric | date | conceptSet | catalog | text) ' +
         'keys into valueKindGuide, which says how to supply that add_constraint value — essential on non-OMOP ' +
         '(SAP HANA / LEAF) datasets whose coded filters use source concept codes/concept sets, not OMOP standard ' +
-        'concept ids. Pass `card` (a cardConfigPath) to get just that card\'s attributes; the full catalog is ' +
+        "concept ids. Pass `card` (a cardConfigPath) to get just that card's attributes; the full catalog is " +
         'large, so prefer the scoped call once you know the card. ' +
         'Use these exact paths in pa_apply_cohort_patch patchOps — never invent paths.',
       inputSchema: {
@@ -619,13 +624,15 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         attributePath: string
         query?: string
         attributeType?: string
-        limit?: number
+        // Typed `unknown`, not `number`: this crosses an unvalidated tool boundary,
+        // so resolveValueLimit — not the declared schema — is what makes it a number.
+        limit?: unknown
       }) {
         if (!attributePath) {
           return textResult({ values: [], error: 'Provide an attributePath (from pa_list_filter_options).' })
         }
         const trimmedQuery = typeof query === 'string' ? query.trim() : ''
-        const cap = Math.max(1, Math.min(limit ?? DEFAULT_VALUE_LIMIT, MAX_VALUE_LIMIT))
+        const cap = resolveValueLimit(limit)
 
         const fetchValues = async (searchQuery: string): Promise<{ rows?: any[]; loadedStatus?: string }> => {
           if (!searchQuery) {
@@ -791,7 +798,10 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
           share: { type: 'boolean', description: 'Share the cohort with other users (default false).' },
           bookmarkId: { type: 'string', description: 'Existing cohort id to overwrite (update). Omit to insert.' },
           method: { type: 'string', enum: ['post', 'put'], description: 'post = insert (default), put = update.' },
-          params: { type: 'object', description: 'Advanced/back-compat: raw fireBookmarkQuery params, forwarded verbatim.' },
+          params: {
+            type: 'object',
+            description: 'Advanced/back-compat: raw fireBookmarkQuery params, forwarded verbatim.',
+          },
         },
       },
       async execute({
@@ -852,7 +862,11 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
           httpMethod = 'post'
         }
 
-        const res = await store.dispatch('fireBookmarkQuery', { method: httpMethod, params: builtParams, bookmarkId: targetId })
+        const res = await store.dispatch('fireBookmarkQuery', {
+          method: httpMethod,
+          params: builtParams,
+          bookmarkId: targetId,
+        })
         const savedId = res?.bmkId ?? targetId
 
         // Mirror the in-app dialogs: reload the list so the row is visible, then

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
@@ -1,0 +1,953 @@
+// Chrome flag #enable-webmcp-testing is ON → modelContext is available natively.
+// Do NOT import '@mcp-b/global' polyfill when the flag is enabled.
+//
+// API location by Chrome version:
+//   Chrome 146–149: navigator.modelContext   (now deprecated)
+//   Chrome 150+:    document.modelContext    (current spec)
+// We try document first, then fall back to navigator for older builds.
+import type { Store } from 'vuex'
+import { applyCohortPatch, describeCardGroups, type PatchOp } from './cohortPatch'
+
+export interface PaToolResult {
+  content: Array<{ type: 'text'; text: string }>
+}
+
+export interface PaTool {
+  name: string
+  description: string
+  inputSchema: Record<string, unknown>
+  execute: (args?: any) => Promise<PaToolResult>
+}
+
+// Optional hooks the host component (PatientAnalytics.vue) hands in so a tool can
+// drive component-local UI that is NOT in the Vuex store — e.g. switching the
+// saved-cohort list ↔ builder view. Kept optional so createPaTools stays
+// unit-testable with only a mocked store (no component, no browser).
+export interface PaComponentHooks {
+  // Show the cohort builder pane (vs. the saved-cohort list). Functionally
+  // required for a programmatically built cohort to render and compute its
+  // count/chart: the chart-query watcher (getFireRequest → fireQuery) only runs
+  // while the builder — and its chart component — is mounted.
+  showBuilder?: () => void
+}
+
+// Wrap a JSON payload in the MCP text-content envelope every tool returns.
+const textResult = (payload: unknown): PaToolResult => ({
+  content: [{ type: 'text', text: JSON.stringify(payload) }],
+})
+
+// pa_search_attribute_values caps how many tokens it returns. A coded catalog
+// search (a drug/condition on a non-OMOP dataset) routinely matches thousands of
+// tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form —
+// e.g. "gemfibrozil" resolved to 1,602 tokens — which floods the model's context
+// and makes it guess which one to pick. Return a bounded slice + a count + a
+// routing note instead. Callers can raise `limit` (bounded by MAX) if they truly
+// need the full list.
+const DEFAULT_VALUE_LIMIT = 50
+const MAX_VALUE_LIMIT = 200
+
+// How the returned values were arrived at. Reported to the model because
+// "these are matches" and "these are every value the column can take" call for
+// completely different next moves.
+type MatchedVia =
+  /** The /values endpoint's own search returned these rows. */
+  | 'search'
+  /** No query: the attribute's complete (unfiltered) value list. */
+  | 'domain'
+  /** The search found nothing; these matched when we scanned the full list here. */
+  | 'domain-scan'
+  /** The search found nothing until it was retried with a different casing. */
+  | 'case-variant'
+
+// A zero-row search is NOT evidence that a value is absent, and treating it as
+// such is exactly how "build a cohort of women…" ended with the assistant asking
+// the user whether "female" might be spelled some other way. The /values search
+// is executed by the backend (a HANA/SQL LIKE is case-sensitive) and matches the
+// stored token, not the clinical word for it — so "female" misses "Female", and
+// "women" misses "FEMALE" on every backend. When a search comes back empty we
+// re-fetch the attribute's UNFILTERED domain and match it here, where the rules
+// are ours and, for a low-cardinality column, the entire list is visible.
+const normalizeToken = (raw: unknown): string =>
+  String(raw ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s._\-/()]+/g, ' ')
+    .trim()
+
+// Interchangeable tokens for the low-cardinality demographic columns every
+// cohort starts from. A dataset stores sex as "FEMALE", "Female", "F" or a
+// concept id depending on the backend, and the user says "women".
+// Deliberately narrow — demographics and booleans only. Clinical terms are NOT
+// synonym-expanded: a near-miss concept is a silent clinical error, so those
+// still route through concept sets / the vocabulary tools.
+const SYNONYM_GROUPS: string[][] = [
+  ['female', 'f', 'fem', 'woman', 'women', 'girl', 'girls'],
+  ['male', 'm', 'man', 'men', 'boy', 'boys'],
+  ['unknown', 'u', 'unk', 'not known', 'no matching concept'],
+  ['other', 'o'],
+  ['yes', 'y', 'true'],
+  ['no', 'n', 'false'],
+]
+
+const synonymsFor = (query: string): string[] => {
+  const q = normalizeToken(query)
+  const group = SYNONYM_GROUPS.find(g => g.includes(q))
+  return group ? group.filter(s => s !== q) : []
+}
+
+// Rank a candidate row against the query: 0 exact, 1 substring, 2 synonym.
+// undefined = no match. Ranked so an exact "F" outranks a substring hit.
+function matchRank(row: any, query: string, synonyms: string[]): number | undefined {
+  const haystacks = [row?.text, row?.display_value, row?.value].map(normalizeToken).filter(Boolean)
+  if (!haystacks.length) return undefined
+  const q = normalizeToken(query)
+  if (q && haystacks.includes(q)) return 0
+  if (q && haystacks.some(h => h.includes(q))) return 1
+  // Synonyms match on EQUALITY only. As a substring rule, "f" (for female) would
+  // match every token containing the letter f.
+  if (synonyms.some(s => haystacks.includes(s))) return 2
+  return undefined
+}
+
+function matchDomainLocally(rows: any[], query: string): any[] {
+  const synonyms = synonymsFor(query)
+  return rows
+    .map(row => ({ row, rank: matchRank(row, query, synonyms) }))
+    .filter((m): m is { row: any; rank: number } => m.rank !== undefined)
+    .sort((a, b) => a.rank - b.rank)
+    .map(m => m.row)
+}
+
+// Casing variants to retry a failed search with, for attributes whose domain is
+// too large to enumerate (so the domain scan above can't run).
+const caseVariants = (query: string): string[] => {
+  const lower = query.toLowerCase()
+  const upper = query.toUpperCase()
+  const title = lower.replace(/\b[a-z]/g, c => c.toUpperCase())
+  return [...new Set([lower, upper, title])].filter(v => v !== query)
+}
+
+// Turn the /values result shape into an actionable hint so the model narrows the
+// query or routes to a concept set, rather than picking one product token (which
+// is clinically incomplete for "any form of X"), misreading TOO_MANY_RESULTS as
+// "term absent", or — the failure this note set exists to close — asking the user
+// to guess a synonym for a value whose complete list is sitting in the response.
+// The store computes `loadedStatus` (a 204 → TOO_MANY_RESULTS) but its action
+// only returns the value array, so we read it from getDomainValues.
+function attributeValuesNote(opts: {
+  matchedVia: MatchedVia
+  total: number
+  returned: number
+  truncated: boolean
+  loadedStatus?: string
+  query: string
+  matchedQuery: string
+  domainTotal?: number
+}): string | undefined {
+  const { matchedVia, total, returned, truncated, loadedStatus, query, matchedQuery, domainTotal } = opts
+  if (loadedStatus === 'TOO_MANY_RESULTS' && total === 0) {
+    return (
+      `The /values endpoint reported TOO_MANY_RESULTS and returned no rows for "${query}". ` +
+      'Narrow the query (add strength/form/vocabulary words, or a more specific term) so it returns ' +
+      'selectable tokens — do NOT conclude the term is absent from the dataset.'
+    )
+  }
+  if (truncated) {
+    return (
+      `Showing the first ${returned} of ${total} ${matchedVia === 'domain' ? 'values' : 'matching tokens'}. ` +
+      'A broad term can match many tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form — ' +
+      `picking one product token is clinically incomplete for "any form of ${query}". Prefer a concept set with ` +
+      'descendants (backend d2e-mcp) when the dataset supports it, or pick the ingredient/standard-level token ' +
+      '(e.g. an RxNorm ingredient), and narrow the query to disambiguate. Raise `limit` only if you genuinely ' +
+      'need the full list.'
+    )
+  }
+  if (matchedVia === 'domain-scan') {
+    return (
+      `The /values search for "${query}" returned no rows, but scanning this attribute's full value list ` +
+      `(${domainTotal} values) matched ${total}. The endpoint's search is case- and token-sensitive, so an empty ` +
+      'search result is never proof a value is absent. Use the `value` field of the row you want.'
+    )
+  }
+  if (matchedVia === 'case-variant') {
+    return (
+      `"${query}" returned nothing but "${matchedQuery}" matched — the /values search is case-sensitive. ` +
+      'Treat casing, not absence, as the default explanation for an empty search result.'
+    )
+  }
+  if (matchedVia === 'domain' && query) {
+    return (
+      `No value matched "${query}". The rows below are this attribute's COMPLETE value list (${domainTotal} ` +
+      'values), so no further search will find anything else here. Pick the row that expresses ' +
+      `"${query}" — do NOT ask the user to suggest a synonym; the whole list is right here. If genuinely none ` +
+      'fits, this is the wrong attribute (a card often exposes both a *source concept code* and a ' +
+      '*concept-name* attribute) or the filter is not expressible on this dataset — say so explicitly.'
+    )
+  }
+  if (total === 0) {
+    return (
+      `No tokens matched "${query}", and this attribute's unfiltered value list came back empty too, so its ` +
+      'domain could not be enumerated. Try a different attributePath — a card often exposes both a *source ' +
+      'concept code* and a *concept-name* attribute; the term may live on the other one.'
+    )
+  }
+  return undefined
+}
+
+// Classify HOW an attribute's constraint value must be supplied, so the model
+// picks the right add_constraint value shape without guessing — the crux for a
+// non-OMOP (SAP HANA / LEAF) config. Such a config filters conditions/drugs/labs
+// on coded *source concept code* CATALOG attributes (type "text" + useRefValue,
+// resolved via pa_search_attribute_values) and on *concept set* attributes
+// (type "conceptSet", taking a { conceptSetId }) — NOT on OMOP standard concept
+// ids. A bare "text" type alone doesn't tell these apart, so surface the routing.
+function describeAttributeValue(attr: any): string {
+  const type = attr.getType?.()
+  const isCatalog =
+    (typeof attr.isCatalogAttribute === 'function' && attr.isCatalogAttribute()) ||
+    // useRefText-only catalogs (coded columns shown by their ref text) also need /values.
+    !!attr.oInternalConfigAttribute?.useRefText
+  if (type === 'conceptSet') {
+    return 'conceptSet'
+  }
+  if (type === 'num') {
+    return 'numeric'
+  }
+  if (type === 'time' || type === 'datetime') {
+    return 'date'
+  }
+  if (isCatalog) {
+    return 'catalog'
+  }
+  return 'text'
+}
+
+// The valueKind → how-to-supply-the-value legend, sent ONCE per response instead
+// of repeated on every attribute. A dataset can expose 170+ filter attributes, and
+// inlining ~150 chars of identical prose per attribute more than doubled this
+// tool's output (≈60KB → ≈27KB when hoisted). That output lands in the agent
+// transcript, which /agent resends whole on every turn — so it was the single
+// biggest driver of both context burn and the 413 the drawer used to hit.
+const VALUE_KIND_GUIDE: Record<string, string> = {
+  numeric: 'add_constraint value:<number> with operator ("<",">","=",…).',
+  date: 'add_constraint value:{ from, to } (date range).',
+  conceptSet:
+    'add_constraint value:{ conceptSetId } — build/find the concept set with the d2e-mcp concept tools. The ' +
+    "attribute's `conceptDomain` (when present) is the OMOP domain its concepts must come from: a set built " +
+    'for another domain matches nothing, so resolve each term against the domain of the card you are filtering ' +
+    '(a Visit card needs a Visit concept set, not the Condition set from an earlier filter).',
+  catalog:
+    'Coded catalog value — resolve the EXACT stored token with pa_search_attribute_values, then pass its ' +
+    'returned `value`. Dataset-specific: never hardcode or invent the token. For a small enumerated column ' +
+    '(gender, race, ethnicity, status flags) call pa_search_attribute_values with NO `query` to list every ' +
+    'value it can take, and pick from that — do not guess a search term.',
+  text: 'add_constraint value:<string> (free text).',
+}
+
+// The valid filter-card / attribute catalog from the frontend config (SAP-MRI or
+// OMOP alike). Shared by pa_list_filter_options AND used to enrich patch failures,
+// so a bad path is self-correcting from the error alone — no Vue/Pinia scraping.
+// Each attribute carries a `valueKind`; `valueKindGuide` says how to supply each
+// kind's value, so the model routes it correctly on a non-OMOP config.
+function listFilterOptions(store: Store<any>): {
+  filterCards: any[]
+  valueKindGuide?: Record<string, string>
+  note?: string
+  error?: string
+} {
+  const config = store.getters.getMriFrontendConfig
+  if (!config?.getFilterCards) {
+    return { filterCards: [], error: 'Frontend config not loaded.' }
+  }
+  const filterCards = (config.getFilterCards() ?? []).map((card: any) => ({
+    cardConfigPath: card.getConfigPath(),
+    cardName: card.getName(),
+    // getFilterAttributes(), not getAllAttributes(): the latter also includes
+    // measure/category-only attributes that are NOT visible in the filter card, so
+    // add_constraint cannot target them. Listing them padded the payload AND
+    // invited the model to pick a path that always fails.
+    attributes: ((card.getFilterAttributes?.() ?? card.getAllAttributes?.() ?? []) as any[]).map((attr: any) => {
+      // The OMOP domain a conceptSet attribute's concepts must come from
+      // (config `domainFilter`, what the UI picker filters the vocabulary by).
+      // Without it the model happily reuses a Condition set on a Visit card —
+      // a cohort that computes and answers the wrong question.
+      const conceptDomain = attr.getDomainFilter?.()
+      return {
+        attributePath: attr.getConfigPath(),
+        name: attr.getName(),
+        type: attr.getType(),
+        valueKind: describeAttributeValue(attr),
+        ...(conceptDomain ? { conceptDomain } : {}),
+      }
+    }),
+  }))
+  return {
+    filterCards,
+    // Per-attribute how-to lives here, keyed by valueKind — see VALUE_KIND_GUIDE.
+    valueKindGuide: VALUE_KIND_GUIDE,
+    note:
+      'Route each add_constraint value by `valueKind`: numeric→number+operator, date→{from,to}, ' +
+      'conceptSet→{conceptSetId} (build via d2e-mcp), catalog→resolve the exact token with ' +
+      'pa_search_attribute_values first. This dataset may be non-OMOP (SAP HANA / LEAF): its coded ' +
+      'condition/drug/measurement filters use source concept codes or concept sets, not OMOP standard ' +
+      'concept ids — so d2e-mcp search_concepts may return nothing; fall back to catalog/conceptSet paths. ' +
+      'If a measurement/lab card exposes no numeric value attribute here, a value threshold ' +
+      '(e.g. BMI < 18.5) is NOT expressible — use a diagnosis/concept-set instead.',
+  }
+}
+
+// The recovery catalog attached to a FAILED patch. Deliberately NOT the whole
+// catalog: a patch failure is almost always one wrong path, and re-sending every
+// card's attributes on every failure duplicated ~30KB into a transcript that
+// /agent resends in full each turn (two of those and the request blew the body
+// limit). So: every card by path+name — enough to fix a wrong cardConfigPath —
+// plus the attributes of only the card(s) the failing ops actually named, which is
+// what fixes a wrong attributePath.
+function recoveryFilterOptions(store: Store<any>, patchOps: PatchOp[]): any[] {
+  const { filterCards } = listFilterOptions(store)
+  // `card` on a constraint op is a runtime filterCardId, not a config path, so the
+  // usable signal is add_card's cardConfigPath and the card prefix of an
+  // attributePath ("<cardConfigPath>.attributes.<key>").
+  const named = new Set<string>()
+  for (const op of patchOps ?? []) {
+    const cardConfigPath = (op as any).cardConfigPath
+    if (typeof cardConfigPath === 'string') named.add(cardConfigPath)
+    const attributePath = (op as any).attributePath
+    if (typeof attributePath === 'string') named.add(attributePath.split('.attributes.')[0])
+  }
+  return filterCards.map((card: any) =>
+    named.has(card.cardConfigPath)
+      ? card
+      : {
+          cardConfigPath: card.cardConfigPath,
+          cardName: card.cardName,
+          // Attributes omitted to keep the transcript small — ask for them by name.
+          attributeCount: card.attributes.length,
+        }
+  )
+}
+
+// Build the Patient Analytics WebMCP tool definitions against a Vuex store.
+//
+// Exported separately from registerPaTools (which needs a live browser
+// `modelContext`) so the handlers can be unit-tested with a mocked store — no
+// Chrome flag, no bridge, no Claude required. This is verification "layer B":
+// handler ↔ Vuex correctness, where most real bugs live. registerPaTools below
+// is a thin adapter that registers whatever this returns.
+export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): PaTool[] {
+  // Saved cohorts are fetched into the store when PA mounts; be defensive in case
+  // a tool runs before that has happened (or after a store reset).
+  const ensureBookmarksLoaded = async () => {
+    if (!store.getters.getBookmarks?.length) {
+      // Match every in-app caller: the loadAll fetch is a GET (fireBookmarkQuery
+      // otherwise defaults method to 'post').
+      await store.dispatch('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+    }
+  }
+
+  return [
+    {
+      name: 'pa_new_cohort',
+      description:
+        'Start a fresh, empty cohort in the PA builder (the "Create D2E cohort" button) and switch to the ' +
+        'builder view so subsequent edits render live. Call this before pa_apply_cohort_patch when building a ' +
+        'cohort from scratch. PA must already be open — this resets the builder, it cannot navigate to PA if unmounted.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Working name for the new cohort (default "New cohort").' },
+        },
+      },
+      async execute({ name }: { name?: string } = {}) {
+        // Mirror Bookmarks.vue addNewCohort(): a brand-new unsaved active bookmark
+        // (no bmkId, isNew) + a blank IFR/chart from config defaults.
+        store.commit('SET_ACTIVE_BOOKMARK', { bookmarkname: name || 'New cohort', isNew: true })
+        await store.dispatch('resetChart')
+        // Switch list → builder so the chart mounts and the result computes.
+        hooks.showBuilder?.()
+        return textResult({ created: true, name: name || 'New cohort' })
+      },
+    },
+    {
+      name: 'pa_get_current_cohort',
+      description:
+        'Return the active cohort / bookmark definition as JSON, plus `cardGroups`: the filter cards as the ' +
+        'builder groups them. Cards in the SAME group are OR-ed; the groups are AND-ed. Read cardGroups before ' +
+        'editing — it gives you the real filterCardIds to target and tells you whether the cohort currently ' +
+        'means "A and B" or "A or B".',
+      inputSchema: { type: 'object', properties: {} },
+      async execute() {
+        return textResult({
+          bookmarkData: store.getters.getBookmarksData,
+          ifr: store.getters.getBookmarkFromIFR,
+          cardGroups: describeCardGroups(store),
+          cardGroupsNote:
+            'Cards within one group are OR-ed; groups are AND-ed. To add an OR alternative use ' +
+            'add_card with orWith:"<an existing filterCardId in that group>"; to change how two cards already ' +
+            'on the cohort combine use set_card_join on the LATER card.',
+        })
+      },
+    },
+    {
+      name: 'pa_list_cohorts',
+      description:
+        'List the saved cohorts (bookmarks) available in this dataset, as { bmkId, name }. ' +
+        'Pass forceRefresh:true to reload from the server — do this right after pa_save_current_cohort so a ' +
+        'just-saved cohort appears (the default path serves a cached list and can be stale).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          forceRefresh: {
+            type: 'boolean',
+            description: 'Reload the list from the server instead of using the cached one.',
+          },
+        },
+      },
+      async execute({ forceRefresh = false }: { forceRefresh?: boolean } = {}) {
+        if (forceRefresh) {
+          await store.dispatch('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+        } else {
+          await ensureBookmarksLoaded()
+        }
+        const cohorts = (store.getters.getBookmarks ?? []).map((b: any) => ({
+          bmkId: b.bmkId,
+          name: b.bookmarkname,
+        }))
+        return textResult({ cohorts })
+      },
+    },
+    {
+      name: 'pa_open_cohort',
+      description:
+        'Open a saved cohort in the PA builder by name (or exact bmkId) and render it live. ' +
+        'Resolve names with pa_list_cohorts first.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Cohort/bookmark display name' },
+          bmkId: { type: 'string', description: 'Exact bookmark id; takes precedence over name' },
+          chartType: { type: 'string', description: 'Optional target chart type, e.g. "bar"' },
+        },
+      },
+      async execute({ name, bmkId, chartType }: { name?: string; bmkId?: string; chartType?: string }) {
+        if (!name && !bmkId) {
+          return textResult({ opened: false, error: 'Provide a cohort name or bmkId.' })
+        }
+        await ensureBookmarksLoaded()
+        const bookmarks: any[] = store.getters.getBookmarks ?? []
+
+        if (bmkId) {
+          if (!bookmarks.some(b => b.bmkId === bmkId)) {
+            return textResult({ opened: false, error: `No cohort with bmkId "${bmkId}".` })
+          }
+        } else {
+          const matches = bookmarks.filter(b => b.bookmarkname === name)
+          if (matches.length === 0) {
+            return textResult({ opened: false, error: `No cohort named "${name}".` })
+          }
+          if (matches.length > 1) {
+            return textResult({
+              opened: false,
+              ambiguous: matches.map(b => ({ bmkId: b.bmkId, name: b.bookmarkname })),
+            })
+          }
+          bmkId = matches[0].bmkId
+        }
+
+        await store.dispatch('loadbookmarkToState', { bmkId, chartType })
+        // Ensure the builder is visible even when a cohort was already active (the
+        // store's null→set view watcher only fires on the first bookmark).
+        hooks.showBuilder?.()
+        return textResult({ opened: true, bmkId })
+      },
+    },
+    {
+      name: 'pa_apply_cohort_patch',
+      description:
+        'Edit the live cohort. Preferred (and the ONLY way to add/remove a filter): pass `patchOps` — typed intent ' +
+        'applied deterministically in-place (add_card / add_constraint / remove_card / remove_constraint / ' +
+        'set_card_join). Discover valid paths with pa_list_filter_options. AND/OR: cards are AND-ed by default; ' +
+        'to express "A OR B" add the second card with orWith:"<the other card>" (or regroup existing cards with ' +
+        'set_card_join). The result reports `cardGroups` — the grouping that actually landed. Legacy `bookmark`: ' +
+        'a full tree, accepted ONLY from a trusted builder — a hand-authored tree is validated and rejected (it ' +
+        'silently loads the wrong cohort). Never hand-author one.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          patchOps: {
+            type: 'array',
+            description:
+              'Typed patch operations. Each: ' +
+              '{ op:"add_card", cardConfigPath, exclude?, ref?, orWith? } | ' +
+              '{ op:"add_constraint", card, attributePath, value, operator? } | ' +
+              '{ op:"remove_card", card } | { op:"remove_constraint", card, attributePath } | ' +
+              '{ op:"set_card_join", card, join }. ' +
+              'The Basic Data card ("patient") always exists — constrain it directly, never add_card it. ' +
+              'Separate filter cards are AND-ed; two cards are OR-ed by putting them in the same group ' +
+              '(add_card orWith, or set_card_join).',
+            items: {
+              type: 'object',
+              properties: {
+                op: {
+                  type: 'string',
+                  enum: ['add_card', 'add_constraint', 'remove_card', 'remove_constraint', 'set_card_join'],
+                },
+                cardConfigPath: {
+                  type: 'string',
+                  description: 'add_card: the card to add, from pa_list_filter_options.',
+                },
+                exclude: { type: 'boolean', description: 'add_card: make it an exclusion card.' },
+                ref: { type: 'string', description: 'add_card: local handle later ops can use as `card`.' },
+                orWith: {
+                  type: 'string',
+                  description:
+                    'add_card: OR the new card with this existing one (a filterCardId, or a `ref` from earlier ' +
+                    'in this patch) by putting both in the same group — use it for "patients with X OR Y", one ' +
+                    'condition per card. Omit for the default, which AND-s the new card with the rest. Cannot ' +
+                    'reference the Basic Data card, and cannot mix an exclusion card with an inclusion one.',
+                },
+                card: {
+                  type: 'string',
+                  description:
+                    'add_constraint / remove_* / set_card_join: a filterCardId ("patient", ' +
+                    '"…conditionoccurrence.1") or an add_card `ref` from earlier in this same patch.',
+                },
+                join: {
+                  type: 'string',
+                  enum: ['AND', 'OR'],
+                  description:
+                    'set_card_join: how `card` combines with the card before it. "OR" merges it into the ' +
+                    'preceding group, "AND" splits it into its own. Apply it to the LATER card of the pair; the ' +
+                    'first card on the cohort has nothing before it to join with.',
+                },
+                attributePath: {
+                  type: 'string',
+                  description: 'add_constraint / remove_constraint: exact path from pa_list_filter_options.',
+                },
+                value: {
+                  description:
+                    'add_constraint: REQUIRED, and the concept-set id goes HERE, not beside it. ' +
+                    'numeric -> a number (with `operator`); catalog/text -> the exact stored string; ' +
+                    'date -> { from, to }; conceptSet -> { conceptSetId, includeDescendants? } where ' +
+                    'conceptSetId came from create_concept_set / list_concept_sets. An empty or missing ' +
+                    'value is rejected — use remove_constraint to clear a filter.',
+                },
+                operator: { type: 'string', description: 'add_constraint: "=", "<", ">", "<=", ">=". Default "=".' },
+              },
+              required: ['op'],
+            },
+          },
+          bookmark: { type: 'object', description: 'Legacy: parsed bookmark object (back-compat)' },
+          chartType: { type: 'string', description: 'Target chart type, e.g. "bar"' },
+        },
+      },
+      async execute({
+        patchOps,
+        bookmark,
+        chartType,
+      }: {
+        patchOps?: PatchOp[]
+        bookmark?: object
+        chartType?: string
+      }) {
+        if (Array.isArray(patchOps)) {
+          try {
+            const result = await applyCohortPatch(store, patchOps)
+            // Make sure the builder (and its chart) is on screen so the edit renders
+            // and the count/chart query actually runs.
+            hooks.showBuilder?.()
+            return textResult(result)
+          } catch (err) {
+            // Attach the valid paths so a wrong card/attribute path is recoverable
+            // straight from the error — no need to call pa_list_filter_options separately
+            // or scrape the app's internals. Scoped to the cards this patch named
+            // (see recoveryFilterOptions); call pa_list_filter_options({ card }) for
+            // the attributes of any other card.
+            return textResult({
+              applied: false,
+              error: err instanceof Error ? err.message : String(err),
+              validFilterOptions: recoveryFilterOptions(store, patchOps),
+            })
+          }
+        }
+        if (bookmark) {
+          // A hand-authored bookmark tree is the #1 footgun here: loadBookmarkDataToState
+          // clobbers the active bookmark with a "Linked Cohort" stub BEFORE it parses, so
+          // a malformed tree (e.g. a filter card missing `attributes`) throws in
+          // convertBM2IFR and leaves the builder pointing at a broken cohort that then
+          // crashes the chart — while the caller may still think it succeeded.
+          // The parse throws before any IFR mutation, so on failure only the active
+          // bookmark is dirty: snapshot it and restore, leaving state untouched, and
+          // surface the error so the caller uses patchOps instead.
+          const prevActiveBookmark = store.getters.getActiveBookmark
+          try {
+            await store.dispatch('loadBookmarkDataToState', { bookmark, chartType })
+            return textResult({ applied: true })
+          } catch (err) {
+            store.commit('SET_ACTIVE_BOOKMARK', prevActiveBookmark)
+            const detail = err instanceof Error ? err.message || err.name : String(err)
+            return textResult({
+              applied: false,
+              error:
+                `Rejected malformed bookmark (${detail}). Do not hand-author bookmark trees — ` +
+                'edit the live cohort with patchOps (add_card / add_constraint) instead.',
+            })
+          }
+        }
+        return textResult({ applied: false, error: 'Provide patchOps (preferred) or a bookmark object.' })
+      },
+    },
+    {
+      name: 'pa_list_filter_options',
+      description:
+        'List the valid filter cards and attributes for the current dataset as ' +
+        '{ cardConfigPath, cardName, attributes: [{ attributePath, name, type, valueKind, conceptDomain? }] }, plus a ' +
+        '`valueKindGuide` map and a routing `note`. `valueKind` (numeric | date | conceptSet | catalog | text) ' +
+        'keys into valueKindGuide, which says how to supply that add_constraint value — essential on non-OMOP ' +
+        '(SAP HANA / LEAF) datasets whose coded filters use source concept codes/concept sets, not OMOP standard ' +
+        'concept ids. Pass `card` (a cardConfigPath) to get just that card\'s attributes; the full catalog is ' +
+        'large, so prefer the scoped call once you know the card. ' +
+        'Use these exact paths in pa_apply_cohort_patch patchOps — never invent paths.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          card: {
+            type: 'string',
+            description:
+              'Optional cardConfigPath (e.g. "patient.interactions.priDiag") — return only this card, with its ' +
+              'attributes. Omit for the whole catalog.',
+          },
+        },
+      },
+      async execute({ card }: { card?: string } = {}) {
+        const options = listFilterOptions(store)
+        if (!card || options.error) {
+          return textResult(options)
+        }
+        const match = options.filterCards.find((c: any) => c.cardConfigPath === card)
+        if (!match) {
+          // A wrong path is the common case here, so answer it with the thing that
+          // fixes it (the valid paths) rather than an error the model must chase.
+          return textResult({
+            filterCards: [],
+            error: `Unknown card "${card}".`,
+            validCardConfigPaths: options.filterCards.map((c: any) => c.cardConfigPath),
+          })
+        }
+        return textResult({ ...options, filterCards: [match] })
+      },
+    },
+    {
+      name: 'pa_search_attribute_values',
+      description:
+        "Resolve the EXACT stored value token for any categorical/text attribute via the app's /values " +
+        'endpoint — no auth/token handling needed. Use it for demographics too: gender/race/etc. tokens are ' +
+        'dataset-specific (e.g. "FEMALE" vs "Female" vs "F"), so NEVER hardcode them — look them up here. ' +
+        'Also resolves a term like "sinusitis" to selectable diagnosis values. OMIT `query` to list the ' +
+        "attribute's COMPLETE value list — the fastest and most reliable route for a low-cardinality column " +
+        '(gender, race, ethnicity, status flags). Returns { matchedVia, total, returned, truncated, loadedStatus, ' +
+        'domainTotal?, values:[{ value, text, display_value }], note }; pass a returned `value` as an ' +
+        'add_constraint value in pa_apply_cohort_patch. `matchedVia` says what you are looking at: "search"/' +
+        '"domain-scan"/"case-variant" = matches for your query; "domain" = the attribute\'s whole value list ' +
+        '(returned when nothing matched, so you can pick from it). A zero-result search is NEVER proof the value ' +
+        'is absent — this tool already rechecked the full domain for you, so read `note` and decide from the ' +
+        'rows returned instead of asking the user for a synonym. The list is CAPPED (default 50, `limit` to ' +
+        'change) — when `truncated` or loadedStatus is "TOO_MANY_RESULTS", NARROW the query rather than paging: ' +
+        'a broad drug/condition term matches thousands of tokens across code systems and strengths, and one ' +
+        'product token is clinically incomplete. For "any form of X", prefer a concept set with descendants ' +
+        '(backend d2e-mcp). attributePath comes from pa_list_filter_options. This returns raw attribute values, ' +
+        'not a concept-set id.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          attributePath: {
+            type: 'string',
+            description:
+              'Attribute config path from pa_list_filter_options, e.g. "patient.interactions.priDiag.attributes.icd10".',
+          },
+          query: {
+            type: 'string',
+            description:
+              'Search text, e.g. "sinusitis". OMIT it to list every value the attribute can take — do that for ' +
+              'demographics and other small enumerated columns instead of guessing a search term.',
+          },
+          attributeType: {
+            type: 'string',
+            description: 'Optional value-type hint: "text" (default) or "conceptSet".',
+          },
+          limit: {
+            type: 'number',
+            description:
+              `Max values to return (default ${DEFAULT_VALUE_LIMIT}, max ${MAX_VALUE_LIMIT}). Narrow the query ` +
+              'instead of raising this when results span many code systems/strengths.',
+          },
+        },
+        required: ['attributePath'],
+      },
+      async execute({
+        attributePath,
+        query,
+        attributeType,
+        limit,
+      }: {
+        attributePath: string
+        query?: string
+        attributeType?: string
+        limit?: number
+      }) {
+        if (!attributePath) {
+          return textResult({ values: [], error: 'Provide an attributePath (from pa_list_filter_options).' })
+        }
+        const trimmedQuery = typeof query === 'string' ? query.trim() : ''
+        const cap = Math.max(1, Math.min(limit ?? DEFAULT_VALUE_LIMIT, MAX_VALUE_LIMIT))
+
+        const fetchValues = async (searchQuery: string): Promise<{ rows?: any[]; loadedStatus?: string }> => {
+          if (!searchQuery) {
+            // Bust the store's "already loaded" short-circuit before every
+            // unfiltered read. Any earlier search on this attributePath left it
+            // cached as loaded — with that search's (possibly empty) rows — and the
+            // action would serve exactly those back instead of fetching the domain,
+            // turning the fallback below into a no-op that confirms its own miss.
+            store.commit('DOMAIN_SET_VALUES', {
+              attributePath,
+              data: { values: [], isLoaded: false, isLoading: false },
+            })
+          }
+          const rows = await store.dispatch('loadValuesForAttributePath', {
+            attributePathUid: attributePath,
+            searchQuery,
+            attributeType: attributeType ?? 'text',
+          })
+          // The store's action returns only the value array, but it records WHY a
+          // list is empty/short as `loadedStatus` (a 204 → "TOO_MANY_RESULTS").
+          // Read it from the getter so the model can tell "no such token" from
+          // "narrow the query".
+          const loadedStatus: string | undefined = store.getters.getDomainValues?.(attributePath)?.loadedStatus
+          return { rows: Array.isArray(rows) ? rows : undefined, loadedStatus }
+        }
+
+        // The store resolves `undefined` when a newer request for the same
+        // attributePath superseded this one (it cancels the in-flight call and
+        // drops the late response). That is a race, not an empty domain, and
+        // reporting it as "no values" is another way the assistant ends up telling
+        // the user a value doesn't exist. Retry once — the retry is uncontended.
+        const fetchValuesRetrying = async (searchQuery: string) => {
+          const first = await fetchValues(searchQuery)
+          return first.rows ? first : fetchValues(searchQuery)
+        }
+
+        let matchedVia: MatchedVia = trimmedQuery ? 'search' : 'domain'
+        let matchedQuery = trimmedQuery
+        const searched = await fetchValuesRetrying(trimmedQuery)
+        let all: any[] = searched.rows ?? []
+        let loadedStatus = searched.loadedStatus
+        let domainTotal: number | undefined = trimmedQuery ? undefined : all.length
+
+        if (trimmedQuery && all.length === 0 && loadedStatus !== 'TOO_MANY_RESULTS') {
+          const domain = await fetchValuesRetrying('')
+          const domainRows = domain.rows ?? []
+          domainTotal = domainRows.length
+          const localMatches = matchDomainLocally(domainRows, trimmedQuery)
+          if (localMatches.length > 0) {
+            all = localMatches
+            loadedStatus = domain.loadedStatus
+            matchedVia = 'domain-scan'
+          } else if (domainRows.length > 0) {
+            // Hand back the COMPLETE list rather than "not found", so the model can
+            // pick a value (or rule the attribute out) in this same step instead of
+            // asking the user to guess a spelling.
+            all = domainRows
+            loadedStatus = domain.loadedStatus
+            matchedVia = 'domain'
+          } else {
+            // The domain isn't enumerable (too large, or the endpoint only answers
+            // searches), so the scan above can't decide it. Retry the search with
+            // other casings — a backend LIKE is case-sensitive, so "female" can
+            // miss a stored "Female".
+            for (const variant of caseVariants(trimmedQuery)) {
+              const alt = await fetchValuesRetrying(variant)
+              if ((alt.rows?.length ?? 0) > 0) {
+                all = alt.rows as any[]
+                loadedStatus = alt.loadedStatus
+                matchedVia = 'case-variant'
+                matchedQuery = variant
+                break
+              }
+            }
+            if (matchedVia === 'search') loadedStatus = domain.loadedStatus ?? loadedStatus
+          }
+        }
+
+        const total = all.length
+        const values = all.slice(0, cap)
+        const truncated = total > values.length
+        const note = attributeValuesNote({
+          matchedVia,
+          total,
+          returned: values.length,
+          truncated,
+          loadedStatus,
+          query: trimmedQuery,
+          matchedQuery,
+          domainTotal,
+        })
+        return textResult({
+          attributePath,
+          ...(trimmedQuery ? { query: trimmedQuery } : {}),
+          matchedVia,
+          total,
+          returned: values.length,
+          truncated,
+          loadedStatus,
+          ...(domainTotal !== undefined ? { domainTotal } : {}),
+          values,
+          ...(note ? { note } : {}),
+        })
+      },
+    },
+    {
+      name: 'pa_get_cohort_result',
+      description:
+        'Return the LIVE computed RESULT of the current cohort: matched patient count, total, active chart type, ' +
+        'and the binned chart data (categories, measures, per-bin patient counts). Use this to verify what actually ' +
+        'rendered after building/editing — pa_get_current_cohort returns only the definition, not the result. ' +
+        'Requires the builder to be open (pa_new_cohort / pa_open_cohort switch to it) so the chart query has run.',
+      inputSchema: { type: 'object', properties: {} },
+      async execute() {
+        const g = store.getters
+        // getResponse is a getter that returns a function; call it for the raw response.
+        const resp = typeof g.getResponse === 'function' ? g.getResponse() : g.getResponse
+        const chartData = resp?.data
+        const chart = chartData
+          ? {
+              totalPatientCount: chartData.totalPatientCount,
+              categories: chartData.categories,
+              measures: chartData.measures,
+              data: chartData.data,
+              noDataReason: chartData.noDataReason,
+              // Set when the last chart query errored (see fireQuery). Without it a
+              // failed query reads as an empty cohort and the count "--" has no cause.
+              ...(chartData.error ? { error: chartData.error } : {}),
+            }
+          : null
+        return textResult({
+          currentPatientCount: g.getCurrentPatientCount,
+          totalPatientCount: g.getDisplayTotalGuardedPatientCount ? g.getTotalPatientListCount : g.getTotalPatientCount,
+          chartType: g.getActiveChart,
+          chart,
+          ...(chartData?.error
+            ? {
+                error: `The last chart query failed, so the count is not a real result: ${chartData.error}`,
+              }
+            : {}),
+        })
+      },
+    },
+    {
+      name: 'pa_save_current_cohort',
+      description:
+        'Persist the current cohort to bookmark-svc and refresh the saved-cohort list. ' +
+        'New cohort → pass { name } (inserts). Overwrite an existing one → pass { bookmarkId } or method:"put" (updates). ' +
+        'The save payload (cmd / bookmark body / shareBookmark) is built from live store state — you do not construct it. ' +
+        'Advanced/back-compat: a raw `params` object, if provided, is forwarded to fireBookmarkQuery verbatim.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Name for a NEW cohort (insert). Required to insert unless updating or passing raw params.',
+          },
+          share: { type: 'boolean', description: 'Share the cohort with other users (default false).' },
+          bookmarkId: { type: 'string', description: 'Existing cohort id to overwrite (update). Omit to insert.' },
+          method: { type: 'string', enum: ['post', 'put'], description: 'post = insert (default), put = update.' },
+          params: { type: 'object', description: 'Advanced/back-compat: raw fireBookmarkQuery params, forwarded verbatim.' },
+        },
+      },
+      async execute({
+        name,
+        share = false,
+        bookmarkId,
+        method,
+        params,
+      }: {
+        name?: string
+        share?: boolean
+        bookmarkId?: string
+        method?: string
+        params?: any
+      } = {}) {
+        // Reload the list after a write so pa_list_cohorts (and the UI) reflect it —
+        // fireBookmarkQuery does NOT refetch after insert/update on its own.
+        const refreshList = () => store.dispatch('fireBookmarkQuery', { method: 'get', params: { cmd: 'loadAll' } })
+
+        // Back-compat: forward a hand-built params object verbatim.
+        if (params) {
+          const res = await store.dispatch('fireBookmarkQuery', { method: method ?? 'post', params, bookmarkId })
+          await refreshList()
+          return textResult({ saved: true, bookmarkId: res?.bmkId ?? bookmarkId })
+        }
+
+        const bookmarkData = store.getters.getBookmarksData
+        if (!bookmarkData || Object.keys(bookmarkData).length === 0) {
+          return textResult({ saved: false, error: 'Current cohort is empty — build filters before saving.' })
+        }
+
+        const active = store.getters.getActiveBookmark
+        const targetId = bookmarkId ?? (method === 'put' ? active?.bmkId : undefined)
+        const isUpdate = method === 'put' || !!targetId
+
+        let builtParams: Record<string, unknown>
+        let httpMethod: string
+        if (isUpdate) {
+          if (!targetId) {
+            return textResult({
+              saved: false,
+              error: 'Update requested but no bookmarkId (and no active saved cohort) to update.',
+            })
+          }
+          builtParams = { cmd: 'update', bookmark: JSON.stringify(bookmarkData), shareBookmark: share }
+          httpMethod = 'put'
+        } else {
+          const cohortName = name ?? (active && !active.isNew ? active.bookmarkname : undefined)
+          if (!cohortName) {
+            return textResult({ saved: false, error: 'Provide a name to save a new cohort.' })
+          }
+          builtParams = {
+            cmd: 'insert',
+            bookmarkname: cohortName,
+            bookmark: JSON.stringify(bookmarkData),
+            shareBookmark: share,
+          }
+          httpMethod = 'post'
+        }
+
+        const res = await store.dispatch('fireBookmarkQuery', { method: httpMethod, params: builtParams, bookmarkId: targetId })
+        const savedId = res?.bmkId ?? targetId
+
+        // Mirror the in-app dialogs: reload the list so the row is visible, then
+        // adopt the saved record as the active bookmark so a follow-up save updates
+        // it instead of inserting a duplicate.
+        await refreshList()
+        if (savedId) {
+          const saved = (store.getters.getBookmarks ?? []).find((b: any) => b.bmkId === savedId)
+          if (saved) store.commit('SET_ACTIVE_BOOKMARK', saved)
+        }
+
+        return textResult({ saved: true, bookmarkId: savedId })
+      },
+    },
+  ]
+}
+
+export function registerPaTools(store: Store<any>, hooks: PaComponentHooks = {}): () => void {
+  const mc = (document as any).modelContext ?? (navigator as any).modelContext
+  if (!mc) {
+    console.warn('[WebMCP] modelContext API not available. Enable chrome://flags/#enable-webmcp-testing (Chrome 146+)')
+    return () => {}
+  }
+
+  const regs: Array<{ unregister?: () => void }> = createPaTools(store, hooks).map(tool => mc.registerTool(tool))
+
+  // Return a cleanup function for beforeUnmount
+  return () => regs.forEach(r => r?.unregister?.())
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts
@@ -7,6 +7,13 @@
 // We try document first, then fall back to navigator for older builds.
 import type { Store } from 'vuex'
 import { applyCohortPatch, describeCardGroups, type PatchOp } from './cohortPatch'
+import {
+  alternateQueries,
+  rankValues,
+  DEFAULT_VALUE_LIMIT,
+  MAX_VALUE_LIMIT,
+  type MatchedVia,
+} from './valueResolution'
 
 export interface PaToolResult {
   content: Array<{ type: 'text'; text: string }>
@@ -36,96 +43,10 @@ const textResult = (payload: unknown): PaToolResult => ({
   content: [{ type: 'text', text: JSON.stringify(payload) }],
 })
 
-// pa_search_attribute_values caps how many tokens it returns. A coded catalog
-// search (a drug/condition on a non-OMOP dataset) routinely matches thousands of
-// tokens across code systems (RxNorm/NDC/ATC/SNOMED) and every strength/form —
-// e.g. "gemfibrozil" resolved to 1,602 tokens — which floods the model's context
-// and makes it guess which one to pick. Return a bounded slice + a count + a
-// routing note instead. Callers can raise `limit` (bounded by MAX) if they truly
-// need the full list.
-const DEFAULT_VALUE_LIMIT = 50
-const MAX_VALUE_LIMIT = 200
-
-// How the returned values were arrived at. Reported to the model because
-// "these are matches" and "these are every value the column can take" call for
-// completely different next moves.
-type MatchedVia =
-  /** The /values endpoint's own search returned these rows. */
-  | 'search'
-  /** No query: the attribute's complete (unfiltered) value list. */
-  | 'domain'
-  /** The search found nothing; these matched when we scanned the full list here. */
-  | 'domain-scan'
-  /** The search found nothing until it was retried with a different casing. */
-  | 'case-variant'
-
-// A zero-row search is NOT evidence that a value is absent, and treating it as
-// such is exactly how "build a cohort of women…" ended with the assistant asking
-// the user whether "female" might be spelled some other way. The /values search
-// is executed by the backend (a HANA/SQL LIKE is case-sensitive) and matches the
-// stored token, not the clinical word for it — so "female" misses "Female", and
-// "women" misses "FEMALE" on every backend. When a search comes back empty we
-// re-fetch the attribute's UNFILTERED domain and match it here, where the rules
-// are ours and, for a low-cardinality column, the entire list is visible.
-const normalizeToken = (raw: unknown): string =>
-  String(raw ?? '')
-    .trim()
-    .toLowerCase()
-    .replace(/[\s._\-/()]+/g, ' ')
-    .trim()
-
-// Interchangeable tokens for the low-cardinality demographic columns every
-// cohort starts from. A dataset stores sex as "FEMALE", "Female", "F" or a
-// concept id depending on the backend, and the user says "women".
-// Deliberately narrow — demographics and booleans only. Clinical terms are NOT
-// synonym-expanded: a near-miss concept is a silent clinical error, so those
-// still route through concept sets / the vocabulary tools.
-const SYNONYM_GROUPS: string[][] = [
-  ['female', 'f', 'fem', 'woman', 'women', 'girl', 'girls'],
-  ['male', 'm', 'man', 'men', 'boy', 'boys'],
-  ['unknown', 'u', 'unk', 'not known', 'no matching concept'],
-  ['other', 'o'],
-  ['yes', 'y', 'true'],
-  ['no', 'n', 'false'],
-]
-
-const synonymsFor = (query: string): string[] => {
-  const q = normalizeToken(query)
-  const group = SYNONYM_GROUPS.find(g => g.includes(q))
-  return group ? group.filter(s => s !== q) : []
-}
-
-// Rank a candidate row against the query: 0 exact, 1 substring, 2 synonym.
-// undefined = no match. Ranked so an exact "F" outranks a substring hit.
-function matchRank(row: any, query: string, synonyms: string[]): number | undefined {
-  const haystacks = [row?.text, row?.display_value, row?.value].map(normalizeToken).filter(Boolean)
-  if (!haystacks.length) return undefined
-  const q = normalizeToken(query)
-  if (q && haystacks.includes(q)) return 0
-  if (q && haystacks.some(h => h.includes(q))) return 1
-  // Synonyms match on EQUALITY only. As a substring rule, "f" (for female) would
-  // match every token containing the letter f.
-  if (synonyms.some(s => haystacks.includes(s))) return 2
-  return undefined
-}
-
-function matchDomainLocally(rows: any[], query: string): any[] {
-  const synonyms = synonymsFor(query)
-  return rows
-    .map(row => ({ row, rank: matchRank(row, query, synonyms) }))
-    .filter((m): m is { row: any; rank: number } => m.rank !== undefined)
-    .sort((a, b) => a.rank - b.rank)
-    .map(m => m.row)
-}
-
-// Casing variants to retry a failed search with, for attributes whose domain is
-// too large to enumerate (so the domain scan above can't run).
-const caseVariants = (query: string): string[] => {
-  const lower = query.toLowerCase()
-  const upper = query.toUpperCase()
-  const title = lower.replace(/\b[a-z]/g, c => c.toUpperCase())
-  return [...new Set([lower, upper, title])].filter(v => v !== query)
-}
+// Query → stored-value matching lives in ./valueResolution, the browser-side
+// twin of the backend's cohortValueResolver.ts (see the note at the top of that
+// file). Keeping it out of here also keeps this file about tool wiring.
+const matchDomainLocally = (rows: any[], query: string): any[] => rankValues(rows, query).map(m => m.row)
 
 // Turn the /values result shape into an actionable hint so the model narrows the
 // query or routes to a concept set, rather than picking one product token (which
@@ -169,10 +90,11 @@ function attributeValuesNote(opts: {
       'search result is never proof a value is absent. Use the `value` field of the row you want.'
     )
   }
-  if (matchedVia === 'case-variant') {
+  if (matchedVia === 'alternate-query') {
     return (
-      `"${query}" returned nothing but "${matchedQuery}" matched — the /values search is case-sensitive. ` +
-      'Treat casing, not absence, as the default explanation for an empty search result.'
+      `"${query}" returned nothing but "${matchedQuery}" matched — the /values search is case-sensitive and ` +
+      'matches the stored token, not the word for it. Treat a rewritten query, not absence, as the default ' +
+      'explanation for an empty search result. Check the rows are really what you asked for before using one.'
     )
   }
   if (matchedVia === 'domain' && query) {
@@ -184,11 +106,12 @@ function attributeValuesNote(opts: {
       '*concept-name* attribute) or the filter is not expressible on this dataset — say so explicitly.'
     )
   }
-  if (total === 0) {
+  if (matchedVia === 'none' || total === 0) {
     return (
-      `No tokens matched "${query}", and this attribute's unfiltered value list came back empty too, so its ` +
-      'domain could not be enumerated. Try a different attributePath — a card often exposes both a *source ' +
-      'concept code* and a *concept-name* attribute; the term may live on the other one.'
+      `No tokens matched "${query}" — not the search, not the rewritten queries — and this attribute's ` +
+      "unfiltered value list came back empty too, so its domain could not be enumerated. Try a different " +
+      'attributePath: a card often exposes both a *source concept code* and a *concept-name* attribute, and ' +
+      'the term may live on the other one.'
     )
   }
   return undefined
@@ -648,10 +571,13 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
         '(gender, race, ethnicity, status flags). Returns { matchedVia, total, returned, truncated, loadedStatus, ' +
         'domainTotal?, values:[{ value, text, display_value }], note }; pass a returned `value` as an ' +
         'add_constraint value in pa_apply_cohort_patch. `matchedVia` says what you are looking at: "search"/' +
-        '"domain-scan"/"case-variant" = matches for your query; "domain" = the attribute\'s whole value list ' +
-        '(returned when nothing matched, so you can pick from it). A zero-result search is NEVER proof the value ' +
-        'is absent — this tool already rechecked the full domain for you, so read `note` and decide from the ' +
-        'rows returned instead of asking the user for a synonym. The list is CAPPED (default 50, `limit` to ' +
+        '"domain-scan"/"alternate-query" = matches for your query (the last one via a rewritten query — check ' +
+        'the rows are really what you asked for); "domain" = the attribute\'s whole value list (returned when ' +
+        'nothing matched, so you can pick from it); "none" = the column could not be read at all, so try a ' +
+        'different attributePath. A zero-result search is NEVER proof the value is absent — this tool already ' +
+        'rechecked the full domain, retried the term\'s casings and its expansions ("ER visit" → "Emergency ' +
+        'Room Visit"), so read `note` and decide from the rows returned instead of asking the user for a ' +
+        'synonym or spelling. The list is CAPPED (default 50, `limit` to ' +
         'change) — when `truncated` or loadedStatus is "TOO_MANY_RESULTS", NARROW the query rather than paging: ' +
         'a broad drug/condition term matches thousands of tokens across code systems and strengths, and one ' +
         'product token is clinically incomplete. For "any form of X", prefer a concept set with descendants ' +
@@ -761,20 +687,25 @@ export function createPaTools(store: Store<any>, hooks: PaComponentHooks = {}): 
             matchedVia = 'domain'
           } else {
             // The domain isn't enumerable (too large, or the endpoint only answers
-            // searches), so the scan above can't decide it. Retry the search with
-            // other casings — a backend LIKE is case-sensitive, so "female" can
-            // miss a stored "Female".
-            for (const variant of caseVariants(trimmedQuery)) {
+            // searches), so the scan above can't decide it. Retry the search with the
+            // rewritten queries: every casing (a backend LIKE is case-sensitive, so
+            // "female" misses a stored "Female"), then the term's expansions and its
+            // distinctive words — searching "emergency" is what reaches a value that
+            // the user's phrase ("ER visit") is not even a substring of.
+            for (const variant of alternateQueries(trimmedQuery)) {
               const alt = await fetchValuesRetrying(variant)
               if ((alt.rows?.length ?? 0) > 0) {
                 all = alt.rows as any[]
                 loadedStatus = alt.loadedStatus
-                matchedVia = 'case-variant'
+                matchedVia = 'alternate-query'
                 matchedQuery = variant
                 break
               }
             }
-            if (matchedVia === 'search') loadedStatus = domain.loadedStatus ?? loadedStatus
+            if (matchedVia === 'search') {
+              matchedVia = 'none'
+              loadedStatus = domain.loadedStatus ?? loadedStatus
+            }
           }
         }
 

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
@@ -167,6 +167,8 @@ declare var sap
 const myWindow: any = window
 
 import { mapActions, mapGetters } from 'vuex'
+import { registerPaTools } from '@/ai/webmcpServer'
+import { publishPaTools } from '@/ai/paToolBridge'
 import icon from '../lib/ui/app-icon.vue'
 import appButton from '../lib/ui/app-button.vue'
 import appIcon from '../lib/ui/app-icon.vue'
@@ -270,10 +272,22 @@ export default {
     },
   },
   mounted() {
+    const paToolHooks = {
+      // Let pa_new_cohort switch from the saved-cohort list to the builder so a
+      // programmatically built cohort renders and computes its count/chart.
+      showBuilder: () => this.toggleCohorts(false),
+    }
+    // Two consumers, one tool set: an external browser agent via Chrome's
+    // modelContext, and an in-page consumer via the window registry. Both wrap
+    // the same createPaTools() array.
+    this._unregisterPaTools = registerPaTools(this.$store, paToolHooks)
+    this._unpublishPaTools = publishPaTools(this.$store, paToolHooks)
     this.updateMinSplitterWidth()
     window.addEventListener('resize', this.updateMinSplitterWidth)
   },
   beforeUnmount() {
+    this._unregisterPaTools?.()
+    this._unpublishPaTools?.()
     window.removeEventListener('resize', this.updateMinSplitterWidth)
     this.chartBusy = false
   },

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/applyConstraintValue.test.ts
@@ -59,9 +59,9 @@ describe('applyConstraintValue', () => {
     })
 
     it('rejects an unparseable numeric value', async () => {
-      await expect(
-        applyConstraintValue(dispatch, constraint({}, { type: 'num' }), 'abc')
-      ).rejects.toThrow('Invalid numeric value for Age')
+      await expect(applyConstraintValue(dispatch, constraint({}, { type: 'num' }), 'abc')).rejects.toThrow(
+        'Invalid numeric value for Age'
+      )
       expect(dispatch).not.toHaveBeenCalled()
     })
   })
@@ -152,9 +152,9 @@ describe('applyConstraintValue', () => {
     })
 
     it('rejects when no date value is present', async () => {
-      await expect(
-        applyConstraintValue(dispatch, constraint({}, { type: 'time' }), '')
-      ).rejects.toThrow('Missing date value for Age')
+      await expect(applyConstraintValue(dispatch, constraint({}, { type: 'time' }), '')).rejects.toThrow(
+        'Missing date value for Age'
+      )
       expect(dispatch).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
Please note: this PR is supposed to be merged only after PR #3000 is merged. The delta between this PR and #3000 is in PR #3001 . For easier reviewing, please refer to [the Files Changed in PR 3001](https://github.com/OHDSI/Data2Evidence/pull/3001/changes)

## **Summary:** : 
This PR adds the `pa_*` **tool surface** for Patient Analytics. 
PR #3000  adds a deterministic cohort-patch *applier* with no caller; this PR adds the callers: 
1. 9 `pa_*` tools built over the app's own Vuex actions, 
2. query→stored-value resolver so a term like *"women"* or *"ER visit"* reaches the token a dataset actually stores,
3. In-page registry so a second consumer in another bundle can reach the same tool set, 
4. `PatientAnalytics.vue` mount/unmount wiring that publishes both surfaces.

Nothing in `develop` consumes either surface, and the browser surface needs a Chrome flag , so **this PR
ships dormant**: on an unflagged browser `registerPaTools` logs a warning and returns a no-op
teardown, and `window.__d2ePaTools` is published but unread until C2 (the portal drawer).

## What changed

| File | Kind | Change |
|---|---|---|
| [webmcpServer.ts](plugins/ui/apps/vue-mri-ui-lib/src/ai/webmcpServer.ts) | **new** | The nine `pa_*` tools (`createPaTools`) + the WebMCP registration adapter (`registerPaTools`)|
| [valueResolution.ts](plugins/ui/apps/vue-mri-ui-lib/src/ai/valueResolution.ts) | **new** | Query → stored-value ranking, query expansion, blind-retry query generation |
| [paToolBridge.ts](plugins/ui/apps/vue-mri-ui-lib/src/ai/paToolBridge.ts) | **new** | `publishPaTools` — versioned `window.__d2ePaTools` registry + `d2e-pa-tools-changed` event  |
| [PatientAnalytics.vue](plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue) | wiring | Register + publish on `mounted`, tear both down on `beforeUnmount` |

## The nine tools

| Tool | Store surface it drives | Notable logic |
|---|---|---|
| `pa_new_cohort` | `SET_ACTIVE_BOOKMARK` + `resetChart` | Mirrors `Bookmarks.vue addNewCohort()`: a new unsaved active bookmark (`isNew: true`, no `bmkId`) plus a blank IFR/chart from config defaults, then `showBuilder()` |
| `pa_get_current_cohort` | `getBookmarksData`, `getBookmarkFromIFR`, `describeCardGroups` | Returns the definition **and** `cardGroups` — the AND/OR structure, which is invisible in the constraint list |
| `pa_list_cohorts` | `fireBookmarkQuery` (`cmd: loadAll`) | `forceRefresh` bypasses the "already loaded" path; the default calls `ensureBookmarksLoaded` |
| `pa_open_cohort` | `loadbookmarkToState` | Name→id resolution with an explicit `ambiguous` result; `showBuilder()` after |
| `pa_apply_cohort_patch` | `applyCohortPatch` (A3) / legacy `loadBookmarkDataToState` | Failure attaches a *scoped* recovery catalog; the legacy path validates and rolls back |
| `pa_list_filter_options` | `getMriFrontendConfig` | `valueKind` classification, hoisted guide, `conceptDomain`, optional `card` scoping |
| `pa_search_attribute_values` | `loadValuesForAttributePath`, `getDomainValues`, `DOMAIN_SET_VALUES` | The five-step escalation ladder — Part 2 |
| `pa_get_cohort_result` | `getResponse`, the patient-count getters, `getActiveChart` | The live *result*, including a failed-query cause |
| `pa_save_current_cohort` | `fireBookmarkQuery` (`insert`/`update`) | Builds the payload from live state; refreshes, then adopts the saved record |

`ensureBookmarksLoaded` dispatches `fireBookmarkQuery` with an explicit `method: 'get'` — every
in-app caller does, because `fireBookmarkQuery` otherwise defaults to `post`, which for
`cmd: loadAll` is the wrong verb.

## Test in browser
| | |
|---|---|
| **Flag URL** | `chrome://flags/#enable-webmcp-testing` |
| **Flag name in the UI** | **WebMCP for testing** |
| **Set it to** | **Enabled**, then click **Relaunch** |
| **Chrome required** | **146+**, and on the **Canary / Dev / Beta** channel — the flag does not exist on Stable yet, where `chrome://flags/#enable-webmcp-testing` simply shows no result |
| **Secure context** | required, but `localhost` counts as one, so plain `http://localhost:<port>` works |

Steps:
1. **Enable the flag** as above and relaunch that Chrome.
2. **Build the PA bundle** so your branch's code is actually served (`bun build-all` in
   `plugins/ui`; the build output is served through the bundled-plugins mount — no copy into
   `d2e-trex` needed).
3. **Open the portal** and log in. 
4. **Mount PA.** Navigate to `Cohorts` and wait for PA to load. The tools are registered in
   `PatientAnalytics.vue`'s `mounted()`, and PA is a single-spa app that mounts only on the PA
   route.
5. **Confirm registration** in the DevTools console of that tab:

   ```js
   await navigator.modelContextTesting.listTools()
   // → the nine pa_* tools
   ```
E.g.
<img width="2559" height="1298" alt="Screenshot 2026-07-29 at 2 45 40 PM" src="https://github.com/user-attachments/assets/0ea551ce-9df6-4010-9c8e-6c6d3a6c6b1e" />

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)