### PR TITLE
[Analyze 2718] Fix wizards shiny source validation

### DIFF
--- a/plugins/ui/apps/wizards/src/components/ShinyDashboardIframe.tsx
+++ b/plugins/ui/apps/wizards/src/components/ShinyDashboardIframe.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { buildShinyDashboardAuthMessage, buildShinyDashboardIframeUrl } from "../utils/shinyDashboardContext";
+import {
+  buildShinyDashboardAuthMessage,
+  buildShinyDashboardIframeUrl,
+  resolveShinyDashboardMessageSource,
+} from "../utils/shinyDashboardContext";
 import styles from "./ShinyDashboardIframe.module.css";
 
 interface ShinyDashboardIframeProps {
@@ -19,6 +23,7 @@ export function ShinyDashboardIframe({
 }: ShinyDashboardIframeProps) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const fallbackTimerRef = useRef<number | null>(null);
+  const messageTargetRef = useRef<Window | null>(null);
   const [token, setToken] = useState("");
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -32,9 +37,10 @@ export function ShinyDashboardIframe({
     }
   }, [iframeUrl]);
 
-  const sendContext = useCallback(() => {
-    if (!iframeRef.current?.contentWindow || !token) return;
-    iframeRef.current.contentWindow.postMessage(
+  const sendContext = useCallback((targetWindow?: Window | null) => {
+    const iframeWindow = targetWindow ?? messageTargetRef.current ?? iframeRef.current?.contentWindow;
+    if (!iframeWindow || !token) return;
+    iframeWindow.postMessage(
       buildShinyDashboardAuthMessage({
         token,
         datasetId,
@@ -71,10 +77,16 @@ export function ShinyDashboardIframe({
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      if (event.source !== iframeRef.current?.contentWindow || event.origin !== iframeOrigin) return;
+      const sourceWindow = resolveShinyDashboardMessageSource(event.source, iframeRef.current?.contentWindow);
+      if (!sourceWindow || event.origin !== iframeOrigin) return;
       if (event.data?.type === "SHINYLIVE_READY") {
+        messageTargetRef.current = sourceWindow;
+        if (fallbackTimerRef.current !== null) {
+          window.clearTimeout(fallbackTimerRef.current);
+          fallbackTimerRef.current = null;
+        }
         setIsReady(true);
-        sendContext();
+        sendContext(sourceWindow);
       } else if (event.data?.type === "SHINYLIVE_ERROR") {
         setError("The dashboard reported an error. Please try opening it again.");
       }
@@ -94,6 +106,10 @@ export function ShinyDashboardIframe({
     []
   );
 
+  useEffect(() => {
+    messageTargetRef.current = null;
+  }, [iframeUrl, reloadKey]);
+
   const handleLoad = () => {
     if (fallbackTimerRef.current !== null) window.clearTimeout(fallbackTimerRef.current);
     fallbackTimerRef.current = window.setTimeout(() => setIsReady(true), 5000);
@@ -103,6 +119,7 @@ export function ShinyDashboardIframe({
     if (fallbackTimerRef.current !== null) window.clearTimeout(fallbackTimerRef.current);
     setError(null);
     setIsReady(false);
+    messageTargetRef.current = null;
     setReloadKey((key) => key + 1);
   };
 

--- a/plugins/ui/apps/wizards/src/utils/__tests__/shinyDashboardContext.test.ts
+++ b/plugins/ui/apps/wizards/src/utils/__tests__/shinyDashboardContext.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "vitest";
-import { buildShinyDashboardAuthMessage, buildShinyDashboardIframeUrl } from "../shinyDashboardContext";
+import {
+  buildShinyDashboardAuthMessage,
+  buildShinyDashboardIframeUrl,
+  resolveShinyDashboardMessageSource,
+} from "../shinyDashboardContext";
+
+function createWindow(children: Window[] = []): Window {
+  const window = { frames: children } as unknown as Window;
+  children.forEach((child) => {
+    Object.defineProperty(child, "parent", { value: window });
+  });
+  return window;
+}
 
 describe("Wizards Shiny dashboard context", () => {
   it("matches the established dataset and dashboard-type route", () => {
@@ -48,5 +60,34 @@ describe("Wizards Shiny dashboard context", () => {
 
     expect(message.context.wizardConfig).toBeNull();
     expect(message.context.cohortId).toBe("42");
+  });
+
+  it("accepts readiness messages from the outer ShinyLive iframe", () => {
+    const iframeWindow = createWindow();
+
+    expect(resolveShinyDashboardMessageSource(iframeWindow, iframeWindow)).toBe(iframeWindow);
+  });
+
+  it("accepts readiness messages from a dashboard nested inside the ShinyLive iframe", () => {
+    const dashboardWindow = createWindow();
+    const iframeWindow = createWindow([dashboardWindow]);
+
+    expect(resolveShinyDashboardMessageSource(dashboardWindow, iframeWindow)).toBe(dashboardWindow);
+  });
+
+  it("rejects messages from a window outside the ShinyLive iframe tree", () => {
+    const iframeWindow = createWindow([createWindow()]);
+    const unrelatedWindow = createWindow();
+
+    expect(resolveShinyDashboardMessageSource(unrelatedWindow, iframeWindow)).toBeNull();
+    expect(resolveShinyDashboardMessageSource(null, iframeWindow)).toBeNull();
+  });
+
+  it("rejects messages nested more deeply than the ShinyLive dashboard", () => {
+    const nestedWindow = createWindow();
+    const dashboardWindow = createWindow([nestedWindow]);
+    const iframeWindow = createWindow([dashboardWindow]);
+
+    expect(resolveShinyDashboardMessageSource(nestedWindow, iframeWindow)).toBeNull();
   });
 });

--- a/plugins/ui/apps/wizards/src/utils/shinyDashboardContext.ts
+++ b/plugins/ui/apps/wizards/src/utils/shinyDashboardContext.ts
@@ -12,6 +12,21 @@ export interface ShinyDashboardAuthMessage {
   context: ShinyDashboardContext;
 }
 
+export function resolveShinyDashboardMessageSource(
+  source: MessageEventSource | null,
+  iframeWindow: Window | null | undefined
+): Window | null {
+  if (!source || !iframeWindow) return null;
+  if (source === iframeWindow) return iframeWindow;
+
+  try {
+    const sourceWindow = source as Window;
+    return sourceWindow.parent === iframeWindow ? sourceWindow : null;
+  } catch {
+    return null;
+  }
+}
+
 export function buildShinyDashboardIframeUrl(datasetId: string, wizardConfig?: Record<string, unknown> | null): string {
   const dashboardType = String(wizardConfig?.dashboardType ?? "").trim();
   if (!datasetId || !dashboardType) return "";


### PR DESCRIPTION
## Summary

ShinyLive runs the dashboard inside a child iframe. The Wizards host previously accepted messages only from the outer iframe, so it rejected the dashboard’s `SHINYLIVE_READY` event and sent authentication context to the wrong window.

This change:

- Accepts readiness messages from the outer iframe or its direct dashboard child.
- Sends `AUTH_TOKEN` to the exact trusted sender.
- Validates message origin and source on both the Wizards and Shiny sides.
- Rejects unrelated same-origin frames.
 

Related to #2718. Follow-up to #2897.