### PR TITLE
Fix drilldown prevalence by month sorting and trellis chart sorting in data characterization

### DIFF
--- a/plugins/ui/apps/portal/src/components/Charts/Common/Drilldown/DrilldownPrevalenceByMonthChart/DrilldownPrevalenceByMonthChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/Drilldown/DrilldownPrevalenceByMonthChart/DrilldownPrevalenceByMonthChart.tsx
@@ -42,7 +42,7 @@ const DrilldownPrevalenceByMonthChart: FC<DrilldownPrevalenceByMonthChartProps> 
   const series = [
     {
       type: "line",
-      data: data.map((obj: any) => Number(obj["YPREVALENCE1000PP"]).toFixed()),
+      data: sortedData.map((obj: any) => Number(obj["YPREVALENCE1000PP"]).toFixed()),
     },
   ];
 

--- a/plugins/ui/apps/portal/src/components/Charts/Common/Drilldown/DrilldownPrevalenceByMonthChart/DrilldownPrevalenceByMonthChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/Drilldown/DrilldownPrevalenceByMonthChart/DrilldownPrevalenceByMonthChart.tsx
@@ -28,9 +28,14 @@ const DrilldownPrevalenceByMonthChart: FC<DrilldownPrevalenceByMonthChartProps> 
     );
   }
 
+  // Sort data by XCALENDARMONTH
+  const sortedData = [...data].sort((a: any, b: any) => {
+    return Number(a["XCALENDARMONTH"]) - Number(b["XCALENDARMONTH"]);
+  });
+
   // Parse and format line chart data
   // Parse XCALENDARMONTH from e.g 200910 -> 10/2009
-  const lineChartXAxisData = data.map(
+  const lineChartXAxisData = sortedData.map(
     (obj: any) => obj["XCALENDARMONTH"].toString().slice(-2) + "/" + obj["XCALENDARMONTH"].toString().slice(0, 4)
   );
 

--- a/plugins/ui/apps/portal/src/components/Charts/Common/Drilldown/DrilldownTrellisChart/DrilldownTrellisChart.tsx
+++ b/plugins/ui/apps/portal/src/components/Charts/Common/Drilldown/DrilldownTrellisChart/DrilldownTrellisChart.tsx
@@ -56,8 +56,9 @@ const DrilldownTrellisChart: FC<DrilldownTrellisChartProps> = ({
   const TITLE_OFFSET = 6 / numRows; // Dynamic offset for grid titles
   const ROW_LABEL_OFFSET = 9 / numRows; // Dynamic offset for row labels
 
-  // Get keys from trellisData sorted
-  const sortedTrellisNames = Object.keys(trellisData).sort();
+  // Get keys from trellisData sorted naturally, so numeric ranges are ordered by value
+  // instead of lexicographically
+  const sortedTrellisNames = Object.keys(trellisData).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
 
   // Calculate global y-axis range for harmonization across all plots
   const allYValues = data.map((obj: any) => Number(obj[trellisXAxisKey])).filter((v: number) => !isNaN(v));


### PR DESCRIPTION
1. Fix data sorting in drilldown prevalence by month charts:
Note: Tim advised not to fill missing months with a prevalence of 0.

<img width="892" height="440" alt="Screenshot 2026-07-31 at 11 06 46 AM" src="https://github.com/user-attachments/assets/acac525a-4fcb-45ba-a7a7-2fcf3b17ffe1" />

3. Make trellis charts sort by numbers first before alphabets in titles

Before:
<img width="1067" height="923" alt="Screenshot 2026-07-31 at 11 01 38 AM" src="https://github.com/user-attachments/assets/25bbe06a-4954-4289-97f0-f5ee9afad6ec" />

After:
<img width="929" height="764" alt="Screenshot 2026-07-31 at 11 02 38 AM" src="https://github.com/user-attachments/assets/9548a164-6cc9-4e5e-8067-44fc7e780188" />

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)