### PR TITLE
[Data - 2831] Fix flow image prefix - v0.17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,7 +311,7 @@ services:
       PLUGINS_REGISTRY: ${PLUGINS_REGISTRY:-https://pkgs.dev.azure.com/data2evidence/d2e/_packaging/d2e/npm/registry/}
       TPM_REGISTRY_URL: ${PLUGINS_REGISTRY:-https://pkgs.dev.azure.com/data2evidence/d2e/_packaging/d2e/npm/registry/}
       PLUGINS_IMAGE_TAG: ${PLUGINS_IMAGE_TAG:-develop}
-      PLUGINS_FLOW_CUSTOM_REPO_IMAGE_CONFIG: "${PLUGINS_FLOW_CUSTOM_REPO_IMAGE_CONFIG:-{}}" #{"current": "ghcr.io/ohdsi/d2e", "new": ""}
+      PLUGINS_FLOW_CUSTOM_REPO_IMAGE_CONFIG: '{"current":"ghcr.io/ohdsi/","new":"${DOCKER_IMAGE_PREFIX:-ghcr.io/ohdsi/}"}'
       PLUGINS_INFORMATION_URL: ${PLUGINS_INFORMATION_URL:-https://feeds.dev.azure.com/data2evidence/d2e/_apis/packaging/Feeds/d2e/packages?api-version=7.1&includeDescription=true}
       PROJECT_NAME: ${PROJECT_NAME:-d2e}
       DATAFLOW_TEMPLATE_REPO_URL: ${DATAFLOW_TEMPLATE_REPO_URL:-https://github.com/data2evidence/templates.git}


### PR DESCRIPTION
`PLUGINS_FLOW_CUSTOM_REPO_IMAGE_CONFIG` is `{}` by default, so Trex finds no "current" or "new" repository mapping, it leaves the manifest image unchanged: e.g. `ghcr.io/ohdsi/d2e/flow-base:0.17.1-beta`. So Prefect Docker-worker deployments used the hardcoded `ghcr.io/ohdsi/d2e/flow-base` image even when `DOCKER_IMAGE_PREFIX` was configured. 

The update of `PLUGINS_FLOW_CUSTOM_REPO_IMAGE_CONFIG` with `DOCKER_IMAGE_PREFIX` solves the issue: https://github.com/OHDSI/Data2Evidence/issues/2831

Test on images when trigger `Update metadata`:
Custom prefix → `${DOCKER_IMAGE_PREFIX}d2e/flow-base:0.17.1-beta`
Unset prefix → `ghcr.io/ohdsi/d2e/flow-base:0.17.1-beta`

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)