### PR TITLE
Fix type conflict in CDM Config

### DIFF
--- a/plugins/ui/apps/portal/src/plugins/mri/CDM/ui5/lib/ConfigModelsData.js
+++ b/plugins/ui/apps/portal/src/plugins/mri/CDM/ui5/lib/ConfigModelsData.js
@@ -344,7 +344,7 @@ sap.ui.define([
 			changeable: true,
 			attributes: [],
 			parentInteraction: [],
-			parentInteractionsMapping: { value: [], validity: { status: "valid", message: "" } },
+			parentInteractionsMapping: { value: "[]", validity: { status: "valid", message: "" } },
 			description: "",
 			isNew: true,
 			additionalInformation: "",

--- a/plugins/ui/apps/portal/src/plugins/mri/CDM/ui5/lib/ConfigModelsManager.js
+++ b/plugins/ui/apps/portal/src/plugins/mri/CDM/ui5/lib/ConfigModelsManager.js
@@ -269,7 +269,7 @@ sap.ui.define([
 
         if (!dimTable.hierarchy) {
             currentData.parentInteraction = [];
-            currentData.parentInteractionsMapping.value = [];
+            currentData.parentInteractionsMapping.value = "[]";
             currentData.parentInteractionLabel.value = "";
         }
 


### PR DESCRIPTION
The bug:
 `parentInteractionsMapping.value`  is contractually a JSON string everywhere it's read or written, but the two initializers seeded it as a raw array. `tooltip` complained and broke breadcrumb navigation.

The fix:
Initialise `parentInteractionsMapping.value` as "[]" which is a string, so `validateAggregation` accepts it via the string alt-type and never reaches the throw. It also aligns the skeleton with what the backend converter already produces (`JSON.stringify([])` is exactly `"[]"`), so freshly-created cards and loaded cards now hold the same type.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)