### PR TITLE
fix: Cohort size 0 in materialised cohort

### DIFF
--- a/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
@@ -53,6 +53,18 @@ function extractSessionVars(dbCredential: any): Record<string, string> {
     return out;
 }
 
+/**
+ * trex_hana_materialize_cohort's source_params_json is a JSON array of bare bind
+ * values, not the {key, type, value} placeholder objects _prepareQuery() returns.
+ * Handing it the objects binds them as JSON text, so every `?` comparison silently
+ * fails to match and the cohort materializes to 0 rows with no error.
+ */
+function flattenBindParameters(placeholders: any[]): any[] {
+    return (placeholders ?? []).map((placeholder: any) =>
+        placeholder?.value === undefined ? null : placeholder.value
+    );
+}
+
 export class CohortEndpoint {
     private constructor(
         public connection: ConnectionInterface,
@@ -611,7 +623,9 @@ export class CohortEndpoint {
 
             const url = buildHanaConnectionUrl(metadata.dbCredential);
             const sessionVars = extractSessionVars(metadata.dbCredential);
-
+            const sourceParams = flattenBindParameters(
+                preparedQuery.placeholders
+            );
             // The hana extension's trex_hana_materialize_cohort is registered on the
             // shared DuckDB database; reach it via a memory connection. %s = VARCHAR
             // params (sent as bind params), %f = the BIGINT cohort id (inlined as a
@@ -626,7 +640,7 @@ export class CohortEndpoint {
                     "SELECT trex_hana_materialize_cohort(%s, %s, %s, %s, %f, %s) AS processed_rows",
                     url,
                     translatedSql,
-                    JSON.stringify(preparedQuery.placeholders ?? []),
+                    JSON.stringify(sourceParams),
                     this.schemaName,
                     Number(cohortDefinitionId),
                     JSON.stringify(sessionVars)

--- a/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
@@ -56,8 +56,6 @@ function extractSessionVars(dbCredential: any): Record<string, string> {
 /**
  * trex_hana_materialize_cohort's source_params_json is a JSON array of bare bind
  * values, not the {key, type, value} placeholder objects _prepareQuery() returns.
- * Handing it the objects binds them as JSON text, so every `?` comparison silently
- * fails to match and the cohort materializes to 0 rows with no error.
  */
 function flattenBindParameters(placeholders: any[]): any[] {
     return (placeholders ?? []).map((placeholder: any) =>

--- a/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
+++ b/plugins/functions/analytics-svc/src/mri/endpoint/CohortEndpoint.ts
@@ -55,11 +55,20 @@ function extractSessionVars(dbCredential: any): Record<string, string> {
 
 /**
  * trex_hana_materialize_cohort's source_params_json is a JSON array of bare bind
- * values, not the {key, type, value} placeholder objects _prepareQuery() returns.
+ * values, not the {type, value} objects _prepareQuery() returns in `placeholders`
+ 
+ * Accepts either shape: a {type, value} wrapper is unwrapped, an already-bare
+ * value is passed through. Absent values become null (SQL NULL). Keep this a
+ * 1:1 map — element order must stay aligned with the `?` markers in the SQL, and
+ * _prepareQuery() has already dropped the numeric placeholders it inlined.
  */
 function flattenBindParameters(placeholders: any[]): any[] {
     return (placeholders ?? []).map((placeholder: any) =>
-        placeholder?.value === undefined ? null : placeholder.value
+        placeholder !== null &&
+        typeof placeholder === "object" &&
+        "value" in placeholder
+            ? (placeholder.value ?? null)
+            : (placeholder ?? null)
     );
 }
 


### PR DESCRIPTION
The cohort size 0 in materialised cohort bug is only reproducible when `ANALYTICS_HANA_STREAMING_ENABLED` is set to true.

`preparedQuery.placeholders` produced `[{"type":"text","value":"FEMALE"}, {"type":"text","value":"Asian"}, …]` when `trex_hana_materialize_cohort` expects an array of bind parameters, e.g. `["FEMALE", "Asian", ...]`

Fix is to flatten placeholders to bare values before serializing.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)