### PR TITLE
fix(ci): stop the tag sweep deleting versions that also carry develop tags

### DIFF
--- a/.github/workflows/cleanup-stale-pr-tags.yml
+++ b/.github/workflows/cleanup-stale-pr-tags.yml
@@ -49,12 +49,24 @@ jobs:
             count=$(echo "$resp" | jq 'length')
             if [ "$count" = "0" ]; then break; fi
 
+            # Delete a version only when EVERY tag on it is pr-/mg-.
+            #
+            # The API deletes versions, not tags, and identical image content is
+            # deduped onto ONE version — so a stable image ends up with a single
+            # version carrying many tags. d2e-logto currently has one version
+            # tagged with five pr-* tags AND develop-a6b76bf AND develop-a0e1d4a.
+            # Matching any single stale pr-* tag therefore deleted develop with
+            # it, which is why the images that change least (d2e-logto,
+            # d2e-dataflow-gen-worker) keep only one develop-* tag while the
+            # others keep 50+, and why ghcr.io/ohdsi/d2e-dataflow-gen-worker:develop
+            # now resolves to a manifest that no longer exists. That broke every
+            # downstream e2e that pulls the develop image set.
             echo "$resp" | jq -r '
               .[]
               | . as $v
-              | (.metadata.container.tags // [])[]
-              | select(test("^(pr-|mg-)"))
-              | "\($v.id) \($v.updated_at) \(.)"
+              | (.metadata.container.tags // []) as $tags
+              | select(($tags | length) > 0 and (all($tags[]; test("^(pr-|mg-)"))))
+              | "\($v.id) \($v.updated_at) \($tags | join(","))"
             ' | while read vid updated tag; do
               vid_ts=$(date -u -d "$updated" +%s)
               if [ "$vid_ts" -lt "$cutoff" ]; then


### PR DESCRIPTION
`cleanup-stale-pr-tags.yml` deletes a package **version** whenever *any* of its tags matches `pr-`/`mg-`. The GHCR API can only delete versions, not individual tags, and identical image content is deduplicated onto a single version — so an image that rarely changes ends up with one version carrying many tags.

`d2e-logto` right now:

```
["pr-3063-0caee12","pr-3035-4ce7076","pr-3066-024b5a4","pr-3010-3cc5996",
 "develop-a6b76bf","develop-a0e1d4a","pr-3080-a4a91cd","pr-3080-d4d79a1","pr-3076-635f18b"]
```

One stale `pr-*` tag on that version is enough for the sweep to delete it, taking both `develop-*` tags with it.

## What it broke

This is why the images that change least keep a single `develop-*` tag while the others keep 50+, and why:

```
$ docker manifest inspect ghcr.io/ohdsi/d2e-dataflow-gen-worker:develop
manifest unknown
```

The packages API still lists a version tagged `develop` for that image (digest `sha256:b445dca5…`, published 2026-08-07) — the tag record survived, the manifest did not. Six of the seven images in the develop set pull; that one does not, so every downstream job that pulls the set fails before it starts. It has been broken since 2026-08-07.

## The change

Sweep a version only when **every** tag on it is `pr-`/`mg-`:

```jq
| (.metadata.container.tags // []) as $tags
| select(($tags | length) > 0 and (all($tags[]; test("^(pr-|mg-)"))))
```

## Checked against the live registry

| image | deletions before | after | versions protected |
|---|---|---|---|
| `d2e-logto` | 1 | **0** | 1 (holds both develop tags) |
| `d2e-trex` | 6 | 6 | 0 |
| `d2e-dataflow-gen-worker` | 4 | 4 | 0 |

Nothing stops being cleaned up except deletions that would take a protected tag with them.

## Still needed separately

This prevents further damage; it cannot restore a manifest that is already gone. `d2e-dataflow-gen-worker:develop` needs republishing before the develop image set is pullable again.