### PR TITLE
Compare regression baselines using p50 instead of p95

### DIFF
--- a/d2e-skill/d2e-regression-tests-skill/SKILL.md
+++ b/d2e-skill/d2e-regression-tests-skill/SKILL.md
@@ -17,8 +17,8 @@ description: A skill for writing and running performance regression tests for D2
 | `DATASET_ID` | `DATASET_ID` | Injected into matching query params and JSON body fields |
 | `PA_CONFIG_ID` | `PA_CONFIG_ID` | Injected into matching query params and JSON body fields |
 | `bearerToken` | `BEARER_TOKEN` | Added as `Authorization` header on every request; **required** — the run exits immediately if unset |
-| `failThreshold` | `PERF_FAIL_THRESHOLD` | p95 regression fraction that fails the test (default 0.20) |
-| `warnThreshold` | `PERF_WARN_THRESHOLD` | p95 regression fraction that warns (default 0.10) |
+| `failThreshold` | `PERF_FAIL_THRESHOLD` | p50 regression fraction that fails the test (default 0.20) |
+| `warnThreshold` | `PERF_WARN_THRESHOLD` | p50 regression fraction that warns (default 0.10) |
 | `repetitions` | `PERF_REPETITIONS` | Requests per scenario per run (default 3) |
 | `warmupRequests` | `PERF_WARMUP_REQUESTS` | Throwaway requests fired per scenario before timing starts, to warm up edge runtime workers (default 1) |
 
@@ -60,18 +60,22 @@ The test runner merges all per-directory `baseline.json` files at startup. To up
 
 ## Baseline metric
 
-The baseline is **p95 latency** (`p95Ms`) — the 95th-percentile response time across all timed repetitions. The results table also displays current min and max as separate columns. Delta (Δ%) and pass/warn/fail thresholds are computed against the stored p95.
+The comparison metric is **p50 latency** — the median response time across all timed repetitions. The results table also displays current min and max as separate columns.
+
+Stored baselines in `scenarios/*/baseline.json` are still **p95** values under the `p95Ms` key; they were deliberately left unregenerated when the comparison switched to the p50. So Δ% and the pass/warn/fail thresholds compare *this run's p50* against the *stored p95*, which is lenient by design — each scenario carries headroom equal to the spread between its own p50 and p95.
+
+The switch exists because the p95 index resolves to the slowest single sample at the repetition counts CI uses, which made the gate a function of runner noise rather than of application performance. See "p50 vs p95 baseline" in `tests/regression/README.md` for the full rationale and for how to remove the asymmetry later.
 
 ## Test failure conditions
 
 A scenario fails if any of the following are true:
 - Any timed response returned a non-2xx HTTP status
 - No baseline entry exists for the scenario (run `npm run baseline` and commit `baseline.json`)
-- The current p95 exceeds the baseline p95 by more than `PERF_FAIL_THRESHOLD` (default 20%)
+- The current p50 exceeds the stored baseline p95 by more than `PERF_FAIL_THRESHOLD` (default 20%)
 
 ## HTML Report
 
-On a failed run, `tests/regression/test-results/regression-report.html` is generated — a dark-theme table showing each scenario's baseline p95, current p95, min, max, Δ%, and status, with a summary and alert banner for failures. It is uploaded automatically as part of the `regression-failure-report-<attempt>` GitHub Actions artifact.
+On a failed run, `tests/regression/test-results/regression-report.html` is generated — a dark-theme table showing each scenario's baseline p95, current p50, min, max, Δ%, and status, with a summary and alert banner for failures. It is uploaded automatically as part of the `regression-failure-report-<attempt>` GitHub Actions artifact.
 
 ## CI
 

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -24,4 +24,14 @@ Each scenario directory gets its own `baseline.json`. Commit these files to lock
 set -a && source .env && set +a && npm test
 ```
 
-Results print a table showing p95 response time vs baseline, delta per scenario, and min/max. Tests fail if any scenario exceeds 20% above baseline p95 (`PERF_FAIL_THRESHOLD`) by more than 15ms (`PERF_MIN_DELTA_MS`, so ms-level jitter on small baselines doesn't fail CI), if a non-2xx response is returned, or if no baseline entry exists for the scenario. The run exits immediately if `BEARER_TOKEN` is not set.
+Results print a table showing the **p50** response time vs baseline, delta per scenario, and min/max. Tests fail if any scenario's p50 exceeds 20% above the stored baseline (`PERF_FAIL_THRESHOLD`) by more than 15ms (`PERF_MIN_DELTA_MS`, so ms-level jitter on small baselines doesn't fail CI), if a non-2xx response is returned, or if no baseline entry exists for the scenario. The run exits immediately if `BEARER_TOKEN` is not set.
+
+## p50 vs p95 baseline
+
+The comparison metric is the **p50 (median)** of each scenario's timed samples. CI runs 10 repetitions, and `percentile()` (`runner/httpClient.ts`) computes `idx = Math.ceil((p/100) * len) - 1`, so with 10 samples the p95 index resolves to the **last element** — the slowest single request of the run. That made the gate a function of runner noise rather than of application performance. The p50 is the stable statistic over the same samples.
+
+The stored baselines in `scenarios/*/baseline.json` are still **p95** values under the `p95Ms` key — they were deliberately left unregenerated when the comparison switched to the p50.
+
+So the gate compares *current p50* against *stored p95*, which is systematically lenient: each scenario carries headroom equal to the spread between its own p50 and p95. This is a known and accepted trade-off — the thresholds were deliberately left at 10%/20%, and nothing that passes today can start failing because of the metric switch.
+
+To remove the asymmetry later, regenerate the baselines on a quiet environment (`npm run baseline`) and commit the result — at that point the stored values become p50s, and the `p95Ms` key should be renamed to `p50Ms` across `runner/compare.ts`, `runner/baselineWriter.ts` and the three `baseline.json` files in one change.

--- a/tests/regression/runner/compare.ts
+++ b/tests/regression/runner/compare.ts
@@ -6,24 +6,32 @@ export type CompareStatus = "pass" | "warn" | "fail" | "no-baseline";
 export interface CompareResult {
   scenarioName: string;
   status: CompareStatus;
-  currentP95Ms: number;
+  currentP50Ms: number;
   baselineP95Ms: number | null;
   deltaFraction: number | null;
   minMs: number;
   maxMs: number;
 }
 
+// Baseline files on disk store a p95 under `p95Ms` and are deliberately left
+// untouched, so the comparison is current-p50 vs stored-p95 and is therefore
+// lenient by design. See "p50 vs p95 baseline" in tests/regression/README.md.
 export type Baseline = Record<string, { p95Ms: number }>;
 
 export function compareToBaseline(result: TimingResult, baseline: Baseline): CompareResult {
   const entry = baseline[result.scenarioName];
+
+  // The median of this run's samples — p50Ms is already computed by runScenario().
+  // Using it instead of p95Ms is the whole change: with 10 repetitions the p95
+  // resolves to the slowest single sample, which made CI fail on runner noise.
+  const currentP50Ms = result.p50Ms;
 
   const baselineP95Ms = entry?.p95Ms;
   if (typeof baselineP95Ms !== "number" || !isFinite(baselineP95Ms) || baselineP95Ms <= 0) {
     return {
       scenarioName: result.scenarioName,
       status: "no-baseline",
-      currentP95Ms: result.p95Ms,
+      currentP50Ms,
       baselineP95Ms: null,
       deltaFraction: null,
       minMs: result.minMs,
@@ -31,9 +39,9 @@ export function compareToBaseline(result: TimingResult, baseline: Baseline): Com
     };
   }
 
-  const delta = (result.p95Ms - baselineP95Ms) / baselineP95Ms;
+  const delta = (currentP50Ms - baselineP95Ms) / baselineP95Ms;
   let status: CompareStatus = "pass";
-  if (result.p95Ms - baselineP95Ms > config.minDeltaMs) {
+  if (currentP50Ms - baselineP95Ms > config.minDeltaMs) {
     if (delta > config.failThreshold) status = "fail";
     else if (delta > config.warnThreshold) status = "warn";
   }
@@ -41,7 +49,7 @@ export function compareToBaseline(result: TimingResult, baseline: Baseline): Com
   return {
     scenarioName: result.scenarioName,
     status,
-    currentP95Ms: result.p95Ms,
+    currentP50Ms,
     baselineP95Ms,
     deltaFraction: delta,
     minMs: result.minMs,

--- a/tests/regression/runner/htmlReport.ts
+++ b/tests/regression/runner/htmlReport.ts
@@ -39,7 +39,7 @@ export function writeHtmlReport(results: CompareResult[], runDate: string): void
     return `<tr class="${rowCls}">
       <td>${r.scenarioName}</td>
       <td class="baseline-col">${baseStr}</td>
-      <td>${r.currentP95Ms.toFixed(1)}ms</td>
+      <td>${r.currentP50Ms.toFixed(1)}ms</td>
       <td>${r.minMs.toFixed(1)}ms</td>
       <td>${r.maxMs.toFixed(1)}ms</td>
       <td class="${deltaCls}">${deltaStr}</td>
@@ -106,7 +106,7 @@ export function writeHtmlReport(results: CompareResult[], runDate: string): void
 </head>
 <body>
   <h1>D2E Regression — Performance Report</h1>
-  <p class="subtitle">${total} scenario(s) · p95 latency · ${runDate}</p>
+  <p class="subtitle">${total} scenario(s) · p50 latency vs baseline p95 · ${runDate}</p>
 
   ${alertHtml}
 
@@ -123,7 +123,7 @@ export function writeHtmlReport(results: CompareResult[], runDate: string): void
       <tr>
         <th>Scenario</th>
         <th class="baseline-col">Baseline p95</th>
-        <th>Current p95</th>
+        <th>Current p50</th>
         <th>Min</th>
         <th>Max</th>
         <th>Δ%</th>
@@ -144,7 +144,7 @@ export function writeHtmlReport(results: CompareResult[], runDate: string): void
     <div class="card"><div class="card-label">No Baseline</div><div class="card-value gray">${noBaseline.length}</div></div>
   </div>
 
-  <p class="footer">Baseline p95 values from <code>tests/regression/scenarios/*/baseline.json</code>. Δ% computed vs stored baseline p95. Thresholds: warn &gt;10%, fail &gt;20%.</p>
+  <p class="footer">Baseline p95 values from <code>tests/regression/scenarios/*/baseline.json</code>. Δ% compares this run's <strong>p50</strong> against the stored <strong>p95</strong> baseline. Thresholds: warn &gt;10%, fail &gt;20%.</p>
 </body>
 </html>`;
 

--- a/tests/regression/scenarios/README.md
+++ b/tests/regression/scenarios/README.md
@@ -44,7 +44,7 @@ set -a && source .env && set +a && npm run report
 
 | Env var | Default | Effect |
 |---|---|---|
-| `PERF_WARN_THRESHOLD` | `0.10` | Prints a warning if p95 grows by more than 10% |
-| `PERF_FAIL_THRESHOLD` | `0.20` | Fails the test if p95 grows by more than 20% |
-| `PERF_MIN_DELTA_MS` | `15` | p95 growth below this many ms never warns/fails (guards small baselines against runner jitter) |
+| `PERF_WARN_THRESHOLD` | `0.10` | Prints a warning if the p50 grows by more than 10% |
+| `PERF_FAIL_THRESHOLD` | `0.20` | Fails the test if the p50 grows by more than 20% |
+| `PERF_MIN_DELTA_MS` | `15` | p50 growth below this many ms never warns/fails (guards small baselines against runner jitter) |
 | `PERF_REPETITIONS` | `3` | Number of times each request is repeated per run |

--- a/tests/regression/tests/compare.test.ts
+++ b/tests/regression/tests/compare.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { compareToBaseline } from "../runner/compare.js";
+import type { Baseline } from "../runner/compare.js";
+import type { TimingResult } from "../runner/httpClient.js";
+
+function timing(overrides: Partial<TimingResult> & { p50Ms: number }): TimingResult {
+  return {
+    scenarioName: "demo",
+    p95Ms: 9999,
+    p99Ms: 9999,
+    minMs: overrides.p50Ms,
+    maxMs: 9999,
+    samples: [],
+    statusCodes: [200],
+    ...overrides,
+  };
+}
+
+// Baselines on disk are p95-derived and stay that way — see the plan's Scope section.
+const baseline: Baseline = { demo: { p95Ms: 100 } };
+
+describe("compareToBaseline", () => {
+  it("compares the p50, not the p95", () => {
+    // p95 is ~100x the baseline; the p50 is below it. The p50 must win → pass.
+    // This is the whole point of the change: one slow request out of ten no
+    // longer decides the verdict.
+    const result = compareToBaseline(timing({ p50Ms: 90, p95Ms: 9999 }), baseline);
+
+    expect(result.status).toBe("pass");
+    expect(result.currentP50Ms).toBe(90);
+  });
+
+  it("reports the baseline p95 it compared against", () => {
+    const result = compareToBaseline(timing({ p50Ms: 90 }), baseline);
+
+    expect(result.baselineP95Ms).toBe(100);
+    expect(result.deltaFraction).toBeCloseTo(-0.1, 10);
+  });
+
+  it("fails when the p50 exceeds the baseline by more than the 20% fail threshold", () => {
+    // +30% and +30ms — past both the fail threshold and the 15ms floor.
+    const result = compareToBaseline(timing({ p50Ms: 130 }), baseline);
+
+    expect(result.status).toBe("fail");
+    expect(result.deltaFraction).toBeCloseTo(0.3, 10);
+  });
+
+  it("warns between the 10% and 20% thresholds when the 15ms floor is cleared", () => {
+    // +16% and +16ms — past the warn threshold and the floor, under 20%.
+    const result = compareToBaseline(timing({ p50Ms: 116 }), baseline);
+
+    expect(result.status).toBe("warn");
+  });
+
+  it("passes below the warn threshold", () => {
+    const result = compareToBaseline(timing({ p50Ms: 105 }), baseline);
+
+    expect(result.status).toBe("pass");
+  });
+
+  it("does not fail on small absolute growth even when the percentage is large", () => {
+    // +100% but only +10ms, under the 15ms minDeltaMs jitter guard.
+    const smallBaseline: Baseline = { demo: { p95Ms: 10 } };
+    const result = compareToBaseline(timing({ p50Ms: 20 }), smallBaseline);
+
+    expect(result.status).toBe("pass");
+  });
+
+  it("returns no-baseline when the scenario has no baseline entry", () => {
+    const result = compareToBaseline(timing({ p50Ms: 90 }), {});
+
+    expect(result.status).toBe("no-baseline");
+    expect(result.baselineP95Ms).toBeNull();
+    expect(result.deltaFraction).toBeNull();
+    expect(result.currentP50Ms).toBe(90);
+  });
+
+  it("returns no-baseline when the stored baseline value is not a usable number", () => {
+    const broken = { demo: { p95Ms: 0 } } as Baseline;
+    const result = compareToBaseline(timing({ p50Ms: 90 }), broken);
+
+    expect(result.status).toBe("no-baseline");
+  });
+
+  it("passes through min and max unchanged", () => {
+    const result = compareToBaseline(timing({ p50Ms: 90, minMs: 80, maxMs: 400 }), baseline);
+
+    expect(result.minMs).toBe(80);
+    expect(result.maxMs).toBe(400);
+  });
+});

--- a/tests/regression/tests/regression.test.ts
+++ b/tests/regression/tests/regression.test.ts
@@ -55,7 +55,7 @@ const STATUS_RANK: Record<string, number> = { fail: 3, warn: 2, pass: 1, "no-bas
 interface GroupedResult {
   name: string;
   status: CompareStatus;
-  totalCurrentP95Ms: number;
+  totalCurrentP50Ms: number;
   totalBaselineP95Ms: number | null;
   deltaFraction: number | null;
   totalMinMs: number;
@@ -80,16 +80,16 @@ function groupResults(results: CompareResult[]): GroupedResult[] {
       (worst, m) => STATUS_RANK[m.status] > STATUS_RANK[worst] ? m.status : worst,
       "no-baseline"
     );
-    const totalCurrentP95Ms = members.reduce((s, m) => s + m.currentP95Ms, 0);
+    const totalCurrentP50Ms = members.reduce((s, m) => s + m.currentP50Ms, 0);
     const anyNoBaseline = members.some(m => m.baselineP95Ms === null);
     const totalBaselineP95Ms = anyNoBaseline ? null : members.reduce((s, m) => s + m.baselineP95Ms!, 0);
     const deltaFraction = totalBaselineP95Ms !== null
-      ? (totalCurrentP95Ms - totalBaselineP95Ms) / totalBaselineP95Ms
+      ? (totalCurrentP50Ms - totalBaselineP95Ms) / totalBaselineP95Ms
       : null;
     return {
       name,
       status,
-      totalCurrentP95Ms,
+      totalCurrentP50Ms,
       totalBaselineP95Ms,
       deltaFraction,
       totalMinMs: members.reduce((s, m) => s + m.minMs, 0),
@@ -107,7 +107,7 @@ function writeDetailedReport(results: CompareResult[]): void {
 
 function printTable(results: GroupedResult[]): void {
   const COL_SCENARIO = 60;
-  const COL_P95      = 26;
+  const COL_METRIC   = 26;
   const COL_MIN      = 8;
   const COL_MAX      = 8;
   const COL_DELTA    = 8;
@@ -115,30 +115,30 @@ function printTable(results: GroupedResult[]): void {
 
   const pad  = (s: string, n: number) => s.padEnd(n);
   const lpad = (s: string, n: number) => s.padStart(n);
-  const divider = `${"─".repeat(COL_SCENARIO + 2)}┼${"─".repeat(COL_P95 + 2)}┼${"─".repeat(COL_MIN + 2)}┼${"─".repeat(COL_MAX + 2)}┼${"─".repeat(COL_DELTA + 2)}┼${"─".repeat(COL_STATUS + 2)}`;
+  const divider = `${"─".repeat(COL_SCENARIO + 2)}┼${"─".repeat(COL_METRIC + 2)}┼${"─".repeat(COL_MIN + 2)}┼${"─".repeat(COL_MAX + 2)}┼${"─".repeat(COL_DELTA + 2)}┼${"─".repeat(COL_STATUS + 2)}`;
   const row = (a: string, b: string, c: string, d: string, e: string, f: string) =>
-    ` ${pad(a, COL_SCENARIO)} │ ${pad(b, COL_P95)} │ ${lpad(c, COL_MIN)} │ ${lpad(d, COL_MAX)} │ ${lpad(e, COL_DELTA)} │ ${pad(f, COL_STATUS)}`;
+    ` ${pad(a, COL_SCENARIO)} │ ${pad(b, COL_METRIC)} │ ${lpad(c, COL_MIN)} │ ${lpad(d, COL_MAX)} │ ${lpad(e, COL_DELTA)} │ ${pad(f, COL_STATUS)}`;
 
   const lines: string[] = [
     "",
     "Performance Regression Results",
     divider,
-    row("Scenario", "p95 (baseline)", "min", "max", "Δ%", "Status"),
+    row("Scenario", "p50 (baseline p95)", "min", "max", "Δ%", "Status"),
     divider,
   ];
 
   for (const r of results) {
-    const p95BaselineStr =
+    const metricStr =
       r.totalBaselineP95Ms !== null
-        ? `${r.totalCurrentP95Ms.toFixed(1)}ms (${r.totalBaselineP95Ms.toFixed(1)}ms)`
-        : `${r.totalCurrentP95Ms.toFixed(1)}ms (no baseline)`;
+        ? `${r.totalCurrentP50Ms.toFixed(1)}ms (${r.totalBaselineP95Ms.toFixed(1)}ms)`
+        : `${r.totalCurrentP50Ms.toFixed(1)}ms (no baseline)`;
     const minStr = `${r.totalMinMs.toFixed(1)}ms`;
     const maxStr = `${r.totalMaxMs.toFixed(1)}ms`;
     const deltaStr =
       r.deltaFraction !== null
         ? `${r.deltaFraction >= 0 ? "+" : ""}${(r.deltaFraction * 100).toFixed(1)}%`
         : "-";
-    lines.push(row(r.name, p95BaselineStr, minStr, maxStr, deltaStr, STATUS_ICON[r.status]));
+    lines.push(row(r.name, metricStr, minStr, maxStr, deltaStr, STATUS_ICON[r.status]));
   }
 
   lines.push(divider);
@@ -149,8 +149,8 @@ function printTable(results: GroupedResult[]): void {
     lines.push("Scenarios exceeding fail threshold:");
     for (const r of failing) {
       lines.push(
-        `  ✗ ${r.name}: p95 ${r.totalCurrentP95Ms.toFixed(1)}ms` +
-        ` (baseline ${r.totalBaselineP95Ms!.toFixed(1)}ms, +${(r.deltaFraction! * 100).toFixed(1)}%)`
+        `  ✗ ${r.name}: p50 ${r.totalCurrentP50Ms.toFixed(1)}ms` +
+        ` (baseline p95 ${r.totalBaselineP95Ms!.toFixed(1)}ms, +${(r.deltaFraction! * 100).toFixed(1)}%)`
       );
     }
   }
@@ -161,8 +161,8 @@ function printTable(results: GroupedResult[]): void {
     lines.push("Scenarios exceeding warn threshold:");
     for (const r of warning) {
       lines.push(
-        `  ⚠ ${r.name}: p95 ${r.totalCurrentP95Ms.toFixed(1)}ms` +
-        ` (baseline ${r.totalBaselineP95Ms!.toFixed(1)}ms, +${(r.deltaFraction! * 100).toFixed(1)}%)`
+        `  ⚠ ${r.name}: p50 ${r.totalCurrentP50Ms.toFixed(1)}ms` +
+        ` (baseline p95 ${r.totalBaselineP95Ms!.toFixed(1)}ms, +${(r.deltaFraction! * 100).toFixed(1)}%)`
       );
     }
   }
@@ -208,8 +208,8 @@ if (scenarios.length === 0) {
       expect(comparison.status, `${scenario.name}: no baseline found — run the baseline writer first`).not.toBe("no-baseline");
       expect(
         comparison.status,
-        `${scenario.name} p95 ${timing.p95Ms.toFixed(1)}ms exceeded fail threshold` +
-        (comparison.baselineP95Ms ? ` (baseline ${comparison.baselineP95Ms.toFixed(1)}ms)` : "")
+        `${scenario.name} p50 ${timing.p50Ms.toFixed(1)}ms exceeded fail threshold` +
+        (comparison.baselineP95Ms ? ` (baseline p95 ${comparison.baselineP95Ms.toFixed(1)}ms)` : "")
       ).not.toBe("fail");
     });
   }


### PR DESCRIPTION
## What

The performance regression gate compared each scenario's **p95** against the stored baseline p95. `percentile()` (`runner/httpClient.ts`) computes `idx = Math.ceil((p/100) * len) - 1`, so at the repetition counts this suite uses the p95 index resolves to the **last element** — the slowest single request of the run. The gate was therefore a function of runner noise rather than of application performance, and could fail on changes that touched nothing related.

This switches the comparison to the **p50 (median)** of the same samples, and relabels the console table, the HTML report and the failure messages so the numbers aren't mistaken for p95s.

## p50 vs p95 behaviour

Stored baselines in `scenarios/*/baseline.json` are **unchanged** — still p95 values under the `p95Ms` key. The gate therefore compares *this run's p50* against the *stored p95*, which is systematically lenient: every scenario carries headroom equal to the spread between its own p50 and p95.

That asymmetry is deliberate, and it is why the thresholds were left at 10% warn / 20% fail: nothing that passes today can start failing because of the metric switch. It is a one-way change in strictness.

To remove the asymmetry later, regenerate the baselines on a quiet environment (`npm run baseline`) and commit them — the stored values then become p50s, and `p95Ms` should be renamed to `p50Ms` across `runner/compare.ts`, `runner/baselineWriter.ts` and the three `baseline.json` files in one change. This is written up under "p50 vs p95 baseline" in `tests/regression/README.md`.

## Tests

Adds `tests/regression/tests/compare.test.ts` — 9 unit tests for `compareToBaseline` covering the metric switch (a run whose p95 is ~100x the baseline but whose p50 is under it must pass), both thresholds, the `minDeltaMs` jitter floor, and the no-baseline paths.

- `vitest run tests/compare.test.ts` — **9/9 pass**
- `tsc --noEmit` — **clean**, covering all changed files

**The live regression suite (`npm test` / `tests/regression.test.ts`) was not run.** It drives real HTTP requests against a running D2E instance and requires a valid `BEARER_TOKEN`; no live endpoint or valid token was available in this environment. Its changes here are renames only (`currentP95Ms` → `currentP50Ms` and label text) and are covered statically by the typecheck, but the end-to-end run still wants a pass in CI or against a live instance before merge.

Note that `vitest.config.ts` wires a `globalSetup` that exits when `BEARER_TOKEN` is unset, so even the new pure-function unit tests only execute where a token is present. Worth decoupling separately.

## Docs

`d2e-skill/d2e-regression-tests-skill/SKILL.md` documented the gate as current p95 vs baseline p95, which stopped being true. Corrected the baseline metric section, the two threshold rows, the fail condition and the HTML report description, and recorded that stored baselines remain p95 so the comparison is knowingly lenient.

No Docusaurus (`docs/website`) page was added: this changes an internal CI/developer harness, not a user-visible or operator-facing feature, and a full-text sweep of the site found no existing regression-suite content that this obsoletes.

### Known pre-existing doc drift, deliberately not fixed here

Out of scope for this change, but worth a follow-up:

- `SKILL.md` documents a "Stability Probe" section for `runner/stabilityProbe.ts`, which does not exist in the tree.
- `PERF_REPETITIONS` is documented as defaulting to `3` in both `SKILL.md` and `scenarios/README.md`; `config.ts` actually defaults to `10`. (`runner/baselineWriter.ts` also logs `?? 3`.)
- `PERF_WARMUP_REQUESTS` is documented as `1`; `config.ts` uses `2`. `PERF_MIN_DELTA_MS` is absent from the `SKILL.md` config table.
