### PR TITLE
fix(white-rabbit): restore scans and stop trapping users in the progress dialog

### DIFF
--- a/docs/website/docs/2-admin_guide/2-etl/README.md
+++ b/docs/website/docs/2-admin_guide/2-etl/README.md
@@ -1,0 +1,112 @@
+# ETL
+
+The **ETL** page lets an administrator build a dataflow that reads source data, inspects its
+structure, and maps it towards the OMOP data model. It is reached from the Admin Portal under
+**ETL**, and requires the `SYSTEM_ADMIN` role.
+
+A dataflow is built from nodes on a canvas. This page covers the **White Rabbit** node, which
+scans source data and reports the tables, fields, and value distributions it finds. The scan
+report is the input to the mapping work that follows.
+
+:::note
+
+The **White Rabbit** and **Rabbit in a Hat** nodes are marked *Experimental*.
+
+:::
+
+---
+
+## Scanning source data
+
+Add a **White Rabbit** node to the canvas and open it. Until a scan has been run, the node shows
+*"Please scan data to see Source tables"*.
+
+- Select **Scan Data** to open the scan dialog.
+- Under **Select Data Location**, choose the source type:
+
+| Source type | Fields to complete |
+|---|---|
+| **CSV files** | **Upload file** (accepts `.csv`), and **Delimiter** |
+| **PostgreSQL** | **Database** and **Schema Name** |
+
+- For CSV sources, **Delimiter** offers `,` `;` `|` `Tab` and `Space`. The default is `,`.
+- **Clear all** resets the entries in the section.
+- Under **Table to Scan**, select **Scan tables**. The button reads *Scanning...* while the
+  source is being read. For a CSV source with nothing uploaded, the list shows
+  *No files to scan*.
+- Select the tables or files to include, then select **Apply**.
+
+The scan then runs as a background job and the progress dialog opens.
+
+---
+
+## Following scan progress
+
+The progress dialog shows a progress bar and the current job state. It polls the job every few
+seconds and updates as the job advances.
+
+| State | Meaning |
+|---|---|
+| **Scheduled** / **Late** | The job is queued but has not started. |
+| **Pending** / **AwaitingRetry** | The job is being prepared. |
+| **Running** / **Retrying** | The scan is in progress. |
+| **Paused** | The job is paused. |
+| **Cancelling** | The job is being cancelled. |
+| **Completed** | The scan succeeded. |
+| **Failed** / **Crashed** / **Cancelled** / **TimedOut** | The scan ended without a usable report. |
+
+Three buttons are available:
+
+| Button | Behaviour |
+|---|---|
+| **Back** | Returns to the scan dialog so the settings can be adjusted and the scan re-run. Available at any time, including while a scan is still running or has stalled. It is only unavailable while **Link tables** is in progress. |
+| **Save report** | Downloads the generated `ScanReport.xlsx`. Enabled only after the scan completes successfully. |
+| **Link tables** | Adds the scanned tables to the node as source tables, so they can be connected to later nodes. Enabled only after the scan completes successfully. |
+
+Once **Link tables** has been used, the node lists the discovered source tables instead of the
+*Scan Data* prompt.
+
+### When the scan does not finish
+
+If the job ends in **Failed**, **Crashed**, **Cancelled**, or **TimedOut**, the dialog stops
+polling and reports that state. **Save report** and **Link tables** stay unavailable, because no
+usable report was produced. Use **Back** to adjust the settings and try again.
+
+If the dialog cannot reach the job at all — for example the dataflow worker is not running — it
+retries a few times and then stops polling and shows:
+
+> Lost contact with the scan job. It may still be running — close this dialog and check the flow
+> run status.
+
+The scan job itself may still be running on the server; this message only means the page gave up
+asking. Leave the dialog with **Back** and check the job run status.
+
+:::note
+
+Re-opening the dialog after a failed scan resets it, so a new scan starts from a clean state.
+
+:::
+
+---
+
+## Repeat scans
+
+Each file scan clears the working directory before downloading the current node's files. A scan
+therefore reports only the files belonging to that node and that run, and is not affected by
+files left behind by an earlier scan or by another node.
+
+---
+
+## Requirements
+
+Scanning is executed by the dataflow worker, which must contain the WhiteRabbit distribution.
+This is provisioned into the `alp-dataflow-gen-worker` image at build time.
+
+If a worker is running without it, the scan job fails and the job log names the missing path
+rather than failing on an unrelated file, for example:
+
+```
+WhiteRabbit distribution not found at /app/whiterabbit/dist/bin.
+```
+
+If this appears, the worker image is misprovisioned and needs to be rebuilt.

--- a/plugins/flows/data_transformation/pixi.lock
+++ b/plugins/flows/data_transformation/pixi.lock
@@ -609,6 +609,346 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fc/3e/a589e9e3702950e0babb1878155f9a731b1bc0e250cf33a2496ab70b9c1a/ollama-0.1.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ff/30/ea8f601a9bf44db99468696efd59eb9cff1157cd55cb586d67116697583f/murmurhash-1.0.15-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+  test:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-2.0.0-ha29393d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py312h703531f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-2.0.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-heca4667_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-2.0.0-hdab9b82_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-2.0.0-h0f4f740_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.3.0-hb7a6aa6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.3.0-h3a305e7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.3.0-h7df7c86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-15.3.0-hd47ba16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.3.0-h27ced10_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.3.0-hd47ba16_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.3.0-h90d9265_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.3.0-h6bd041b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.3.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.9-gpl_hc2c16d8_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.9.6-hc20babb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.0-h17a8019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.3.0-h17a8019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hf670292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.3.0-h54950a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.3-h49c6c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb03c661_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-26.6.0-hc039f44_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-17.0.18-ha668962_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h7c397b8_1011.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-h8ab3286_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/r-base-4.4.3-h502d0c9_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpy2-3.6.6-py312r44h4bada26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sed-4.10-h19d0853_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.3-ha02ee65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.3-ha02ee65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.3-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.3.0-h2b852eb_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.3.0-hb2c5482_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzlocal-5.4.4-pyh8f84b5b_0.conda
+      - pypi: https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/78/297b838f3b9511589badc8f472f70b31cf3bbf9eb99fa0a4d6e911d3114a/duckdb-1.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/13/2c/5e079cefe955ae58e5a052fe037c850ce493eb7269dedeb960237e78fb0f/wheel-0.46.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/19/57/9f172b900795ea37246c78b5f52e00f4779984370855b3e161600156906d/psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1b/b1/5745d7523d8ce53b87779f46ef6cf5c5c342997939c2fe967e607b944e43/coolname-2.2.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/26/b4/08c9d297edd5e1182506edecccbb88a92e1122a057953068cadac420ca5d/jinja2_humanize_extension-0.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/28/95/b56fc6b2abe37c03923b50415df483cf93e09e7438872280a5486131d804/numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/29/ad/15da606d71f40bcf2c405f84ca3d4195cb252f4eaa2f551fe6b2e630ee7c/cython-3.2.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/8e/096d00c7c480ef2ff4265349b14e2261d4ab787ba1f74e2e80d1c58079c3/regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2d/16/3e8c6e7c322464c9963b1bbf90cc0286dbd3789e4e251dc9c7a02f540224/prefect_shell-0.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2e/c3/94ade4906a2f88bc935772f59c934013b4205e773bcb4239db114a6da136/pyarrow_hotfix-0.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2f/f5/c36551e93acba41a59939ae6a0fb77ddb3f2e8e8caa716410c65f7341f72/asgi_lifespan-2.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/33/4b/f28074b15788b142fd4de1cbd30619e06bf54dacba95b406ed2f487ead5a/pyomop-6.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/f7/e6a2fdf2a23d59b4b48b8fa89e8d4bf2dd371aea2c6ba8fcecec20a4acb9/pendulum-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3c/4c/369f0b5665afa8ad6fb1862da979dbf61a650ea2b99b5dccda8953aa327c/distributed-2026.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3d/ca/36133653e00939922dd1416f4c56177361289172a30563fcb9552c9ccde4/readchar-4.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3f/b1/fce88472306a62a35655c2bc64f22921313022e8b4f8534c2b61ff135a43/xvfbwrapper-0.2.29-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/45/a8/283556be5310e61a8360766e510ed72a751433c1679c3f907f85798f7ccf/prefect-3.6.10-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/3e/9a5382868cad0d89abe517cf0ad9497b302c0c3e724856f916c2f22e1973/prodict-0.8.22-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4e/4e/21cd0b8f365449f1576f93de1ec8718ed18a7a3bc086dfbdeb79437bba7a/botocore-1.41.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/56/95/9377bcb415797e44274b51d46e3249eba641711cf3348050f76ee7b15ffc/httpx-0.27.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/57/64/eff2564783bd650ca25e15938d1c5b459cda997574a510f7de69688cb0b4/asyncio-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/4f/37960d5255988b218c40c9b5a2b731013684294a50735d1dd1ab4894e531/google_cloud_core-2.6.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5f/88/8dac5496354650972434966ba570a4a824fafed43471cf190faea4b085fc/timeago-1.0.16-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/3a/cfee3c50294f55a2f0f9575052dec2c2a48891ad4b1c2a133b05a87026cd/proto_plus-1.28.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/c0/f491506bdff4d73750f74cf18fea7d6ca409ada2f81c4c4d10a32edf5688/google_cloud_bigquery-3.43.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6b/c4/ee4096ffa2eeeca0c749b26f0371bd26aa5c8b611c43de99a4f86d3de0a7/pandasql-0.7.3.tar.gz
+      - pypi: https://files.pythonhosted.org/packages/6c/a6/923769b6dbb4e3a4c07a867e0c7fa8e4b230f675095cd7109d4e3eb9ddf0/pymssql-2.3.4-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/70/d8/e7478aa23695dc1e1d2e0ee1ffd4a5f155b86347ec2780d1d9e8cc1668c2/prefect_dask-0.3.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/73/8d/b0539e8dce90861efc38fea3eefb15a5d0cfeacf818614762e77a9f192f9/SQLAlchemy-2.0.38-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/77/fc/8cb9073bb1bee54eb49a1ae501a36402d01763812962ac811cdc1c81a9d7/parsy-2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7c/67/f9b49471b1a4010054de62c5820952522fc4f7d5903b0af977fe9960e834/orthanc_api_client-0.15.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/5f/7c22733da92b3a6cc4dddcaa8731089d213c2790bbc997e51c429a4e8f8b/dask-2026.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/86/c0/2851a8a55d0fea03b80fd45815069b686e032938fc68fa9d91ac776c148c/ibis_framework-11.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/57/80b986ebfecd9c6a177ddf1c2319717f0cd8feffb2b78946595a18a2fc88/orjson-3.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/96/c0/271f3e1e3502a8decb8ee5c680dbed2d8dc2cd504f5e20f7ed491d5f37e1/atpublic-7.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/44/bb9ff095ae7b1b6908480f683b6ca6b71c2105d343a5e5cb25334b01f5fa/s3fs-2024.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/6e/e8b80c04f50bcbde518298e371d8bc64afc3646b90dd5369b867e68a7166/python_calamine-0.3.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/05/4e3b902bc0ca407188aa5fe38af49be634487aec242a77287103242e11b2/pydocket-0.24.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ac/ba/77ef49baf338c03a11deadac984e3161b3f2b4fa4bb5aab160e7ca0fd522/google_resumable_media-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ad/68/316cbc54b7163fa22571dcf42c9cc46562aae0a021b974e0a8141e897200/mcp-1.12.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b0/aa/0b7365d30fed43e7a3449aba1fe20a0a7174d9cf13e282af4e69ac825441/humanize-4.16.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/58/3bf0b7d474607dc7fd67dd1365c4e0f392c8177eaf4054e5ddee3ebd53b5/aiobotocore-2.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/5c/20f573c6f800ad784603c7bd5787770ef648758289af2970d12c39072534/prefect_docker-0.7.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/bc/c1/a8a92ae1bc4b1a8f804c776d7d3f0c771b78a62c3ad4df1be41b3fd8c767/google_api_core-2.34.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c6/b2/454d6e7f0158951d8a78c2e1eb4f69ae81beb8dca5fee9809c6c99e9d0d0/fsspec-2024.10.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c8/52/1f2df7e7d1be3d65ddc2936d820d4a3d9777a54f4204f5ca46b8513eff77/typer-0.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cb/1b/349e07ad184d64e81109e85a3557d7e05631fa3d05344169114ba743c4d3/dateparser-1.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d3/e9/acfea54abdd66a059ff82995d3703eca3a27df3dc1bdc6afaf8a30a854fe/apprise-1.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/00/73204406228cf989bea6b0fd9fe4702fab49a8a152a0c6f90856dadb6ac7/grpcio_status-1.83.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/d7/45/05cc2ecbf61163bbbb18678dcdc7e7e7285f9f50f4dcf96a9ff07633ac52/wfdb-4.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/5b/4e7d67d880b3344afff01708725a39717694a79391a32711fd40a8958bed/pydicom-2.4.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dc/55/6467fde553886cb293e41538f3a8b4e4fd4688c6df242cf982162d8367fb/python_json_logger-4.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/32/95cfa1833316ca2b6b2e58150a4900bc1ad256043cdd36198f1887618ccc/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f3/bc/2a07cef49046e6cf5d1a8b1de553aaef8491b4170dbfe254c8687c764408/sqlglot-30.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/95/b8ba862968712caa12a19666175334fa979e1f198b896a430adb3bacfe87/py_key_value_aio-0.4.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f8/5c/e226de133afd8bb267ec27eead9ae3d784b95b39a287ed404caab39a5f50/genson-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/72/0bdb7a1f6e77df183ba631f63ee9e2765590bd26ac8196f606b21f44512c/fhiry-5.2.2-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -665,6 +1005,19 @@ packages:
   run_exports: {}
   size: 3661455
   timestamp: 1774197460085
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.46.1-default_hfdba357_102.conda
+  sha256: fb7bf36984a37ce7e4714d1d1da0bd0e3bfc679520f5cdc184afc676fd4b5da2
+  md5: a0c5e0b7f58c8ceeb08e5bc41251d5a2
+  depends:
+  - ld_impl_linux-64 2.46.1 default_hbd61a6d_102
+  - sysroot_linux-64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 3713752
+  timestamp: 1784214522814
 - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
   sha256: 78a58d523d072b7f8e591b8f8572822e044b31764ed7e8d170392e7bc6d58339
   md5: 2a307a17309d358c9b42afdd3199ddcc
@@ -676,6 +1029,17 @@ packages:
   run_exports: {}
   size: 36304
   timestamp: 1774197485247
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.46.1-default_h4852527_102.conda
+  sha256: 08d7238663fc408ba2ab60b02fa3d06a7ca9d872962e03e90c7e0fdecb7ed1d0
+  md5: 32fd07abe84eb14f17c7f5cc6fa8df82
+  depends:
+  - binutils_impl_linux-64 2.46.1 default_hfdba357_102
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 36337
+  timestamp: 1784214551894
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bwidget-1.10.1-ha770c72_1.conda
   sha256: c88dd33c89b33409ebcd558d78fdc66a63c18f8b06e04d170668ffb6c8ecfabd
   md5: 983b92277d78c0d0ec498e460caa0e6d
@@ -686,6 +1050,20 @@ packages:
   run_exports: {}
   size: 129594
   timestamp: 1750261567920
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - bzip2 >=1.0.8,<2.0a0
+  size: 257808
+  timestamp: 1785906269155
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -714,6 +1092,22 @@ packages:
     - c-ares >=1.34.6,<2.0a0
   size: 207882
   timestamp: 1765214722852
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
+  sha256: 5139b6afbfaca91c47104ba9a6a40f81211e1c9200e96b73ce3a56f0ca1902f4
+  md5: 2cef891b791040aab83e218c7d137679
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - c-ares-static <0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - c-ares >=1.34.8,<2.0a0
+  size: 226755
+  timestamp: 1786116641939
 - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
   sha256: 8e7a40f16400d7839c82581410aa05c1f8324a693c9d50079f8c50dc9fb241f0
   md5: abd85120de1187b0d1ec305c2173c71b
@@ -727,6 +1121,17 @@ packages:
   run_exports: {}
   size: 6693
   timestamp: 1753098721814
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-2.0.0-ha29393d_0.conda
+  sha256: a54488d2b00380f542a2e1aa00dee3d878803a8c2c025dfce852a23685584dc6
+  md5: b08763a8d93f2ba35bbf956dab90950b
+  depends:
+  - gcc 15.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 7017
+  timestamp: 1786642183250
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
   sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
   md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -774,6 +1179,23 @@ packages:
   run_exports: {}
   size: 302926
   timestamp: 1783424167115
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py312h703531f_2.conda
+  sha256: b649eacfd07be8fb889ef609601436dff831b2e9d095ef029601f3f10946c7d6
+  md5: 3101547f7c22db267bd40988f67d7ab1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=15
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  run_exports: {}
+  size: 302100
+  timestamp: 1786775110054
 - conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-1.11.0-ha770c72_0.conda
   sha256: 5709f2cbfeb8690317ba702611bdf711a502b417fecda6ad3313e501f6f8bd61
   md5: fdcf2e31dd960ef7c5daa9f2c95eff0e
@@ -787,6 +1209,19 @@ packages:
   run_exports: {}
   size: 7482
   timestamp: 1753098722454
+- conda: https://conda.anaconda.org/conda-forge/linux-64/compilers-2.0.0-ha770c72_0.conda
+  sha256: 441d087687e65823a6cf2b2b409b140003f26db406599a996988d06866bc2df0
+  md5: fc251585a901f26b9a3218c9193a1851
+  depends:
+  - c-compiler 2.0.0 ha29393d_0
+  - cxx-compiler 2.0.0 hdab9b82_0
+  - fortran-compiler 2.0.0 h0f4f740_0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6939
+  timestamp: 1786642183951
 - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_19.conda
   sha256: 769357d82d19f59c23888d935d92b67739bdb2acaacaa7bbe7c4fe4ee5346287
   md5: fd57230e9a97b97bf20dd63aeae6fe61
@@ -817,6 +1252,25 @@ packages:
   run_exports: {}
   size: 194776
   timestamp: 1782911792708
+- conda: https://conda.anaconda.org/conda-forge/linux-64/curl-8.21.0-heca4667_4.conda
+  sha256: 8f14ff477bf2cdf3cd4ff0ab2486b3e6490350da650e67be6c6a0b8a18994a90
+  md5: a91f709770cddb5e7a027ab000c441a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libcurl 8.21.0 heca4667_4
+  - libgcc >=14
+  - libpsl >=0.23.0,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 195067
+  timestamp: 1785500114646
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
   sha256: 3fcc97ae3e89c150401a50a4de58794ffc67b1ed0e1851468fcc376980201e25
   md5: 5da8c935dca9186673987f79cef0b2a5
@@ -830,6 +1284,17 @@ packages:
   run_exports: {}
   size: 6635
   timestamp: 1753098722177
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-2.0.0-hdab9b82_0.conda
+  sha256: 384ab445d260e0d69e701c32eb0ed870d348ec7e3efc78d944823855d4512ca1
+  md5: 923dacbfd97122c65c97a35f6e959ab8
+  depends:
+  - gxx 15.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6972
+  timestamp: 1786642183694
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
   sha256: 7684da83306bb69686c0506fb09aa7074e1a55ade50c3a879e4e5df6eebb1009
   md5: af491aae930edc096b58466c51c4126c
@@ -884,6 +1349,26 @@ packages:
     - fonts-conda-ecosystem
   size: 281880
   timestamp: 1780450077431
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+  sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
+  md5: 922776b528a470ab5afa81fd42abfa1d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=15
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - fontconfig >=2.18.3,<3.0a0
+    - fonts-conda-ecosystem
+  size: 296288
+  timestamp: 1786667377340
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.11.0-h9bea470_0.conda
   sha256: 53e5562ede83b478ebe9f4fc3d3b4eff5b627883f48aa0bf412e8fd90b5d6113
   md5: d5596f445a1273ddc5ea68864c01b69f
@@ -898,6 +1383,17 @@ packages:
   run_exports: {}
   size: 6656
   timestamp: 1753098722318
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-2.0.0-h0f4f740_0.conda
+  sha256: 7c1439c589983a6d76b5acaafe55437dd942ae21dc970e497ee0a3270fdd8a0d
+  md5: 7b2f4089fcf4cf6aa43ff932daee8c8b
+  depends:
+  - gfortran 15.*
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 6970
+  timestamp: 1786642183826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
   sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
   md5: 8462b5322567212beeb025f3519fb3e2
@@ -912,6 +1408,20 @@ packages:
     - libfreetype6 >=2.14.3
   size: 173839
   timestamp: 1774298173462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+  sha256: 612a8e0c1a6ecae23da54d81ef395f6ebb5c8e4468ec2611593ebce75876a4e0
+  md5: 2d0ea23b23603e07ca47f23f949f67b6
+  depends:
+  - libfreetype 2.14.3 ha770c72_2
+  - libfreetype6 2.14.3 h5e6c136_2
+  license: GPL-2.0-only OR FTL
+  purls: []
+  run_exports:
+    weak:
+    - libfreetype >=2.14.3
+    - libfreetype6 >=2.14.3
+  size: 175239
+  timestamp: 1786641011029
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
   sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
   md5: f9f81ea472684d75b9dd8d0b328cf655
@@ -925,6 +1435,19 @@ packages:
     - fribidi >=1.0.16,<2.0a0
   size: 61244
   timestamp: 1757438574066
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
+  sha256: 4846a3ca0402f3fe33ad84ed50ab213c6aafde4a0faef3c5002f6bf753e21671
+  md5: 1cd10eda5692519d01bb20e086e214c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - fribidi >=1.0.16,<2.0a0
+  size: 61782
+  timestamp: 1785912528684
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-14.3.0-h0dff253_19.conda
   sha256: e3f541c4be7296b800a972482b7a5e399614d5e3310d3d083257fbdb4df81ea0
   md5: 2dd149aa693db92758af3e685ef30439
@@ -937,6 +1460,19 @@ packages:
   run_exports: {}
   size: 29459
   timestamp: 1778268802660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-15.3.0-hb7a6aa6_1.conda
+  sha256: 53841a512c646051639c3158827b272f1ecae0f92943202dca02324868c6f073
+  md5: bf95291843cd18e597f145bda7bb2472
+  depends:
+  - gcc_impl_linux-64 15.3.0 h3a305e7_1
+  track_features:
+  - gcc_no_conda_specs
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 29261
+  timestamp: 1785375577887
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-h235f0fe_19.conda
   sha256: 1e2500ca976d4831c953d1c6db7b238d2e6806910b930e3eb631b79ba5c3ba41
   md5: 99936dc616b7ce97b0468759b8a7c64e
@@ -955,6 +1491,24 @@ packages:
   run_exports: {}
   size: 77667192
   timestamp: 1778268558509
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.3.0-h3a305e7_1.conda
+  sha256: 04f17e59047bed885b69672f40813bcecb975e46f0a9ed83f64db8c3cccb61a5
+  md5: 872d37b25207922f83f2326fdcbfcb91
+  depends:
+  - binutils_impl_linux-64 >=2.46.1
+  - libgcc >=15.3.0
+  - libgcc-devel_linux-64 15.3.0 h2b852eb_101
+  - libgomp >=15.3.0
+  - libsanitizer 15.3.0 h54950a5_1
+  - libstdcxx >=15.3.0
+  - libstdcxx-devel_linux-64 15.3.0 hb2c5482_101
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 84123073
+  timestamp: 1785375365155
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-14.3.0-h50e9bb6_27.conda
   sha256: d7f427d6db94a5eed2a43b186f8dc17cc1fbeb03517442390a36f1cde02548b0
   md5: 90369fa27fae2f7bf7eaaccc34c793e2
@@ -970,6 +1524,21 @@ packages:
     - libgcc >=14
   size: 29324
   timestamp: 1781279939286
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.3.0-h7df7c86_0.conda
+  sha256: 3c59a56e14a47f857ed4b81ee3eb98d5fc8291314888857360c3719726bfe25d
+  md5: 0e39df41cedb6e85d6be6d0b26267c42
+  depends:
+  - gcc_impl_linux-64 15.3.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    strong:
+    - libgcc >=15
+  size: 29727
+  timestamp: 1785386591839
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-14.3.0-he448592_7.conda
   sha256: 7ab008dd3dc5e6ca0de2614771019a1d35480d51df6216c96b1cf6a5e660ee40
   md5: 94394acdc56dcb4d55dddf0393134966
@@ -983,6 +1552,19 @@ packages:
   run_exports: {}
   size: 30407
   timestamp: 1759966108779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran-15.3.0-hd47ba16_1.conda
+  sha256: c248fe930440ef81fb952981dbea180baa369178f823c6cb60a3416a2e294448
+  md5: f12891a1fa1b7630d0bbe1feaafd9407
+  depends:
+  - gcc 15.3.0 hb7a6aa6_1
+  - gcc_impl_linux-64 15.3.0 h3a305e7_1
+  - gfortran_impl_linux-64 15.3.0 h27ced10_1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 28612
+  timestamp: 1785375649962
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-14.3.0-h1a219da_19.conda
   sha256: aee591aab674d70829ecc1abaa7f2ad5fcccbfad7bafa5ebca1225c86c60f18f
   md5: d5f5c8cc2a64220838a096041b7a7fb4
@@ -998,6 +1580,21 @@ packages:
   run_exports: {}
   size: 18551249
   timestamp: 1778268735401
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-15.3.0-h27ced10_1.conda
+  sha256: 70bf68d657f9b51669e3e6bc968d2d47ef44072b65f699beee2a74a0569b291b
+  md5: a6f5833f3485dc10d1f53342ec7d4e59
+  depends:
+  - gcc_impl_linux-64 >=15.3.0
+  - libgcc >=15.3.0
+  - libgfortran5 >=15.3.0
+  - libstdcxx >=15.3.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 20669185
+  timestamp: 1785375499183
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-14.3.0-h5ce6d8a_27.conda
   sha256: b8e6bd99f0b7a5e8757a1cf9bf64edc6217206d8872fb9af5d8204e5b581b3d1
   md5: cedd6fb9fad7611ee0bcb0fb531d77f1
@@ -1016,6 +1613,20 @@ packages:
     - libgcc >=14
   size: 27545
   timestamp: 1781279939286
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+  sha256: 3611c5d605cd56017704e6c01c7bd849e74a656a546d4c49d655fde49ddfeecc
+  md5: bd7c3a8586ed0101f094962100d30a63
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - giflib >=5.2.2,<5.3.0a0
+  size: 77403
+  timestamp: 1784694210187
 - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
   sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
   md5: 3bf7b9fd5a7136126e0234db4b87c8b6
@@ -1029,6 +1640,21 @@ packages:
     - giflib >=5.2.2,<5.3.0a0
   size: 77248
   timestamp: 1712692454246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+  sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
+  md5: f9fe2984587fa8235a6af6004760cd18
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  run_exports:
+    weak:
+    - graphite2 >=1.3.15,<2.0a0
+  size: 102835
+  timestamp: 1786118485753
 - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
   sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
   md5: cf09e9fc938518e91d0706572cadf17a
@@ -1071,6 +1697,18 @@ packages:
   run_exports: {}
   size: 30403
   timestamp: 1759966121169
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-15.3.0-hd47ba16_1.conda
+  sha256: fde700338d9e2fb46aeec11aeef35dff2027b47a4a2793d0b912461355e08bc8
+  md5: f720007e2b5b31ea04436bb475fe9d67
+  depends:
+  - gcc 15.3.0 hb7a6aa6_1
+  - gxx_impl_linux-64 15.3.0 h90d9265_1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports: {}
+  size: 28607
+  timestamp: 1785375661027
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_19.conda
   sha256: a31694c26d6a525d44f81130ebf7b9abe18771b7eaecb2cf93630c0b8b8fb936
   md5: 8b867d053ed89743eeac52c3a50f112d
@@ -1085,6 +1723,20 @@ packages:
   run_exports: {}
   size: 15235650
   timestamp: 1778268773535
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-15.3.0-h90d9265_1.conda
+  sha256: 1789d2d9a59c202687dfd9c5a7041e89dd900584a7e0d7e79295a18c72d8be08
+  md5: 66e9c612135813008f3dce2c7c90cf1f
+  depends:
+  - gcc_impl_linux-64 15.3.0 h3a305e7_1
+  - libstdcxx-devel_linux-64 15.3.0 hb2c5482_101
+  - sysroot_linux-64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 17023496
+  timestamp: 1785375535165
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-14.3.0-hd240bd5_27.conda
   sha256: cf5a44d14732b79e3c2bc6ebe1dba4f6b9077939f3093c75e36ad340737b5c15
   md5: 41fae38a424bbc78438cfec6a4fde187
@@ -1102,6 +1754,23 @@ packages:
     - libgcc >=14
   size: 27854
   timestamp: 1781279939286
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-15.3.0-h6bd041b_0.conda
+  sha256: de0acb64b31514d79014c911c98984be6e133bafbc8e55a3acbfc95f41b56f90
+  md5: 71acea0bb38413c9813a9ddaba443503
+  depends:
+  - gxx_impl_linux-64 15.3.0.*
+  - gcc_linux-64 ==15.3.0 h7df7c86_0
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    strong:
+    - libstdcxx >=15
+    - libgcc >=15
+  size: 28104
+  timestamp: 1785386591839
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
   sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
   md5: 72e956a71241633d8c80aa198fd08784
@@ -1115,6 +1784,19 @@ packages:
     - libharfbuzz >=14.2.1
   size: 11039
   timestamp: 1782800611635
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.3.0-ha770c72_0.conda
+  sha256: 511813aaad42ed2494efc77452738fed7734985e069efc08c279a701b1708ba0
+  md5: 7f42f814e1306f83e4cac267baa9acab
+  depends:
+  - libharfbuzz-devel 14.3.0 h17a8019_0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libharfbuzz >=14.3.0
+  size: 11045
+  timestamp: 1785770087614
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   md5: c80d8a3b84358cb967fa81e7075fbc8a
@@ -1130,6 +1812,34 @@ packages:
     - icu >=78.3,<79.0a0
   size: 12723451
   timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  md5: 72a381cbad04f24b1c2a43ef707f45b4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - icu >=78.3,<79.0a0
+  size: 14459115
+  timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+  md5: ba55d1b89fd7775e67de8291029b4059
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - keyutils >=1.6.3,<2.0a0
+  size: 135295
+  timestamp: 1786739238128
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -1143,6 +1853,25 @@ packages:
     - keyutils >=1.6.3,<2.0a0
   size: 134088
   timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+  sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+  md5: 53318d715316929a574f83591308b1f8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=15
+  - libstdcxx >=15
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - krb5 >=1.22.2,<1.23.0a0
+  size: 1394333
+  timestamp: 1786762112514
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
   sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
   md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
@@ -1192,6 +1921,20 @@ packages:
   run_exports: {}
   size: 728002
   timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 745303
+  timestamp: 1784214507189
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275
@@ -1207,6 +1950,21 @@ packages:
     - lerc >=4.1.0,<5.0a0
   size: 261513
   timestamp: 1773113328888
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+  sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
+  md5: fb9d356b1a57d6d54768be7ebd5fce09
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - lerc >=4.2.0,<5.0a0
+  size: 271158
+  timestamp: 1785036167977
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h7b12aa8_1.conda
   sha256: 32933de2d4fa6e6ffd949052815b49cb65a0649ad70007155c533ab97ea8cefd
   md5: c4393db381bffa0a83a8d9e47b238106
@@ -1249,6 +2007,29 @@ packages:
     - libarchive >=3.8.8,<3.9.0a0
   size: 867280
   timestamp: 1782289011634
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.9-gpl_hc2c16d8_100.conda
+  sha256: 000b4baa9ce849b5fb259af9256331d0c7872361ac63a2bba0d0c48eb35663d0
+  md5: 3988040b14a8083b1a5382d99f584e5f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libarchive >=3.8.9,<3.9.0a0
+  size: 876197
+  timestamp: 1785250447640
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
   build_number: 8
   sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
@@ -1270,6 +2051,41 @@ packages:
     - libblas >=3.11.0,<4.0a0
   size: 18804
   timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h4a7cf45_openblas.conda
+  build_number: 9
+  sha256: 39c7b3c5427b435c9c059ede9da61d46d42574e5b846ad37fdc3af4a5eab1e48
+  md5: f5c4b041925dea221dc4bad2e50569d9
+  depends:
+  - libopenblas >=0.3.34,<0.3.35.0a0
+  - libopenblas >=0.3.34,<1.0a0
+  constrains:
+  - blas 2.309   openblas
+  - libcblas   3.11.0   9*_openblas
+  - liblapack  3.11.0   9*_openblas
+  - liblapacke 3.11.0   9*_openblas
+  - mkl <2027
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libblas >=3.11.0,<4.0a0
+  size: 18033
+  timestamp: 1786059035239
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
+  sha256: e5864f257f839ffc27d681659bac95901f524f602b9121e5dcc5e2df18437f2d
+  md5: 7a2499a177753582fb7ae7e9dc4a908a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libbrotlicommon >=1.2.0,<1.3.0a0
+  size: 80265
+  timestamp: 1786622773969
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
   sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
   md5: 72c8fd1af66bd67bf580645b426513ed
@@ -1284,6 +2100,21 @@ packages:
     - libbrotlicommon >=1.2.0,<1.3.0a0
   size: 79965
   timestamp: 1764017188531
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
+  sha256: dad31b6d104973deb89710929a35651033aad692d4e7793cdb5b786a9bd54678
+  md5: 6ab3315dc56618d652c1da42a648a129
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 h39a168f_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libbrotlidec >=1.2.0,<1.3.0a0
+  size: 34828
+  timestamp: 1786622783405
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
   sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
   md5: 366b40a69f0ad6072561c1d09301c886
@@ -1299,6 +2130,21 @@ packages:
     - libbrotlidec >=1.2.0,<1.3.0a0
   size: 34632
   timestamp: 1764017199083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
+  sha256: d37124d0f51816e7d5e3a94bfc9ed3d6174d077f9b4f832d20c5a08b52bebf1f
+  md5: 2ac965638d4c6b2b38383bb1aebaf543
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 h39a168f_3
+  - libgcc >=15
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libbrotlienc >=1.2.0,<1.3.0a0
+  size: 298639
+  timestamp: 1786622792145
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
   sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
   md5: 4ffbb341c8b616aa2494b6afb26a0c5f
@@ -1332,6 +2178,24 @@ packages:
     - libcblas >=3.11.0,<4.0a0
   size: 18778
   timestamp: 1779859107964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_h0358290_openblas.conda
+  build_number: 9
+  sha256: 4c532a70ea9aeff2fa1aabaa4828ebc00c2ed12b22aa8ba19da5302b882fc82b
+  md5: 092c5649f3727af436ab0f67f48c3811
+  depends:
+  - libblas 3.11.0 9_h4a7cf45_openblas
+  constrains:
+  - blas 2.309   openblas
+  - liblapack  3.11.0   9*_openblas
+  - liblapacke 3.11.0   9*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libcblas >=3.11.0,<4.0a0
+  size: 17998
+  timestamp: 1786059041397
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
   sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
   md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
@@ -1370,6 +2234,27 @@ packages:
     - libcurl >=8.21.0,<9.0a0
   size: 480327
   timestamp: 1782911787190
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
+  sha256: aff8ef75636d0825ce34911e0bef2f26816e7afd090a9dcb4b9bacab75cbf584
+  md5: 3f2fd5617cfacac49c85f6dc63842ea1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libpsl >=0.23.0,<0.24.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libcurl >=8.21.0,<9.0a0
+  size: 480565
+  timestamp: 1785500108494
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
   sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
   md5: 6c77a605a7a689d17d4819c0f8ac9a00
@@ -1384,6 +2269,36 @@ packages:
     - libdeflate >=1.25,<1.26.0a0
   size: 73490
   timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+  sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+  md5: 40f9b31aa9cf007789867df0decd0492
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libdeflate >=1.25,<1.26.0a0
+  size: 73710
+  timestamp: 1785908694612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+  sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+  md5: 50708d3b951d0f8e2d7f2df5b5edc040
+  depends:
+  - ncurses
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - ncurses >=6.6,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libedit >=3.1.20250104,<3.2.0a0
+  size: 135098
+  timestamp: 1786616658086
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -1400,6 +2315,20 @@ packages:
     - libedit >=3.1.20250104,<3.2.0a0
   size: 134676
   timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  md5: 7bc31538d6e3fb349e897353969237ec
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-2-Clause OR GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libev >=4.33,<4.34.0a0
+  size: 43220
+  timestamp: 1785917328200
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
@@ -1441,6 +2370,20 @@ packages:
     - libffi >=3.5.2,<3.6.0a0
   size: 58592
   timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
+  sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
+  md5: 0abe40a9880086ca4d2e5daf09dceff9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libffi >=3.7.0,<3.8.0a0
+  size: 67576
+  timestamp: 1783520858222
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
   sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
   md5: e289f3d17880e44b633ba911d57a321b
@@ -1451,6 +2394,31 @@ packages:
   run_exports: {}
   size: 8049
   timestamp: 1774298163029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+  sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
+  md5: f8054e759d0ddddaf34a5c8fedc900a1
+  depends:
+  - libfreetype6 >=2.14.3
+  license: GPL-2.0-only OR FTL
+  purls: []
+  run_exports: {}
+  size: 8407
+  timestamp: 1786641007099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+  sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
+  md5: b72a266a9317036fd0464cb98b027cd0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - freetype >=2.14.3
+  license: GPL-2.0-only OR FTL
+  purls: []
+  run_exports: {}
+  size: 387671
+  timestamp: 1786641006460
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
   sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
   md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
@@ -1481,6 +2449,21 @@ packages:
   run_exports: {}
   size: 1041084
   timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 1057877
+  timestamp: 1785375436766
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
   sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
   md5: 331ee9b72b9dff570d56b1302c5ab37d
@@ -1494,6 +2477,19 @@ packages:
     - libgcc
   size: 27694
   timestamp: 1778269016987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.1.0-h69a702a_1.conda
+  sha256: 225275c562337a1cd61705da0ee4235dde7bba7504de1c34b74c894adb2b0eee
+  md5: 7ed870c014a6f23c7dfafda53d2763a9
+  depends:
+  - libgcc 16.1.0 ha9f2e26_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - libgcc
+  size: 28210
+  timestamp: 1785375440733
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
   sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
   md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
@@ -1507,6 +2503,19 @@ packages:
   run_exports: {}
   size: 27655
   timestamp: 1778269042954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+  sha256: 9e82d410a50bd4e5e47cbbb026454c3eb543954baca4db23929575b571bf56a3
+  md5: 2fbed65cc90cf0724e1ec4de13696737
+  depends:
+  - libgfortran5 16.1.0 h79bb938_1
+  constrains:
+  - libgfortran-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 28134
+  timestamp: 1785375470055
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
   sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
   md5: 85072b0ad177c966294f129b7c04a2d5
@@ -1521,6 +2530,20 @@ packages:
   run_exports: {}
   size: 2483673
   timestamp: 1778269025089
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+  sha256: 05078ab464d506dff971860cb1a553b35bc27c0b5ce8ec29b8bfaca5f2359652
+  md5: dd51ed33e8c70995f8e33cc9dc537297
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=16.1.0
+  constrains:
+  - libgfortran 16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 2538696
+  timestamp: 1785375448623
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.9.4-hc20babb_0.conda
   sha256: 2fa319bd152dcd03d8ea21d289a34aaa14ce3781173964cc9e52bdecc43e311d
   md5: 4ce3d27b6752f4a4c92325232b11bbe0
@@ -1540,6 +2563,25 @@ packages:
     - libgit2 >=1.9.4,<1.10.0a0
   size: 1038373
   timestamp: 1779458895042
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgit2-1.9.6-hc20babb_0.conda
+  sha256: 193027f5dde1698ad63cc6ac636e93f6a307a6b460ad641c43b5b38216ec1605
+  md5: f3c88febd64c2c03cdda0e4fd1527f0e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  license: GPL-2.0-only WITH GCC-exception-2.0
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libgit2 >=1.9.6,<1.10.0a0
+  size: 1046396
+  timestamp: 1784388654589
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.2-h0d30a3d_0.conda
   sha256: 4bee10e62796f01e4fa2b5849135b1cc061337fe9cf5eb9bd79e9664922ae0e4
   md5: 889febc66cd9e4190f80ef9718fa239b
@@ -1559,6 +2601,25 @@ packages:
     - libglib >=2.88.2,<3.0a0
   size: 4754220
   timestamp: 1782463895250
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
+  sha256: 4499458124bcf0bd45e8bd17576f9f007cb1373cb3b01659105443f522bab45c
+  md5: 533cb021c1bfeba9f720e669cd863fdf
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  constrains:
+  - glib >2.66
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - libglib >=2.88.3,<3.0a0
+  size: 4755172
+  timestamp: 1786457663614
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
   sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
   md5: faac990cb7aedc7f3a2224f2c9b0c26c
@@ -1572,6 +2633,19 @@ packages:
     - _openmp_mutex >=4.5
   size: 603817
   timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 640415
+  timestamp: 1785375373755
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
   sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
   md5: fb4669c3990b94ea32fbb81f433e9aa6
@@ -1593,6 +2667,27 @@ packages:
   run_exports: {}
   size: 1297668
   timestamp: 1782800580119
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.0-h17a8019_0.conda
+  sha256: fb72d6f7e90d4927cb53a4e13592559ce74b65052323d5d6dd12499b026c680e
+  md5: f33637ebded146eafa6b2197c8f597a6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.3,<3.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 1333436
+  timestamp: 1785770053613
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
   sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
   md5: 99cf21100441e51272f1cd6fe0632a20
@@ -1618,6 +2713,31 @@ packages:
     - libharfbuzz >=14.2.1
   size: 1970690
   timestamp: 1782800603897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.3.0-h17a8019_0.conda
+  sha256: 7ce9326c2520ae758f523ae2d72a0762f7494d77fe8cc9a96065df541e1db8e2
+  md5: 15634b3c7e5a68ca7c6e0bbf84cb2383
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - freetype
+  - graphite2 >=1.3.15,<2.0a0
+  - icu >=78.3,<79.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.3,<3.0a0
+  - libharfbuzz 14.3.0 h17a8019_0
+  - libpng >=1.6.58,<1.7.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libharfbuzz >=14.3.0
+  size: 2081226
+  timestamp: 1785770079548
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -1646,6 +2766,21 @@ packages:
     - libjpeg-turbo >=3.2.0,<4.0a0
   size: 652868
   timestamp: 1783731886811
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+  sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
+  md5: 898d1c9793eaa52efc4727bd84d2e39a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  run_exports:
+    weak:
+    - libjpeg-turbo >=3.2.0,<4.0a0
+  size: 650434
+  timestamp: 1785896381946
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
   build_number: 8
   sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
@@ -1664,6 +2799,24 @@ packages:
     - liblapack >=3.11.0,<3.12.0a0
   size: 18790
   timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h47877c9_openblas.conda
+  build_number: 9
+  sha256: ea989e2dabd21d296a5a4ec515e695645aefcdf778ffdb5eeea515421d243ab5
+  md5: e51473c2b7e1f9cb61daafccfd912abf
+  depends:
+  - libblas 3.11.0 9_h4a7cf45_openblas
+  constrains:
+  - blas 2.309   openblas
+  - libcblas   3.11.0   9*_openblas
+  - liblapacke 3.11.0   9*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblapack >=3.11.0,<3.12.0a0
+  size: 18021
+  timestamp: 1786059046733
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
   sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
   md5: b88d90cad08e6bc8ad540cb310a761fb
@@ -1679,6 +2832,21 @@ packages:
     - liblzma >=5.8.3,<6.0a0
   size: 113478
   timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 112995
+  timestamp: 1786348617826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.3-hb03c661_0.conda
   sha256: 7858f6a173206bc8a5bdc8e75690483bb66c0dcc3809ac1cb43c561a4723623a
   md5: 55c20edec8e90c4703787acaade60808
@@ -1693,6 +2861,20 @@ packages:
     - liblzma >=5.8.3,<6.0a0
   size: 491429
   timestamp: 1775825511214
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-devel-5.8.3-hb03c661_1.conda
+  sha256: adef6e8b60afb684110b06b5310977c6836e1c923ce3ec199f45c0f000b42f20
+  md5: 6d83d6a332c19424e9e66b69b180ec11
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - liblzma 5.8.3 hb03c661_1
+  license: 0BSD
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 491970
+  timestamp: 1786348627135
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
   sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
   md5: 2a45e7f8af083626f009645a6481f12d
@@ -1758,6 +2940,24 @@ packages:
     - libopenblas >=0.3.33,<1.0a0
   size: 5931919
   timestamp: 1776993658641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.34-pthreads_h94d23a6_0.conda
+  sha256: 23392fc4f4e5ba230fcd1ef825878ba5ca7ee4f6259fac0cbb13299134b7bf7a
+  md5: c282d68f272927612462b5d626838ef1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.34,<0.3.35.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libopenblas >=0.3.34,<1.0a0
+  size: 5952629
+  timestamp: 1784287497473
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
   sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
   md5: eba48a68a1a2b9d3c0d9511548db85db
@@ -1772,6 +2972,20 @@ packages:
     - libpng >=1.6.58,<1.7.0a0
   size: 317729
   timestamp: 1776315175087
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+  sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
+  md5: fcf71c8d979148873f6f8ad4cfc73d86
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15
+  - libzlib >=1.3.2,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  run_exports:
+    weak:
+    - libpng >=1.6.58,<1.7.0a0
+  size: 316643
+  timestamp: 1786616563127
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_1.conda
   sha256: f7232cb79a31f5a5bcd499aea930b469cde8b96d26db9541022493fd274d2a6e
   md5: 6c9103e7ea739a3bb3505da49a4708c1
@@ -1789,6 +3003,23 @@ packages:
     - libpq >=18.4,<19.0a0
   size: 2709008
   timestamp: 1782580447454
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+  sha256: b1eb210c180fda9c445b11cba1286ec250ce2c2a85ccb0551a4ed5423df51e68
+  md5: 72e019c04ed02a179da38c56965802d1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=15
+  - openldap >=2.6.13,<2.7.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: PostgreSQL
+  purls: []
+  run_exports:
+    weak:
+    - libpq >=18.6,<19.0a0
+  size: 2719680
+  timestamp: 1786641133110
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hd9031aa_0.conda
   sha256: cd11890a2c1f14d0342bfcbd81f97152d61dc71c27c7085efc13705a8f64f7c9
   md5: e2834a423b3967e7b3b1e901c4a5f42f
@@ -1805,6 +3036,22 @@ packages:
     - libpsl >=0.22.0,<0.23.0a0
   size: 83067
   timestamp: 1782394772411
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hf670292_0.conda
+  sha256: 2e6405feb59e3f40a5a4641dfa73afda158046893aa73d478e23415e18997ece
+  md5: c8217f5bdd5b018087bdea081912cda5
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libpsl >=0.23.1,<0.24.0a0
+  size: 72505
+  timestamp: 1786443494718
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_19.conda
   sha256: 8766de5423b0a510e2b1bdd1963d0554bdad2119f3e31d8fbd4189af434235ca
   md5: 007796e5a595bbc7df4a5e1580d72e1a
@@ -1820,6 +3067,21 @@ packages:
     - libsanitizer 14.3.0
   size: 7947790
   timestamp: 1778268494844
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.3.0-h54950a5_1.conda
+  sha256: 96fed6bd79c799abd264910977ee8a21b37183a1faa9b355b79c89f6d24f0385
+  md5: 2d686149517c144a4e9166a50afa2425
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.3.0
+  - libstdcxx >=15.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports:
+    weak:
+    - libsanitizer 15.3.0
+  size: 8135626
+  timestamp: 1785375318911
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
   sha256: b677bbf1c339d894757c3dcfbb2f88649e499e4991d70ae09a1466da9a6c92d6
   md5: 965e4d531b588b2e42f66fd8e48b056c
@@ -1847,6 +3109,37 @@ packages:
     - libsqlite >=3.53.3,<4.0a0
   size: 962119
   timestamp: 1782519076616
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+  sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
+  md5: df088a279cd5e6fd2790b4c196434da1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  purls: []
+  run_exports:
+    weak:
+    - libsqlite >=3.53.4,<4.0a0
+  size: 964200
+  timestamp: 1785016112246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+  sha256: 7e463000fa1cba3f3a6597b776f6ab301d425a96e3bc20d0d9d76a3b9f237aa3
+  md5: 5c526561e1d2a2e071941174eae84557
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libssh2 >=1.11.1,<2.0a0
+  size: 306045
+  timestamp: 1786713107897
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -1877,6 +3170,20 @@ packages:
   run_exports: {}
   size: 5852044
   timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_1
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 6631744
+  timestamp: 1785375462643
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
   sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
   md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
@@ -1926,6 +3233,20 @@ packages:
     - libuv >=1.52.1,<2.0a0
   size: 419935
   timestamp: 1779396012261
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  md5: 01c4ed87826af55996768af6dbc936b4
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 420040
+  timestamp: 1785914567661
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
   sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   md5: aea31d2e5b1091feca96fcfe945c3cf9
@@ -1942,6 +3263,22 @@ packages:
     - libwebp-base >=1.6.0,<2.0a0
   size: 429011
   timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+  sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
+  md5: 9332b53d0ea93c5d39e33be03a0c611a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - libwebp-base >=1.6.0,<2.0a0
+  size: 428430
+  timestamp: 1785954557217
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
   sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
   md5: 92ed62436b625154323d40d5f2f11dd7
@@ -1971,6 +3308,19 @@ packages:
     - libxcrypt >=4.4.36
   size: 100393
   timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+  sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
+  md5: f7a7ff5a6ab331e037abd34f379a631d
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - libxcrypt >=4.4.38
+  size: 101957
+  timestamp: 1785887123445
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
   sha256: 3d44f737c5ae52d5af32682cc1530df433f401f8e58a7533926536244127572a
   md5: e79d2c2f24b027aa8d5ab1b1ba3061e7
@@ -2045,6 +3395,21 @@ packages:
     - libzlib >=1.3.2,<2.0a0
   size: 63629
   timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 63713
+  timestamp: 1785362952714
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
   sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
   md5: 9de5350a85c4a20c685259b889aa6393
@@ -2060,6 +3425,21 @@ packages:
     - lz4-c >=1.10.0,<1.11.0a0
   size: 167055
   timestamp: 1733741040117
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
+  sha256: b8c0e930183e6b7f83cd35ace102f2b8c2f0faae41dc05255dc72f247dfc556a
+  md5: e38a3253d72ab07d471483f24947e2a2
+  depends:
+  - libgcc >=15
+  - libstdcxx >=15
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - lz4-c >=1.10.0,<1.11.0a0
+  size: 181812
+  timestamp: 1786717122815
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
   sha256: 5c6bbeec116e29f08e3dad3d0524e9bc5527098e12fc432c0e5ca53ea16337d4
   md5: 45161d96307e3a447cc3eb5896cf6f8c
@@ -2074,6 +3454,18 @@ packages:
     - lzo >=2.10,<3.0a0
   size: 191060
   timestamp: 1753889274283
+- conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb03c661_3.conda
+  sha256: 4c65d2769847778a6d84db6984ac81bcec6f8958d349f1fe57ae040ccc56a801
+  md5: b4a198dc40024de2a59c1343e4ae4144
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: GPL-3.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 510695
+  timestamp: 1785879853297
 - conda: https://conda.anaconda.org/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
   sha256: d652c7bd4d3b6f82b0f6d063b0d8df6f54cc47531092d7ff008e780f3261bdda
   md5: 33405d2a66b1411db9f7242c8b97c9e7
@@ -2116,6 +3508,19 @@ packages:
     - ncurses >=6.6,<7.0a0
   size: 918956
   timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  md5: ee6c0cd80a60961a1f48aa3e0b91f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  purls: []
+  run_exports:
+    weak:
+    - ncurses >=6.6,<7.0a0
+  size: 911196
+  timestamp: 1786355078102
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-26.5.0-hc039f44_0.conda
   sha256: 46a11c60f21d5d483d4f8a44ec51da747cc83d14378f55478405b5a0a935d5f7
   md5: aac35b885d19bb6ec2e411611017fc45
@@ -2144,6 +3549,34 @@ packages:
     - nodejs >=26.5.0,<27.0a0
   size: 19951948
   timestamp: 1783543358983
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-26.6.0-hc039f44_0.conda
+  sha256: 049788cee5e10fe13846f806d8ae854642414aeb06018ad268ce9959b529be77
+  md5: c99a655b4c729eef64e63140962b8cc9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libuv >=1.52.1,<2.0a0
+  - libabseil >=20260526.0,<20260527.0a0
+  - libabseil * cxx17*
+  - zstd >=1.5.7,<1.6.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - icu >=78.3,<79.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - c-ares >=1.34.8,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - nodejs >=26.6.0,<27.0a0
+  size: 20013853
+  timestamp: 1785852655297
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-17.0.18-ha668962_0.conda
   sha256: 0462c2a4ada21b2428410d8a27cb125b0bbeb29cccc07e69f66ba41587f88ee9
   md5: 98c0955fbe4b6bcb67a43817e57552bc
@@ -2214,6 +3647,21 @@ packages:
     - openssl >=3.6.3,<4.0a0
   size: 3159683
   timestamp: 1781069855778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+  md5: c5955c27917ff2234def47f075e71e02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  run_exports:
+    weak:
+    - openssl >=3.6.3,<4.0a0
+  size: 3182423
+  timestamp: 1785913583650
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
   sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
   md5: d53ffc0edc8eabf4253508008493c5bc
@@ -2238,6 +3686,30 @@ packages:
     - pango >=1.56.4,<2.0a0
   size: 458036
   timestamp: 1774281947855
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
+  sha256: 48f27a6c3e4062bc09dafe9c7f6b288c5de5655e81095ab7f1aad920b2163b7b
+  md5: 6a2822aaf9a34ac3708904a47ff3dd7e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.18.2,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.16,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libglib >=2.88.3,<3.0a0
+  - libharfbuzz >=14.3.0
+  - libpng >=1.6.58,<1.7.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: LGPL-2.1-or-later
+  purls: []
+  run_exports:
+    weak:
+    - pango >=1.58.2,<2.0a0
+  size: 469916
+  timestamp: 1786107384537
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
   sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
   md5: 7a3bff861a6583f1889021facefc08b1
@@ -2270,6 +3742,21 @@ packages:
     - pixman >=0.46.4,<1.0a0
   size: 450960
   timestamp: 1754665235234
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+  sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
+  md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - pixman >=0.46.4,<1.0a0
+  size: 376704
+  timestamp: 1786106621354
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
   sha256: c9601efb1af5391317e04eca77c6fe4d716bf1ca1ad8da2a05d15cb7c28d7d4e
   md5: 1bee70681f504ea424fb07cdb090c001
@@ -2282,6 +3769,30 @@ packages:
   run_exports: {}
   size: 115175
   timestamp: 1720805894943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h7c397b8_1011.conda
+  sha256: ff8d0023722ef5600850074a9bbf418be4d2ec78edbf4d5db45d9f0331f248e4
+  md5: 435898aaa55d40aa4c016214d9e9ed98
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 141002
+  timestamp: 1786352333107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
+  sha256: afc3b27b2cbb0487c1d0e963f96e71181ecfb623a24fb393bb19ff974a6382a1
+  md5: df2c27f36bdb0dde779f55b5df76a352
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports: {}
+  size: 9115
+  timestamp: 1786067714761
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -2294,6 +3805,39 @@ packages:
   run_exports: {}
   size: 8252
   timestamp: 1726802366959
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-h8ab3286_1_cpython.conda
+  build_number: 1
+  sha256: df3d1e5f972e79e78b61730c09135c795f6e7aa45b7777835c95f451e85eff0d
+  md5: c6e02a78e3b6427c633328fea9399534
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.7.0,<3.8.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libxcrypt >=4.4.38
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  run_exports:
+    weak:
+    - python_abi 3.12.* *_cp312
+    noarch:
+    - python
+  size: 31527849
+  timestamp: 1786445051525
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
   sha256: a44655c1c3e1d43ed8704890a91e12afd68130414ea2c0872e154e5633a13d7e
   md5: 7eccb41177e15cc672e1babe9056018e
@@ -2449,6 +3993,23 @@ packages:
     - tk >=8.6.13,<8.7.0a0
   size: 3301196
   timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  purls: []
+  run_exports:
+    weak:
+    - tk >=8.6.13,<8.7.0a0
+  size: 3550916
+  timestamp: 1784229071544
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tktable-2.10-h5a7a40f_8.conda
   sha256: 3e20b2f2902a1f402ef2420ce2b9e8c91f9e02748d55530894ac1f640561fdd0
   md5: 72628f56d7a99b86efa435a0b97a4b47
@@ -2463,6 +4024,20 @@ packages:
   run_exports: {}
   size: 102544
   timestamp: 1773732786017
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+  sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
+  md5: 85c9442aec283b4e464fa9ecc484a2f3
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libice >=1.1.2,<2.0a0
+  size: 62517
+  timestamp: 1786474410404
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45
@@ -2477,6 +4052,22 @@ packages:
     - xorg-libice >=1.1.2,<2.0a0
   size: 58628
   timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+  sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
+  md5: aa7459ed9ad086ba11dda843d764b33d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libice >=1.1.2,<2.0a0
+  - libuuid >=2.42.2,<3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libsm >=1.2.6,<2.0a0
+  size: 30739
+  timestamp: 1786545374265
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
   sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
   md5: 1c74ff8c35dcadf952a16f752ca5aa49
@@ -2522,6 +4113,20 @@ packages:
     - xorg-libxau >=1.0.12,<2.0a0
   size: 15321
   timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+  sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
+  md5: f06ef439c280a5f90b8bf62355008dbc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libxau >=1.0.12,<2.0a0
+  size: 16419
+  timestamp: 1786381001122
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
   sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
   md5: 1dafce8548e38671bea82e3f5c6ce22f
@@ -2536,6 +4141,20 @@ packages:
     - xorg-libxdmcp >=1.1.5,<2.0a0
   size: 20591
   timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+  sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
+  md5: 2e66c929f3d879708335b6ea4557c838
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  run_exports:
+    weak:
+    - xorg-libxdmcp >=1.1.5,<2.0a0
+  size: 21120
+  timestamp: 1786381006369
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
   sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
   md5: 34e54f03dfea3e7a2dcf1453a85f1085
@@ -2666,6 +4285,23 @@ packages:
     - liblzma >=5.8.3,<6.0a0
   size: 24360
   timestamp: 1775825568523
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.8.3-ha02ee65_1.conda
+  sha256: 547b2392d8f7b76efd4a0970946f6da2a1136ad5fe3dc936af81e02eb7181076
+  md5: 36a079606b3aaf9d726211825f182452
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - liblzma 5.8.3 hb03c661_1
+  - liblzma-devel 5.8.3 hb03c661_1
+  - xz-gpl-tools 5.8.3 ha02ee65_1
+  - xz-tools 5.8.3 hb03c661_1
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 23610
+  timestamp: 1786348658246
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.3-ha02ee65_0.conda
   sha256: 8f139666ea18dc8340a44a54056627dd4e89e242e8cd136ab2467d6dc2c192ba
   md5: 8f5e2c6726c1339287a3c76a2c138ac7
@@ -2682,6 +4318,22 @@ packages:
     - liblzma >=5.8.3,<6.0a0
   size: 34213
   timestamp: 1775825548743
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.3-ha02ee65_1.conda
+  sha256: ed6dbec5e4f0f71e7ac629b90dc4c9fba38d194cc88eab891c29e461b408977a
+  md5: 137db930adb0b3c5407485e0e1a50cfa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - liblzma 5.8.3 hb03c661_1
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD AND LGPL-2.1-or-later AND GPL-2.0-or-later
+  purls: []
+  run_exports:
+    weak:
+    - liblzma >=5.8.3,<6.0a0
+  size: 40118
+  timestamp: 1786348648882
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.3-hb03c661_0.conda
   sha256: 162ebd76803464b8c8ebc7d45df32edf0ec717b3bf369a437ae3b0254f22dc2e
   md5: b62b615caa60812640f24db3a8d0fc87
@@ -2696,6 +4348,20 @@ packages:
   run_exports: {}
   size: 95955
   timestamp: 1775825530484
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.3-hb03c661_1.conda
+  sha256: c74fa3eddd3ea648456517948f85068d8a07acad7752fd83c7e95b6cebb7114a
+  md5: 10d693a2db6e8339e4eebcb3a3dae88d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - liblzma 5.8.3 hb03c661_1
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD AND LGPL-2.1-or-later
+  purls: []
+  run_exports: {}
+  size: 96459
+  timestamp: 1786348637686
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
   sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
   md5: c2a01a08fc991620a74b32420e97868a
@@ -2710,6 +4376,20 @@ packages:
     - libzlib >=1.3.2,<2.0a0
   size: 95931
   timestamp: 1774072620848
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+  sha256: 16080a1c7724f7d25727cdc23c7658e0cec2db52448c1dc0c33467ee2c6e1c62
+  md5: 6acb86426229f96f93e5468d1df3a5e8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib 1.3.2 h25fd6f3_3
+  license: Zlib
+  license_family: Other
+  purls: []
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 96132
+  timestamp: 1785362957588
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
@@ -2724,6 +4404,20 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 601375
   timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  md5: aa459086047c0e5e27023ab19f8cb86a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  run_exports:
+    weak:
+    - zstd >=1.5.7,<1.6.0a0
+  size: 601301
+  timestamp: 1786599621503
 - conda: https://conda.anaconda.org/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
   sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
   md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
@@ -2742,6 +4436,40 @@ packages:
   run_exports: {}
   size: 128866
   timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  md5: 0f51e2391ade309db462a55611263e9c
+  depends:
+  - __unix
+  license: ISC
+  purls: []
+  run_exports: {}
+  size: 131780
+  timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
+  run_exports: {}
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
+  md5: 8e662bd460bda79b1ea39194e3c4c9ab
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=hash-mapping
+  run_exports: {}
+  size: 21333
+  timestamp: 1763918099466
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -2803,6 +4531,18 @@ packages:
   run_exports: {}
   size: 4059
   timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
+  md5: 9614359868482abba1bd15ce465e3c42
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/iniconfig?source=hash-mapping
+  run_exports: {}
+  size: 13387
+  timestamp: 1760831448842
 - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
   md5: 04558c96691bed63104678757beb4f8d
@@ -2839,6 +4579,17 @@ packages:
   run_exports: {}
   size: 3091520
   timestamp: 1778268364856
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.3.0-h2b852eb_101.conda
+  sha256: 3445ae9282a245fec2be3eb4c60d828175e1a73638341893ec3169149bccb8ee
+  md5: 9afea57731f87c849741d9ac038b21a1
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 3086070
+  timestamp: 1785375205831
 - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_119.conda
   sha256: 1b4263aa5d8c8c659e8e38b66868f42867347e0c8941513ee77269afc00a5186
   md5: d1a866495b9654ccfef5392b8541dc58
@@ -2850,6 +4601,17 @@ packages:
   run_exports: {}
   size: 20199810
   timestamp: 1778268389428
+- conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-64-15.3.0-hb2c5482_101.conda
+  sha256: 295b1cfbfaab310b54ad2295e94f134388e6e365c8dafac40f614934c79c35b6
+  md5: 404bf57a7a6e8bb9fb1a82a48bedafe5
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  run_exports: {}
+  size: 20331815
+  timestamp: 1785375230090
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
   sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
   md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
@@ -2876,6 +4638,19 @@ packages:
   run_exports: {}
   size: 1203173
   timestamp: 1780262795392
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
+  md5: d7585b6550ad04c8c5e21097ada2888e
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=hash-mapping
+  run_exports: {}
+  size: 25877
+  timestamp: 1764896838868
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
   sha256: e27e0473fc6723311a0bd48b89b616fa1b996a2f7a2b555338cbbcfb9c640568
   md5: 9c5491066224083c41b6d5635ed7107b
@@ -2889,6 +4664,40 @@ packages:
   run_exports: {}
   size: 55886
   timestamp: 1779293633166
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
+  md5: 16c18772b340887160c79a6acc022db0
+  depends:
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=hash-mapping
+  run_exports: {}
+  size: 893031
+  timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
+  md5: 64c98a12c4e23eb238bf66bbecafdf3c
+  depends:
+  - colorama
+  - pygments >=2.7.2
+  - python >=3.10
+  - iniconfig >=1.0.1
+  - packaging >=22
+  - pluggy >=1.5,<2
+  - tomli >=1
+  - exceptiongroup >=1
+  - python
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytest?source=hash-mapping
+  run_exports: {}
+  size: 306724
+  timestamp: 1782127176429
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
   build_number: 8
   sha256: 80677180dd3c22deb7426ca89d6203f1c7f1f256f2d5a94dc210f6e758229809
@@ -2928,6 +4737,32 @@ packages:
     - __glibc >=2.28,<3.0.a0
   size: 24008591
   timestamp: 1765578833462
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=hash-mapping
+  run_exports: {}
+  size: 21561
+  timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+  sha256: 2d888f90af0686044882c74193ec80a90ec1943145d94a7b1b048958acda1848
+  md5: c70ad746c22219b9700931707482992c
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
+  run_exports: {}
+  size: 52631
+  timestamp: 1783002732887
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
   md5: ad659d0a2b3e47e38d829aa8cad2d610
@@ -2936,6 +4771,14 @@ packages:
   run_exports: {}
   size: 119135
   timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
+  license: LicenseRef-Public-Domain
+  purls: []
+  run_exports: {}
+  size: 118849
+  timestamp: 1784250406640
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzlocal-5.4.4-pyh8f84b5b_0.conda
   sha256: 5d693f6f22b584fb69bac52e716872a1432c50527ced54d66064cc27e5946c0b
   md5: cbd15812c946aecc2d9479318aca450f
@@ -3088,6 +4931,11 @@ packages:
   version: 2026.7.10
   sha256: f6222cafe00e072bb2b8f14142cd969637411fbc4dd3b1d73a90a3b817fa046f
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+  name: certifi
+  version: 2026.7.22
+  sha256: 62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl
   name: python-dotenv
   version: 1.2.2
@@ -3141,6 +4989,13 @@ packages:
   name: pycparser
   version: '3.0'
   sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+  name: python-dotenv
+  version: 1.2.3
+  sha256: 904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9
+  requires_dist:
+  - click>=5.0 ; extra == 'cli'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: orjson
@@ -3724,6 +5579,17 @@ packages:
   - av ; extra == 'video'
   - pillow>=10.0.1,<=15.0 ; extra == 'vision'
   requires_python: '>=3.9.0'
+- pypi: https://files.pythonhosted.org/packages/20/89/e62cc37b69ad357cc8ecd6e7367f5245f523d3cbb338a66197212bdf6749/alembic-1.19.1-py3-none-any.whl
+  name: alembic
+  version: 1.19.1
+  sha256: b39018cb3d9413a19cbd54cf3c02ad33998641f0538eb77413a488a21c3e14be
+  requires_dist:
+  - sqlalchemy>=1.4.23
+  - mako
+  - typing-extensions>=4.12
+  - tomli ; python_full_version < '3.11'
+  - tzdata ; extra == 'tz'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: aiohttp
   version: 3.14.1
@@ -3868,6 +5734,11 @@ packages:
   version: 3.2.3
   sha256: d1f8700ba89c977438744f083890d87187f15709507a5489e0f6d682053b7fa0
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/2a/8e/096d00c7c480ef2ff4265349b14e2261d4ab787ba1f74e2e80d1c58079c3/regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: regex
+  version: 2026.7.19
+  sha256: 9dce8ec9695f531a1b8a6f314fd4b393adcccf2ea861db480cdf97a301d01a68
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/2b/89/9fedd4ba73034d8101c9095731aab75e08dae09178a6955100299af0f20f/distributed-2026.7.0-py3-none-any.whl
   name: distributed
   version: 2026.7.0
@@ -3960,6 +5831,21 @@ packages:
   requires_dist:
   - sniffio
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+  name: pydantic-settings
+  version: 2.15.0
+  sha256: 0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42
+  requires_dist:
+  - pydantic>=2.7.0
+  - python-dotenv>=0.21.0
+  - typing-inspection>=0.4.0
+  - boto3>=1.35.0 ; extra == 'aws-secrets-manager'
+  - azure-identity>=1.16.0 ; extra == 'azure-key-vault'
+  - azure-keyvault-secrets>=4.8.0 ; extra == 'azure-key-vault'
+  - google-cloud-secret-manager>=2.23.1 ; extra == 'gcp-secret-manager'
+  - tomli>=2.0.1 ; extra == 'toml'
+  - pyyaml>=6.0.1 ; extra == 'yaml'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
   name: sortedcontainers
   version: 2.4.0
@@ -4180,11 +6066,36 @@ packages:
   version: 3.0.3
   sha256: d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/3c/4c/369f0b5665afa8ad6fb1862da979dbf61a650ea2b99b5dccda8953aa327c/distributed-2026.7.1-py3-none-any.whl
+  name: distributed
+  version: 2026.7.1
+  sha256: 64eaf4406a04ad26acdc5b8e32fad6bac522d07539225a530bab49610b0114a9
+  requires_dist:
+  - click>=8.0
+  - cloudpickle>=3.0.0
+  - dask>=2026.7.1,<2026.7.2
+  - jinja2>=2.10.3
+  - locket>=1.0.0
+  - msgpack>=1.0.2
+  - packaging>=20.0
+  - psutil>=5.8.0
+  - pyyaml>=5.4.1
+  - sortedcontainers>=2.0.5
+  - tblib>=1.6.0,!=3.2.0,!=3.2.1
+  - toolz>=0.12.0
+  - tornado>=6.2.0
+  - zict>=3.0.0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/3d/ca/36133653e00939922dd1416f4c56177361289172a30563fcb9552c9ccde4/readchar-4.2.2-py3-none-any.whl
   name: readchar
   version: 4.2.2
   sha256: 92daf7e42c52b0787e6c75d01ecfb9a94f4ceff3764958b570c1dddedd47b200
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+  name: annotated-doc
+  version: 0.0.5
+  sha256: 117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl
   name: requests-toolbelt
   version: 1.0.0
@@ -4192,6 +6103,11 @@ packages:
   requires_dist:
   - requests>=2.0.1,<3.0.0
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/3f/b1/fce88472306a62a35655c2bc64f22921313022e8b4f8534c2b61ff135a43/xvfbwrapper-0.2.29-py3-none-any.whl
+  name: xvfbwrapper
+  version: 0.2.29
+  sha256: 6c4f411fdb10ee6e1ec7a5c69b67bc8d9720cfb294de0ffa45721bc8ba1cdd6b
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/40/c2/d28988d3cba74e712f47a498e2b3e3b58ac215106019bf5d8c20f8ab9822/google_ai_generativelanguage-0.4.0-py3-none-any.whl
   name: google-ai-generativelanguage
   version: 0.4.0
@@ -4425,6 +6341,25 @@ packages:
   - pyarrow ; extra == 'all'
   - adbc-driver-manager ; extra == 'all'
   requires_python: '>=3.10.0'
+- pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: aiohttp
+  version: 3.14.3
+  sha256: 543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42
+  requires_dist:
+  - aiohappyeyeballs>=2.5.0
+  - aiosignal>=1.4.0
+  - async-timeout>=4.0,<6.0 ; python_full_version < '3.11'
+  - attrs>=17.3.0
+  - frozenlist>=1.1.1
+  - multidict>=4.5,<7.0
+  - propcache>=0.2.0
+  - typing-extensions>=4.4 ; python_full_version < '3.13'
+  - yarl>=1.17.0,<2.0
+  - aiodns>=3.3.0 ; sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+  - brotli>=1.2 ; platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+  - brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
+  - backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/54/03/e09325cfc40a33a82b31ba1a3f1d97e85246736856a45a43b19fcb48b1c2/typer_slim-0.21.2-py3-none-any.whl
   name: typer-slim
   version: 0.21.2
@@ -4626,6 +6561,18 @@ packages:
   - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
   - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/5d/4f/37960d5255988b218c40c9b5a2b731013684294a50735d1dd1ab4894e531/google_cloud_core-2.6.1-py3-none-any.whl
+  name: google-cloud-core
+  version: 2.6.1
+  sha256: 2682a8a4474a32f56292fb4bca7fa7e4fb0b4af958f6abfe4bca8d195747fd45
+  requires_dist:
+  - google-api-core>=2.28.0,<3.0.0
+  - google-auth>=2.14.1,!=2.24.0,!=2.25.0,<3.0.0
+  - grpcio>=1.59.0,<2.0.0 ; extra == 'grpc'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  - grpcio-status>=1.59.0,<2.0.0 ; extra == 'grpc'
+  - grpcio-status>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/5f/88/8dac5496354650972434966ba570a4a824fafed43471cf190faea4b085fc/timeago-1.0.16-py3-none-any.whl
   name: timeago
   version: 1.0.16
@@ -4642,6 +6589,14 @@ packages:
   name: filelock
   version: 3.29.7
   sha256: 987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/61/3a/cfee3c50294f55a2f0f9575052dec2c2a48891ad4b1c2a133b05a87026cd/proto_plus-1.28.3-py3-none-any.whl
+  name: proto-plus
+  version: 1.28.3
+  sha256: dc76880b8ee951cca002098574376cf71e055f9f16d9ba6570fb8a06f726d281
+  requires_dist:
+  - protobuf>=6.33.5,<8.0.0
+  - google-api-core>=2.25.0 ; extra == 'testing'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/61/62/150c841f24cda9e30f588ef396ed83f64cfdc13b92d2f925bb96df337ba9/ruamel_yaml_clib-0.2.15-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: ruamel-yaml-clib
@@ -4663,6 +6618,21 @@ packages:
   requires_dist:
   - pycparser ; implementation_name != 'PyPy'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl
+  name: markdown
+  version: 3.10.3
+  sha256: fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea
+  requires_dist:
+  - coverage ; extra == 'testing'
+  - pyyaml ; extra == 'testing'
+  - mkdocs>=1.6 ; extra == 'docs'
+  - mkdocs-nature>=0.6 ; extra == 'docs'
+  - mdx-gh-links>=0.2 ; extra == 'docs'
+  - mkdocstrings[python]>=0.28.3 ; extra == 'docs'
+  - mkdocs-gen-files ; extra == 'docs'
+  - mkdocs-section-index ; extra == 'docs'
+  - mkdocs-literate-nav ; extra == 'docs'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
   name: attrs
   version: 26.1.0
@@ -4676,6 +6646,23 @@ packages:
   - mypy-extensions>=0.3.0
   - typing-extensions>=3.7.4
   - typing>=3.7.4 ; python_full_version < '3.5'
+- pypi: https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl
+  name: redis
+  version: 8.1.0
+  sha256: a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb
+  requires_dist:
+  - async-timeout>=4.0.3 ; python_full_version < '3.11.3'
+  - pybreaker>=1.4.0 ; extra == 'circuit-breaker'
+  - hiredis>=3.2.0 ; extra == 'hiredis'
+  - pyjwt>=2.13.0 ; extra == 'jwt'
+  - cryptography>=36.0.1 ; extra == 'ocsp'
+  - pyopenssl>=20.0.1 ; extra == 'ocsp'
+  - requests>=2.31.0 ; extra == 'ocsp'
+  - opentelemetry-api>=1.39.1 ; extra == 'otel'
+  - opentelemetry-exporter-otlp-proto-http>=1.39.1 ; extra == 'otel'
+  - opentelemetry-sdk>=1.39.1 ; extra == 'otel'
+  - xxhash~=3.6.0 ; extra == 'xxhash'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/66/aa/bcbd1c6b1c7dfd717ff5c899a1c8adcc6b3e391fb7a0b00fdc64e4e54235/blis-0.7.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: blis
   version: 0.7.11
@@ -4799,6 +6786,50 @@ packages:
   - torch ; extra == 'torch'
   - pillow>=6.2.1 ; extra == 'vision'
   requires_python: '>=3.8.0'
+- pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+  name: typing-inspection
+  version: 0.4.4
+  sha256: 65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147
+  requires_dist:
+  - typing-extensions>=4.15.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/67/c0/f491506bdff4d73750f74cf18fea7d6ca409ada2f81c4c4d10a32edf5688/google_cloud_bigquery-3.43.0-py3-none-any.whl
+  name: google-cloud-bigquery
+  version: 3.43.0
+  sha256: a39217f14f215472ce9da816f20ebaf77fdb1db7ccdc8360772d8bf6bafb55c2
+  requires_dist:
+  - google-api-core[grpc]>=2.28.0,<3.0.0
+  - google-auth[pyopenssl]>=2.14.1,<3.0.0
+  - google-cloud-core>=2.4.1,<3.0.0
+  - google-resumable-media>=2.0.0,<3.0.0
+  - packaging>=24.2.0
+  - python-dateutil>=2.8.2,<3.0.0
+  - requests>=2.21.0,<3.0.0
+  - google-cloud-bigquery-storage>=2.29.0,<3.0.0 ; extra == 'bqstorage'
+  - grpcio>=1.59.0,<2.0.0 ; extra == 'bqstorage'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'bqstorage'
+  - pyarrow>=4.0.0 ; extra == 'bqstorage'
+  - pandas>=1.3.0 ; extra == 'pandas'
+  - pandas-gbq>=0.26.1 ; extra == 'pandas'
+  - grpcio>=1.59.0,<2.0.0 ; extra == 'pandas'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'pandas'
+  - pyarrow>=3.0.0 ; extra == 'pandas'
+  - db-dtypes>=1.0.4,<2.0.0 ; extra == 'pandas'
+  - ipywidgets>=7.7.1 ; extra == 'ipywidgets'
+  - ipykernel>=6.2.0 ; extra == 'ipywidgets'
+  - geopandas>=0.9.0,<2.0.0 ; extra == 'geopandas'
+  - shapely>=1.8.4,<3.0.0 ; extra == 'geopandas'
+  - ipython>=7.23.1 ; extra == 'ipython'
+  - bigquery-magics>=0.6.0 ; extra == 'ipython'
+  - matplotlib>=3.10.3 ; extra == 'matplotlib'
+  - tqdm>=4.23.4,<5.0.0 ; extra == 'tqdm'
+  - opentelemetry-api>=1.1.0 ; extra == 'opentelemetry'
+  - opentelemetry-sdk>=1.1.0 ; extra == 'opentelemetry'
+  - opentelemetry-instrumentation>=0.20b0 ; extra == 'opentelemetry'
+  - proto-plus>=1.26.1,<2.0.0 ; extra == 'bigquery-v2'
+  - protobuf>=6.33.5,<8.0.0 ; extra == 'bigquery-v2'
+  - google-cloud-bigquery[bigquery-v2,bqstorage,geopandas,ipython,ipywidgets,matplotlib,opentelemetry,pandas,tqdm] ; extra == 'all'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl
   name: jsonschema
   version: 4.26.0
@@ -4852,6 +6883,15 @@ packages:
   version: 1.2.1
   sha256: 020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl
+  name: cryptography
+  version: 50.0.0
+  sha256: b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae
+  requires_dist:
+  - cffi>=2.0.0 ; platform_python_implementation != 'PyPy'
+  - typing-extensions>=4.13.2 ; python_full_version < '3.11'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  requires_python: '!=3.9.0,>=3.9,!=3.9.1'
 - pypi: https://files.pythonhosted.org/packages/6b/c4/ee4096ffa2eeeca0c749b26f0371bd26aa5c8b611c43de99a4f86d3de0a7/pandasql-0.7.3.tar.gz
   name: pandasql
   version: 0.7.3
@@ -4973,6 +7013,16 @@ packages:
   - doit>=0.36.0 ; extra == 'dev'
   - pydevtool ; extra == 'dev'
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+  name: tornado
+  version: 6.5.8
+  sha256: 547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: charset-normalizer
+  version: 3.5.1
+  sha256: b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08
+  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/70/9b/b26405992d807a592ab3e7792f0eb2c2f71fe69111c972caf7786ba99199/langchain_core-0.2.43-py3-none-any.whl
   name: langchain-core
   version: 0.2.43
@@ -5256,6 +7306,17 @@ packages:
   - granian>=2.3.1 ; extra == 'granian'
   - daphne>=4.2.0 ; extra == 'daphne'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  name: greenlet
+  version: 3.5.5
+  sha256: 147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d
+  requires_dist:
+  - sphinx ; extra == 'docs'
+  - furo ; extra == 'docs'
+  - objgraph ; extra == 'test'
+  - psutil ; extra == 'test'
+  - setuptools ; extra == 'test'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
   name: annotated-types
   version: 0.7.0
@@ -5331,6 +7392,45 @@ packages:
   - coverage ; extra == 'test'
   - pytest ; extra == 'test'
   requires_python: '>=3.8,<4'
+- pypi: https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl
+  name: h2
+  version: 4.4.1
+  sha256: 0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6
+  requires_dist:
+  - hyperframe>=6.1,<7
+  - hpack>=4.2,<5
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/7e/5f/7c22733da92b3a6cc4dddcaa8731089d213c2790bbc997e51c429a4e8f8b/dask-2026.7.1-py3-none-any.whl
+  name: dask
+  version: 2026.7.1
+  sha256: 985ffd6c5e9d7979ede515e84ae8d39b647d6aa64f77600f15714ff65f578fe6
+  requires_dist:
+  - click>=8.1
+  - cloudpickle>=3.0.0
+  - fsspec>=2021.9.0
+  - packaging>=20.0
+  - partd>=1.4.0
+  - pyyaml>=5.4.1
+  - toolz>=0.12.0
+  - importlib-metadata>=4.13.0 ; python_full_version < '3.12'
+  - numpy>=1.24 ; extra == 'array'
+  - dask[array] ; extra == 'dataframe'
+  - pandas>=2.0 ; extra == 'dataframe'
+  - pyarrow>=16.0 ; extra == 'dataframe'
+  - distributed>=2026.7.1,<2026.7.2 ; extra == 'distributed'
+  - bokeh>=3.1.0 ; extra == 'diagnostics'
+  - jinja2>=2.10.3 ; extra == 'diagnostics'
+  - dask[array,dataframe,diagnostics,distributed] ; extra == 'complete'
+  - lz4>=4.3.2 ; extra == 'complete'
+  - pandas[test] ; extra == 'test'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - pytest-rerunfailures ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - pre-commit ; extra == 'test'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -5676,6 +7776,11 @@ packages:
   version: 6.0.3
   sha256: ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/8c/57/80b986ebfecd9c6a177ddf1c2319717f0cd8feffb2b78946595a18a2fc88/orjson-3.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  name: orjson
+  version: 3.12.0
+  sha256: 1192a7021b6d071aaf909864f6e924d6a2675ca360485b972b8401749311750b
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl
   name: asyncpg
   version: 0.31.0
@@ -5800,11 +7905,24 @@ packages:
   - aiobotocore[awscli]>=2.5.4,<3.0.0 ; extra == 'awscli'
   - aiobotocore[boto3]>=2.5.4,<3.0.0 ; extra == 'boto3'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+  name: annotated-types
+  version: 0.8.0
+  sha256: f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl
   name: pyasn1
   version: 0.6.4
   sha256: deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl
+  name: googleapis-common-protos
+  version: 1.75.1
+  sha256: 28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79
+  requires_dist:
+  - protobuf>=6.33.5,<8.0.0
+  - grpcio>=1.59.0,<2.0.0 ; extra == 'grpc'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl
   name: griffe
   version: 1.15.0
@@ -5923,6 +8041,11 @@ packages:
   - pytest>=7.1.0 ; extra == 'dev'
   - hypothesis>=6.70.0 ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl
+  name: uncalled-for
+  version: 0.4.0
+  sha256: 16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl
   name: ply
   version: '3.11'
@@ -5958,6 +8081,16 @@ packages:
   - requests>=2.13.0,<3.0.0
   - pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl
+  name: mako
+  version: 1.4.1
+  sha256: a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617
+  requires_dist:
+  - markupsafe>=2.0
+  - pytest ; extra == 'testing'
+  - babel ; extra == 'babel'
+  - lingua>=4.16 ; extra == 'lingua'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl
   name: semver
   version: 3.0.4
@@ -5967,6 +8100,28 @@ packages:
   name: text-unidecode
   version: '1.3'
   sha256: 1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8
+- pypi: https://files.pythonhosted.org/packages/a7/05/4e3b902bc0ca407188aa5fe38af49be634487aec242a77287103242e11b2/pydocket-0.24.1-py3-none-any.whl
+  name: pydocket
+  version: 0.24.1
+  sha256: 1faa6c3d566f1f0431e35dfa12db4ccee515d945b913b516ee3e6279afb9e789
+  requires_dist:
+  - burner-redis>=0.1.7
+  - cloudpickle>=3.1.1
+  - cronsim>=2.6
+  - exceptiongroup>=1.2.0 ; python_full_version < '3.11'
+  - opentelemetry-api>=1.33.0
+  - prometheus-client>=0.21.1
+  - py-key-value-aio[memory,redis]>=0.3.0
+  - python-json-logger>=2.0.7
+  - redis>=5
+  - rich>=13.9.4
+  - taskgroup>=0.2.2 ; python_full_version < '3.11'
+  - typer>=0.15.1
+  - typing-extensions>=4.12.0
+  - tzdata>=2025.2 ; sys_platform == 'win32'
+  - uncalled-for>=0.4.0
+  - opentelemetry-sdk>=1.33.0 ; extra == 'metrics'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/a8/5c/53f18822017b8bda6bd8bb4e02048e911fdc79a3dafdc83ab994fe922a84/protobuf-4.25.9-cp37-abi3-manylinux2014_x86_64.whl
   name: protobuf
   version: 4.25.9
@@ -6153,6 +8308,16 @@ packages:
   - protobuf>=3.20.2,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<7.0.0 ; extra == 'bigquery-v2'
   - google-cloud-bigquery[bigquery-v2,bqstorage,geopandas,ipython,ipywidgets,matplotlib,opentelemetry,pandas,tqdm] ; extra == 'all'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ac/ba/77ef49baf338c03a11deadac984e3161b3f2b4fa4bb5aab160e7ca0fd522/google_resumable_media-2.10.1-py3-none-any.whl
+  name: google-resumable-media
+  version: 2.10.1
+  sha256: 4e2cbc704207ddc09f23b1f18e8ef4a4ccbfe0f1768b370e5c969704adbd0a1c
+  requires_dist:
+  - google-crc32c>=1.0.0,<2.0.0
+  - requests>=2.18.0,<3.0.0 ; extra == 'requests'
+  - aiohttp>=3.6.2,<4.0.0 ; extra == 'aiohttp'
+  - google-auth>=2.14.1,<3.0.0 ; extra == 'aiohttp'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/ad/68/316cbc54b7163fa22571dcf42c9cc46562aae0a021b974e0a8141e897200/mcp-1.12.4-py3-none-any.whl
   name: mcp
   version: 1.12.4
@@ -6204,6 +8369,14 @@ packages:
   - requests>=2.18.0,<3.0.0 ; extra == 'requests'
   - aiohttp>=3.6.2,<4.0.0 ; extra == 'aiohttp'
   - google-auth>=1.22.0,<2.0.0 ; extra == 'aiohttp'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+  name: grpcio
+  version: 1.83.0
+  sha256: aeb339838db07600481ef869507279b75326c75eac6d10f7afa62a0da1d2bcdd
+  requires_dist:
+  - typing-extensions~=4.12
+  - grpcio-tools>=1.83.0 ; extra == 'protobuf'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b3/06/c3a23c9a0263b136c519f033a58d4641e73065fefc7754e9667ec206d992/pybind11-3.0.4-py3-none-any.whl
   name: pybind11
@@ -6375,6 +8548,66 @@ packages:
   - babel ; extra == 'babel'
   - lingua ; extra == 'lingua'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl
+  name: google-auth
+  version: 2.56.3
+  sha256: 8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53
+  requires_dist:
+  - pyasn1-modules>=0.2.1
+  - cryptography>=38.0.3 ; python_full_version < '3.14'
+  - cryptography>=41.0.5 ; python_full_version >= '3.14'
+  - cryptography>=38.0.3 ; python_full_version < '3.14' and extra == 'cryptography'
+  - cryptography>=41.0.5 ; python_full_version >= '3.14' and extra == 'cryptography'
+  - cryptography>=38.0.3 ; python_full_version < '3.14' and extra == 'pyopenssl'
+  - cryptography>=41.0.5 ; python_full_version >= '3.14' and extra == 'pyopenssl'
+  - aiohttp>=3.8.0,<4.0.0 ; python_full_version < '3.14' and extra == 'aiohttp'
+  - aiohttp>=3.9.0,<4.0.0 ; python_full_version >= '3.14' and extra == 'aiohttp'
+  - requests>=2.30.0,<3.0.0 ; extra == 'aiohttp'
+  - cryptography>=38.0.3 ; python_full_version < '3.14' and extra == 'enterprise-cert'
+  - cryptography>=41.0.5 ; python_full_version >= '3.14' and extra == 'enterprise-cert'
+  - pyjwt>=2.0 ; extra == 'pyjwt'
+  - pyu2f>=0.1.5 ; extra == 'reauth'
+  - requests>=2.30.0,<3.0.0 ; extra == 'requests'
+  - grpcio>=1.59.0,<2.0.0 ; python_full_version < '3.14' and extra == 'testing'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'testing'
+  - flask ; extra == 'testing'
+  - freezegun ; extra == 'testing'
+  - pyjwt>=2.0 ; extra == 'testing'
+  - pytest ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-localserver ; extra == 'testing'
+  - pyu2f>=0.1.5 ; extra == 'testing'
+  - responses ; extra == 'testing'
+  - urllib3>=1.26.15,<3.0.0 ; extra == 'testing'
+  - packaging>=20.0 ; extra == 'testing'
+  - aiohttp>=3.8.0,<4.0.0 ; python_full_version < '3.14' and extra == 'testing'
+  - aiohttp>=3.9.0,<4.0.0 ; python_full_version >= '3.14' and extra == 'testing'
+  - requests>=2.30.0,<3.0.0 ; extra == 'testing'
+  - aioresponses ; extra == 'testing'
+  - pytest-asyncio ; extra == 'testing'
+  - urllib3>=1.26.15,<3.0.0 ; extra == 'urllib3'
+  - packaging>=20.0 ; extra == 'urllib3'
+  - rsa>=4.0.0,<5 ; extra == 'rsa'
+  - grpcio>=1.59.0,<2.0.0 ; python_full_version < '3.14' and extra == 'grpc'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/bc/c1/a8a92ae1bc4b1a8f804c776d7d3f0c771b78a62c3ad4df1be41b3fd8c767/google_api_core-2.34.0-py3-none-any.whl
+  name: google-api-core
+  version: 2.34.0
+  sha256: cdf9c67e7ca2402d86ccbfde5f2503fc83e3cc3f58cc78456ae96cad24a6d2de
+  requires_dist:
+  - googleapis-common-protos>=1.69.2,<2.0.0
+  - protobuf>=6.33.5,<8.0.0
+  - proto-plus>=1.26.1,<2.0.0
+  - google-auth>=2.14.1,<3.0.0
+  - requests>=2.33.0,<3.0.0
+  - google-auth[aiohttp]>=2.14.1,<3.0.0 ; extra == 'async-rest'
+  - aiohttp>=3.13.4 ; extra == 'async-rest'
+  - grpcio>=1.59.0,<2.0.0 ; extra == 'grpc'
+  - grpcio>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  - grpcio-status>=1.59.0,<2.0.0 ; extra == 'grpc'
+  - grpcio-status>=1.75.1,<2.0.0 ; python_full_version >= '3.14' and extra == 'grpc'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl
   name: marshmallow
   version: 3.26.2
@@ -6580,6 +8813,26 @@ packages:
   - pyparsing>=3
   - python-dateutil>=2.7
   requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl
+  name: opentelemetry-api
+  version: 1.44.0
+  sha256: 94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef
+  requires_dist:
+  - typing-extensions>=4.5.0
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cb/1b/349e07ad184d64e81109e85a3557d7e05631fa3d05344169114ba743c4d3/dateparser-1.4.2-py3-none-any.whl
+  name: dateparser
+  version: 1.4.2
+  sha256: 752f3d49d477cf7f60a7a9c8bcb19c882496ede0e377d5a3d80014cdfeca7050
+  requires_dist:
+  - python-dateutil>=2.7.0
+  - pytz>=2024.2
+  - regex>=2024.9.11
+  - tzlocal>=0.2
+  - convertdate>=2.2.1 ; extra == 'calendars'
+  - hijridate ; extra == 'calendars'
+  - langdetect>=1.0.0 ; extra == 'langdetect'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: contourpy
   version: 1.3.3
@@ -6689,11 +8942,29 @@ packages:
   - pywin32 ; extra == 'windows'
   - tzdata ; extra == 'windows'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d6/00/73204406228cf989bea6b0fd9fe4702fab49a8a152a0c6f90856dadb6ac7/grpcio_status-1.83.0-py3-none-any.whl
+  name: grpcio-status
+  version: 1.83.0
+  sha256: f6a838a7c5fb84ae98833ec0ef81ed438c26e11e54b2ddb8e92ad328c861de69
+  requires_dist:
+  - protobuf>=6.33.5,<8.0.0
+  - grpcio>=1.83.0
+  - googleapis-common-protos>=1.5.5
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/d6/45/fc303eb433e8a2a271739c98e953728422fa61a3c1f36077a49e395c972e/xmltodict-0.14.2-py2.py3-none-any.whl
   name: xmltodict
   version: 0.14.2
   sha256: 20cc7d723ed729276e808f26fb6b3599f786cbc37e06c65e192ba77c40f20aac
   requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: yarl
+  version: 1.24.5
+  sha256: f08c7513ecef5aad65687bfdf6bc601ae9fccd04a42904501f8f7141abad9eb9
+  requires_dist:
+  - idna>=2.0
+  - multidict>=4.0
+  - propcache>=0.2.1
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/d7/45/05cc2ecbf61163bbbb18678dcdc7e7e7285f9f50f4dcf96a9ff07633ac52/wfdb-4.3.1-py3-none-any.whl
   name: wfdb
   version: 4.3.1
@@ -6771,6 +9042,16 @@ packages:
   - python-multipart>=0.0.18 ; extra == 'full'
   - pyyaml ; extra == 'full'
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl
+  name: anyio
+  version: 4.14.2
+  sha256: 9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494
+  requires_dist:
+  - exceptiongroup>=1.0.2 ; python_full_version < '3.11'
+  - idna>=2.8
+  - typing-extensions>=4.5 ; python_full_version < '3.13'
+  - trio>=0.32.0 ; extra == 'trio'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/db/5b/4e7d67d880b3344afff01708725a39717694a79391a32711fd40a8958bed/pydicom-2.4.5-py3-none-any.whl
   name: pydicom
   version: 2.4.5
@@ -6815,6 +9096,26 @@ packages:
   version: 1.0.0
   sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl
+  name: uvicorn
+  version: 0.52.3
+  sha256: 116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c
+  requires_dist:
+  - click>=7.0
+  - h11>=0.8
+  - typing-extensions>=4.0 ; python_full_version < '3.11'
+  - httptools>=0.8.0 ; extra == 'standard'
+  - python-dotenv>=0.13 ; extra == 'standard'
+  - pyyaml>=5.1 ; extra == 'standard'
+  - uvloop>=0.15.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32' and extra == 'standard'
+  - watchfiles>=0.20 ; extra == 'standard'
+  - websockets>=13.0 ; extra == 'standard'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/dc/55/6467fde553886cb293e41538f3a8b4e4fd4688c6df242cf982162d8367fb/python_json_logger-4.2.0-py3-none-any.whl
+  name: python-json-logger
+  version: 4.2.0
+  sha256: 158a52126fcd6869e09574d2b66272666f3dc8f468c62637ef9a1fa883719cb9
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
   name: typing-inspection
   version: 0.4.2
@@ -6822,6 +9123,22 @@ packages:
   requires_dist:
   - typing-extensions>=4.12.0
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl
+  name: sse-starlette
+  version: 3.4.8
+  sha256: 6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d
+  requires_dist:
+  - starlette>=0.49.1
+  - anyio>=4.7.0
+  - uvicorn>=0.34.0 ; extra == 'examples'
+  - fastapi>=0.115.12 ; extra == 'examples'
+  - pydantic>=2 ; extra == 'examples'
+  - sqlalchemy[asyncio]>=2.0.41 ; extra == 'examples-db'
+  - aiosqlite>=0.21.0 ; extra == 'examples-db'
+  - uvicorn>=0.34.0 ; extra == 'uvicorn'
+  - granian>=2.3.1 ; extra == 'granian'
+  - daphne>=4.2.0 ; extra == 'daphne'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: scipy
   version: 1.18.0
@@ -7098,6 +9415,15 @@ packages:
   version: 2.0.13
   sha256: f190a92fe46197ee64d32560eb121c2809bb843341733227f51538ce77b3410d
   requires_python: '>=3.9,<3.15'
+- pypi: https://files.pythonhosted.org/packages/eb/a3/b69efbf4143b5b9859b977770bbbabcc2796b702fa69dc40271e45cd5a56/prometheus_client-0.26.0-py3-none-any.whl
+  name: prometheus-client
+  version: 0.26.0
+  sha256: fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6
+  requires_dist:
+  - twisted ; extra == 'twisted'
+  - aiohttp ; extra == 'aiohttp'
+  - django ; extra == 'django'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
   name: python-dateutil
   version: 2.9.0.post0
@@ -7194,6 +9520,30 @@ packages:
   sha256: bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961
   requires_dist:
   - typing-extensions>=4.1.0 ; python_full_version < '3.11'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f3/bc/2a07cef49046e6cf5d1a8b1de553aaef8491b4170dbfe254c8687c764408/sqlglot-30.17.0-py3-none-any.whl
+  name: sqlglot
+  version: 30.17.0
+  sha256: 84435ac283a60173da31b5fd7d11a725037a1c3fd6ed1e21fb065de74ddb579f
+  requires_dist:
+  - duckdb>=0.6 ; extra == 'dev'
+  - sqlglot-mypy>=2.3.0.post1 ; python_full_version >= '3.10' and extra == 'dev'
+  - mypy ; python_full_version < '3.10' and extra == 'dev'
+  - setuptools-scm ; extra == 'dev'
+  - pandas ; extra == 'dev'
+  - pandas-stubs ; extra == 'dev'
+  - python-dateutil ; extra == 'dev'
+  - pytz ; extra == 'dev'
+  - pdoc ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - ruff==0.15.6 ; extra == 'dev'
+  - types-python-dateutil ; extra == 'dev'
+  - types-pytz ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - pyperf ; extra == 'dev'
+  - sqlglotc==30.17.0 ; python_full_version >= '3.10' and extra == 'c'
+  - sqlglotrs==0.13.0 ; extra == 'rs'
+  - sqlglotc==30.17.0 ; python_full_version >= '3.10' and extra == 'rs'
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl
   name: pydantic
@@ -7317,6 +9667,20 @@ packages:
   - pybind11>=2.2.3
   - psutil
   - numpy>=1.10.0 ; python_full_version >= '3.5'
+- pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+  name: tqdm
+  version: 4.70.0
+  sha256: 7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
+  requires_dist:
+  - colorama ; sys_platform == 'win32'
+  - requests ; extra == 'discord'
+  - envwrap ; extra == 'discord'
+  - slack-sdk ; extra == 'slack'
+  - envwrap ; extra == 'slack'
+  - requests ; extra == 'telegram'
+  - envwrap ; extra == 'telegram'
+  - ipywidgets>=6 ; extra == 'notebook'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
   name: toolz
   version: 1.1.0

--- a/plugins/flows/data_transformation/pyproject.toml
+++ b/plugins/flows/data_transformation/pyproject.toml
@@ -163,8 +163,18 @@ packaging = "<25"
 compilers = "*"
 make = "*"
 
+[tool.pixi.feature.test.dependencies]
+pytest = "9.*"
+
 [tool.pixi.environments]
 default = { solve-group = "default" }
+# Own solve-group (no solve-group key) on purpose: putting the test env in the
+# default solve-group makes a test-only dependency perturb the environment that
+# ships in the worker image — pytest's deps flipped colorama, exceptiongroup,
+# pluggy, pygments and typing_extensions from pypi wheels to conda packages in
+# `default`. Isolated, `default` stays byte-identical. Not provisioned into the
+# image either: provision-envs.sh installs only default, ner and bunny.
+test = { features = ["test"] }
 # Own solve-group: the NER stack's pins (scipy 1.16, torch 2.8 cpu) must not
 # constrain the default environment.
 ner = { features = ["ner"], no-default-feature = true }

--- a/plugins/flows/data_transformation/white_rabbit_plugin/paths.py
+++ b/plugins/flows/data_transformation/white_rabbit_plugin/paths.py
@@ -1,0 +1,54 @@
+"""Filesystem preconditions for the WhiteRabbit plugin.
+
+Deliberately free of Prefect imports so these can be unit-tested without a
+flow-run harness. The WhiteRabbit dist is provisioned into the
+dataflow-gen-worker image (see services/alp-dataflow-gen-worker/Dockerfile);
+these helpers make the flow tasks self-sufficient and make a misprovisioned
+worker report itself clearly.
+"""
+
+from pathlib import Path
+
+
+def ensure_whiterabbit_dirs(dir_path: str, csv_dir: str) -> None:
+    """Create the WhiteRabbit working directories if they are absent.
+
+    open(path, "w") creates a file but never its parent, which is why a missing
+    directory previously surfaced as a FileNotFoundError naming config.ini.
+    """
+    Path(dir_path).mkdir(parents=True, exist_ok=True)
+    Path(csv_dir).mkdir(parents=True, exist_ok=True)
+
+
+def require_whiterabbit_dist(bin_path: str) -> None:
+    """Fail fast, and honestly, when the WhiteRabbit distribution is absent."""
+    if not Path(bin_path).exists():
+        raise RuntimeError(
+            f"WhiteRabbit distribution not found at {bin_path}. "
+            "The dist is provisioned into the dataflow-gen-worker image from "
+            "the whiterabbit OCI stage; a worker built without it cannot run "
+            "scans."
+        )
+
+
+def clear_csv_working_dir(csv_dir: str) -> int:
+    """Remove CSV files left in the shared scan working directory.
+
+    Every node's CSVs are downloaded into this one flat directory and scans run
+    with tables_to_scan="*", so without this a scan would report tables
+    belonging to previous scans and to other ETL nodes. Only *.csv is removed:
+    the directory is also the working folder WhiteRabbit writes ScanReport.xlsx
+    into.
+
+    Returns the number of files removed.
+    """
+    directory = Path(csv_dir)
+    if not directory.is_dir():
+        return 0
+
+    removed = 0
+    for entry in directory.iterdir():
+        if entry.is_file() and entry.suffix.lower() == ".csv":
+            entry.unlink()
+            removed += 1
+    return removed

--- a/plugins/flows/data_transformation/white_rabbit_plugin/tasks.py
+++ b/plugins/flows/data_transformation/white_rabbit_plugin/tasks.py
@@ -11,6 +11,7 @@ from prefect.artifacts import create_markdown_artifact
 
 from .types import INISettings, FileSaveResponse, WhiteRabbitRunType
 from .types import WHITERABBIT_BIN_PATH, WHITERABBIT_CSV_DIR, WHITERABBIT_DIR_PATH  
+from .paths import ensure_whiterabbit_dirs, require_whiterabbit_dist
 
 from _shared_flow_utils.dao.DBDao import DBDao
 from _shared_flow_utils.api.WhiteRabbitAPI import WhiteRabbitAPI
@@ -54,6 +55,9 @@ def create_white_rabbit_settings(scan_type: WhiteRabbitRunType, scan_settings: d
     config["settings"] = ini_content.dump_settings_json()
 
     config_path = f"{WHITERABBIT_DIR_PATH}/config.ini"
+
+    ensure_whiterabbit_dirs(WHITERABBIT_DIR_PATH, WHITERABBIT_CSV_DIR)
+    require_whiterabbit_dist(WHITERABBIT_BIN_PATH)
 
     logger.debug(f"Writing file config.ini to {config_path}...")
     

--- a/plugins/flows/data_transformation/white_rabbit_plugin/tasks.py
+++ b/plugins/flows/data_transformation/white_rabbit_plugin/tasks.py
@@ -11,7 +11,11 @@ from prefect.artifacts import create_markdown_artifact
 
 from .types import INISettings, FileSaveResponse, WhiteRabbitRunType
 from .types import WHITERABBIT_BIN_PATH, WHITERABBIT_CSV_DIR, WHITERABBIT_DIR_PATH  
-from .paths import ensure_whiterabbit_dirs, require_whiterabbit_dist
+from .paths import (
+    clear_csv_working_dir,
+    ensure_whiterabbit_dirs,
+    require_whiterabbit_dist,
+)
 
 from _shared_flow_utils.dao.DBDao import DBDao
 from _shared_flow_utils.api.WhiteRabbitAPI import WhiteRabbitAPI
@@ -156,6 +160,14 @@ def download_files_from_supabase_storage(node_id: str, supabase_api: SupabaseSto
     and downloads all matching CSV files to the WHITERABBIT_CSV_DIR directory.
     '''
     logger = get_run_logger()
+
+    # Every node downloads into this one flat directory and the scan runs with
+    # tables_to_scan="*", so leftovers from a previous scan (or another node)
+    # would silently appear as extra tables in this scan's report.
+    removed = clear_csv_working_dir(WHITERABBIT_CSV_DIR)
+    if removed:
+        logger.info(f"Removed {removed} stale CSV file(s) from {WHITERABBIT_CSV_DIR}")
+
     files_uploaded = supabase_api.list_files(node_id)
     csv_files = [file for file in files_uploaded if file.get('type') == 'CSV']
     

--- a/plugins/flows/data_transformation/white_rabbit_plugin/tests/conftest.py
+++ b/plugins/flows/data_transformation/white_rabbit_plugin/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+# tasks.py imports _shared_flow_utils, which lives at plugins/flows/ — one level
+# above this plugin's project root. The pixi activation env pins PYTHONPATH to
+# the plugin dir only, so add the parent explicitly.
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+)

--- a/plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py
+++ b/plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py
@@ -1,0 +1,64 @@
+import pytest
+
+from white_rabbit_plugin.paths import (
+    ensure_whiterabbit_dirs,
+    require_whiterabbit_dist,
+    clear_csv_working_dir,
+)
+
+
+def test_ensure_creates_both_directories(tmp_path):
+    base = tmp_path / "whiterabbit"
+    csv_dir = base / "csvfiles"
+
+    ensure_whiterabbit_dirs(str(base), str(csv_dir))
+
+    assert base.is_dir()
+    assert csv_dir.is_dir()
+
+
+def test_ensure_is_idempotent(tmp_path):
+    base = tmp_path / "whiterabbit"
+    csv_dir = base / "csvfiles"
+
+    ensure_whiterabbit_dirs(str(base), str(csv_dir))
+    ensure_whiterabbit_dirs(str(base), str(csv_dir))
+
+    assert csv_dir.is_dir()
+
+
+def test_require_dist_raises_runtime_error_when_missing(tmp_path):
+    missing_bin = tmp_path / "whiterabbit" / "dist" / "bin"
+
+    with pytest.raises(RuntimeError) as excinfo:
+        require_whiterabbit_dist(str(missing_bin))
+
+    # The whole point of this fix: name the dist, not config.ini.
+    assert str(missing_bin) in str(excinfo.value)
+    assert "config.ini" not in str(excinfo.value)
+
+
+def test_require_dist_does_not_raise_when_present(tmp_path):
+    bin_dir = tmp_path / "whiterabbit" / "dist" / "bin"
+    bin_dir.mkdir(parents=True)
+
+    require_whiterabbit_dist(str(bin_dir))
+
+
+def test_clear_csv_working_dir_removes_only_csv_files(tmp_path):
+    csv_dir = tmp_path / "csvfiles"
+    csv_dir.mkdir()
+    (csv_dir / "stale_one.csv").write_text("a,b\n1,2\n")
+    (csv_dir / "stale_two.CSV").write_text("a,b\n3,4\n")
+    (csv_dir / "ScanReport.xlsx").write_bytes(b"not a csv")
+
+    removed = clear_csv_working_dir(str(csv_dir))
+
+    assert removed == 2
+    assert not (csv_dir / "stale_one.csv").exists()
+    assert not (csv_dir / "stale_two.CSV").exists()
+    assert (csv_dir / "ScanReport.xlsx").exists()
+
+
+def test_clear_csv_working_dir_tolerates_missing_dir(tmp_path):
+    assert clear_csv_working_dir(str(tmp_path / "nope")) == 0

--- a/plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py
+++ b/plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py
@@ -62,3 +62,44 @@ def test_clear_csv_working_dir_removes_only_csv_files(tmp_path):
 
 def test_clear_csv_working_dir_tolerates_missing_dir(tmp_path):
     assert clear_csv_working_dir(str(tmp_path / "nope")) == 0
+
+
+def test_download_task_clears_stale_csvs_before_downloading(tmp_path, monkeypatch):
+    """A scan must not inherit CSVs from a previous scan or another node."""
+    # Imported inside the test on purpose: tasks.py pulls in Prefect at module
+    # load, and the other tests in this file are deliberately dependency-free.
+    from prefect.logging import disable_run_logger
+
+    from white_rabbit_plugin import tasks
+
+    csv_dir = tmp_path / "csvfiles"
+    csv_dir.mkdir()
+    (csv_dir / "from_a_previous_scan.csv").write_text("a\n1\n")
+
+    monkeypatch.setattr(tasks, "WHITERABBIT_CSV_DIR", str(csv_dir))
+
+    downloaded = []
+
+    class FakeSupabaseAPI:
+        def list_files(self, node_id):
+            return [{"name": "current.csv", "type": "CSV"}]
+
+        def download_file_to_path(self, node_id, filename, filepath):
+            downloaded.append((filename, filepath))
+            (csv_dir / filename).write_text("b\n2\n")
+
+    # .fn skips the Prefect task wrapper, so the task's get_run_logger() call has
+    # no run context to bind to and raises MissingContextError. disable_run_logger
+    # swaps in a null logger for the duration of this one call. Scoped here rather
+    # than in a fixture: it is a property of calling *this* task outside a flow,
+    # and a module-wide fixture would silently mask the same error in tests that
+    # should never touch Prefect at all.
+    with disable_run_logger():
+        result = tasks.download_files_from_supabase_storage.fn(
+            "node-1", FakeSupabaseAPI()
+        )
+
+    assert result is True
+    assert downloaded == [("current.csv", str(csv_dir))]
+    assert (csv_dir / "current.csv").exists()
+    assert not (csv_dir / "from_a_previous_scan.csv").exists()

--- a/plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts
+++ b/plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts
@@ -60,7 +60,12 @@ export class ScanDataRouter {
           );
           res.setHeader("Content-Type", "application/octet-stream");
           res.status(200).send(result);
-        } catch (error) {}
+        } catch (error) {
+          this.logger.error(
+            `Error when getting scan report: ${JSON.stringify(error)}`
+          );
+          next(error);
+        }
       }
     );
 

--- a/plugins/ui/apps/flow/package.json
+++ b/plugins/ui/apps/flow/package.json
@@ -11,7 +11,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode=development",
     "build:watch": "vite build --mode=development --watch",
-    "clean": "rimraf ./dist"
+    "clean": "rimraf ./dist",
+    "test:unit": "vitest"
   },
   "dependencies": {
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
@@ -60,7 +61,9 @@
     "webpack": "^5.76.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^5.2.1",
-    "@types/pako": "^2.0.3"
+    "@types/pako": "^2.0.3",
+    "jsdom": "^24.0.0",
+    "vitest": "^4.0.18"
   },
   "keywords": [],
   "author": "D4L",

--- a/plugins/ui/apps/flow/src/components/Dialog/ScanProgressDialog/ScanProgressDialog.tsx
+++ b/plugins/ui/apps/flow/src/components/Dialog/ScanProgressDialog/ScanProgressDialog.tsx
@@ -12,6 +12,10 @@ import {
   useLazyGetSourceSchemaByFlowRunIdQuery,
   useLazyGetScanReportQuery,
 } from "~/features/flow/slices";
+import {
+  classifyFlowState,
+  MAX_CONSECUTIVE_POLL_ERRORS,
+} from "~/features/flow/utils/scan-progress-state";
 
 export type CloseDialogType = "success" | "cancelled";
 import "./ScanProgressDialog.scss";
@@ -25,13 +29,6 @@ interface ScanProgressDialogProps {
   scanMetadata: ScanMetadata;
   onFormDataChange: (updates: { [field: string]: any }) => void;
 }
-
-const FLOW_STATE_MAP = {
-  Scheduled: 10,
-  Pending: 25,
-  Running: 50,
-  Completed: 100,
-};
 
 export const ScanProgressDialog: FC<ScanProgressDialogProps> = ({
   open,
@@ -47,6 +44,8 @@ export const ScanProgressDialog: FC<ScanProgressDialogProps> = ({
   const [scanCompleted, setScanCompleted] = useState(false);
   const [scanFailed, setScanFailed] = useState(false);
   const [log, setLog] = useState<string>("");
+  const [pollError, setPollError] = useState<string>("");
+  const pollErrorCountRef = useRef(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const updateNodeInternals = useUpdateNodeInternals();
   // setTableSourceHandles
@@ -62,6 +61,9 @@ export const ScanProgressDialog: FC<ScanProgressDialogProps> = ({
     setLog("");
     setProgress(0);
     setScanCompleted(false);
+    setScanFailed(false);
+    setPollError("");
+    pollErrorCountRef.current = 0;
   }, []);
 
   const handleClose = useCallback(
@@ -110,29 +112,40 @@ export const ScanProgressDialog: FC<ScanProgressDialogProps> = ({
     try {
       const status = await getFlowRunStatus(scanId).unwrap();
 
-      if (status.state_name === "Completed") {
+      pollErrorCountRef.current = 0;
+      setPollError("");
+
+      const {
+        terminal,
+        failed,
+        progress: statePercent,
+      } = classifyFlowState(status.state_name);
+
+      if (terminal) {
         setScanCompleted(true);
-        if (intervalRef.current) {
-          clearInterval(intervalRef.current);
-        }
-      } else if (
-        status.state_name === "Failed" ||
-        status.state_name === "Crashed"
-      ) {
-        setScanCompleted(true);
-        setScanFailed(true);
+        setScanFailed(failed);
         if (intervalRef.current) {
           clearInterval(intervalRef.current);
         }
       }
+
       setLog(status.state_name);
-      if (status.state_name in FLOW_STATE_MAP) {
-        setProgress(
-          FLOW_STATE_MAP[status.state_name as keyof typeof FLOW_STATE_MAP],
-        );
+      if (statePercent !== undefined) {
+        setProgress(statePercent);
       }
     } catch (e) {
+      pollErrorCountRef.current += 1;
       console.error("Failed to fetch scan progress", e);
+
+      if (pollErrorCountRef.current >= MAX_CONSECUTIVE_POLL_ERRORS) {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
+        setPollError(
+          "Lost contact with the scan job. It may still be running — " +
+            "close this dialog and check the flow run status.",
+        );
+      }
     }
   }, [scanId]);
 
@@ -142,7 +155,7 @@ export const ScanProgressDialog: FC<ScanProgressDialogProps> = ({
   }, []);
 
   useEffect(() => {
-    if (open && scanId !== "" && !scanCompleted) {
+    if (open && scanId !== "" && !scanCompleted && !pollError) {
       // Initial fetch
       fetchScanProgress();
 
@@ -154,7 +167,7 @@ export const ScanProgressDialog: FC<ScanProgressDialogProps> = ({
         }
       };
     }
-  }, [open, scanId, scanCompleted, fetchScanProgress]);
+  }, [open, scanId, scanCompleted, pollError, fetchScanProgress]);
 
   return (
     <Dialog
@@ -169,13 +182,13 @@ export const ScanProgressDialog: FC<ScanProgressDialogProps> = ({
           Scanning... Estimated time depends on selected database
         </div>
         <LinearProgress variant="determinate" value={progress} />
-        <div className="scan-progress-dialog__log">{log}</div>
+        <div className="scan-progress-dialog__log">{pollError || log}</div>
       </div>
       <div className="scan-progress-dialog__actions">
         <Button
           onClick={handleBack}
           variant="outlined"
-          disabled={!scanCompleted || loading}
+          disabled={loading}
         >
           Back
         </Button>

--- a/plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.test.ts
+++ b/plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import {
+  classifyFlowState,
+  MAX_CONSECUTIVE_POLL_ERRORS,
+} from "./scan-progress-state";
+
+describe("classifyFlowState", () => {
+  test("Completed is terminal and successful", () => {
+    expect(classifyFlowState("Completed")).toEqual({
+      terminal: true,
+      failed: false,
+      progress: 100,
+    });
+  });
+
+  test.each(["Failed", "Crashed", "Cancelled", "TimedOut"])(
+    "%s is terminal and failed",
+    (state) => {
+      const result = classifyFlowState(state);
+      expect(result.terminal).toBe(true);
+      expect(result.failed).toBe(true);
+    }
+  );
+
+  test.each(["Scheduled", "Pending", "Running", "Paused", "Cancelling"])(
+    "%s is not terminal",
+    (state) => {
+      const result = classifyFlowState(state);
+      expect(result.terminal).toBe(false);
+      expect(result.failed).toBe(false);
+    }
+  );
+
+  test("known in-progress states carry a progress value", () => {
+    expect(classifyFlowState("Pending").progress).toBe(25);
+    expect(classifyFlowState("Running").progress).toBe(50);
+  });
+
+  test("an unknown state is treated as non-terminal with no progress", () => {
+    expect(classifyFlowState("SomeFutureState")).toEqual({
+      terminal: false,
+      failed: false,
+      progress: undefined,
+    });
+  });
+
+  test("poll error tolerance is a small positive number", () => {
+    expect(MAX_CONSECUTIVE_POLL_ERRORS).toBeGreaterThan(0);
+    expect(MAX_CONSECUTIVE_POLL_ERRORS).toBeLessThanOrEqual(5);
+  });
+});

--- a/plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.ts
+++ b/plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure classification of Prefect flow-run state names for the Scan Data
+ * progress dialog. Kept dependency-free so it is unit-testable without a
+ * Redux store or a rendered component.
+ */
+
+export const FLOW_STATE_PROGRESS: Record<string, number> = {
+  Scheduled: 10,
+  Late: 10,
+  Pending: 25,
+  AwaitingRetry: 25,
+  Running: 50,
+  Retrying: 50,
+  Paused: 50,
+  Cancelling: 75,
+  Completed: 100,
+  Failed: 100,
+  Crashed: 100,
+  Cancelled: 100,
+  TimedOut: 100,
+};
+
+const TERMINAL_SUCCESS = "Completed";
+
+/**
+ * Prefect terminal failure states. The dialog previously handled only Failed
+ * and Crashed, so Cancelled and TimedOut runs left it polling forever.
+ */
+const TERMINAL_FAILURE = new Set(["Failed", "Crashed", "Cancelled", "TimedOut"]);
+
+/** Consecutive poll failures tolerated before the dialog gives up and reports. */
+export const MAX_CONSECUTIVE_POLL_ERRORS = 3;
+
+export interface ScanStateClassification {
+  terminal: boolean;
+  failed: boolean;
+  progress: number | undefined;
+}
+
+export function classifyFlowState(stateName: string): ScanStateClassification {
+  const progress = FLOW_STATE_PROGRESS[stateName];
+
+  if (stateName === TERMINAL_SUCCESS) {
+    return { terminal: true, failed: false, progress };
+  }
+  if (TERMINAL_FAILURE.has(stateName)) {
+    return { terminal: true, failed: true, progress };
+  }
+  return { terminal: false, failed: false, progress };
+}

--- a/plugins/ui/apps/flow/tsconfig.json
+++ b/plugins/ui/apps/flow/tsconfig.json
@@ -20,5 +20,5 @@
   },
   "files": ["src/lifecycles.tsx"],
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/plugins/ui/apps/flow/vitest.config.ts
+++ b/plugins/ui/apps/flow/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from "node:url";
+import { mergeConfig, defineConfig, configDefaults } from "vitest/config";
+import viteConfig from "./vite.config";
+
+// vite.config.ts exports a callback-form config, so it must be invoked with a
+// configEnv before merging — mergeConfig cannot merge a function directly.
+// Same constraint as apps/concept-mapping.
+export default defineConfig((configEnv) =>
+  mergeConfig(
+    viteConfig(configEnv),
+    defineConfig({
+      test: {
+        globals: true,
+        environment: "jsdom",
+        exclude: [...configDefaults.exclude],
+        root: fileURLToPath(new URL("./", import.meta.url)),
+      },
+    })
+  )
+);

--- a/plugins/ui/bun.lock
+++ b/plugins/ui/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@data2evidence/d2e-ui",
@@ -159,6 +160,7 @@
         "css-loader": "^6.7.1",
         "html-webpack-plugin": "^5.5.0",
         "interpolate-html-plugin": "^4.0.0",
+        "jsdom": "^24.0.0",
         "monaco-editor-webpack-plugin": "^7.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -168,6 +170,7 @@
         "terser-webpack-plugin": "^5.3.1",
         "ts-loader": "^9.2.8",
         "typescript": "^5.2.2",
+        "vitest": "^4.0.18",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^5.2.1",
@@ -7979,6 +7982,8 @@
 
     "flow/clean-webpack-plugin": ["clean-webpack-plugin@4.0.0", "", { "dependencies": { "del": "^4.1.1" }, "peerDependencies": { "webpack": ">=4.0.0 <6.0.0" } }, "sha512-WuWE1nyTNAyW5T7oNyys2EN0cfP2fdRxhxnIQWiAp0bMabPdHhoGxM8A6YL2GhqwgrPnnaemVE7nv5XJ2Fhh2w=="],
 
+    "flow/jsdom": ["jsdom@24.1.3", "", { "dependencies": { "cssstyle": "^4.0.1", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^4.1.4", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ=="],
+
     "flow/pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
 
     "flow/ts-loader": ["ts-loader@9.5.4", "", { "dependencies": { "chalk": "^4.1.0", "enhanced-resolve": "^5.0.0", "micromatch": "^4.0.0", "semver": "^7.3.4", "source-map": "^0.7.4" }, "peerDependencies": { "typescript": "*", "webpack": "^5.0.0" } }, "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ=="],
@@ -10683,6 +10688,22 @@
 
     "flat-cache/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "flow/jsdom/cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
+    "flow/jsdom/data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "flow/jsdom/html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "flow/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "flow/jsdom/tough-cookie": ["tough-cookie@4.1.4", "", { "dependencies": { "psl": "^1.1.33", "punycode": "^2.1.1", "universalify": "^0.2.0", "url-parse": "^1.5.3" } }, "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag=="],
+
+    "flow/jsdom/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "flow/jsdom/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "flow/jsdom/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
     "fork-ts-checker-webpack-plugin/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
     "fork-ts-checker-webpack-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
@@ -12583,6 +12604,16 @@
 
     "flat-cache/rimraf/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
+    "flow/jsdom/cssstyle/@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
+    "flow/jsdom/cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "flow/jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "flow/jsdom/tough-cookie/universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
+
+    "flow/jsdom/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
     "fork-ts-checker-webpack-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "gethue/vue/@vue/compiler-dom/@vue/compiler-core": ["@vue/compiler-core@3.2.0", "", { "dependencies": { "@babel/parser": "^7.12.0", "@babel/types": "^7.12.0", "@vue/shared": "3.2.0", "estree-walker": "^2.0.1", "source-map": "^0.6.1" } }, "sha512-+kfA4pisto26tcEh9Naf/qrizplYWnkBLHu3fX5Yu0c47RVBteVG3dHENFczl3Egwra+5NP5f3YuOgxK1ZMbNQ=="],
@@ -13346,6 +13377,8 @@
     "eslint-plugin-testing-library/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "flat-cache/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "flow/jsdom/cssstyle/@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "gethue/vue/@vue/compiler-dom/@vue/compiler-core/@babel/parser": ["@babel/parser@7.28.4", "", { "dependencies": { "@babel/types": "^7.28.4" }, "bin": "./bin/babel-parser.js" }, "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg=="],
 

--- a/services/alp-dataflow-gen-worker/Dockerfile
+++ b/services/alp-dataflow-gen-worker/Dockerfile
@@ -16,6 +16,14 @@
 # Trade-off carried over: pixi-cache hardlinks dedupe only within a stage;
 # light-group COPYs materialize full copies. Build-time wins over size here.
 
+# WhiteRabbit dist (Java) for data_transformation's white_rabbit_plugin.
+# Standalone stage, deliberately NOT part of the heavy-env FROM lineage, so
+# BuildKit pulls it concurrently and only the copied layer reaches the final
+# image. Pinned by digest: :master is a floating tag on a package last
+# published ~Jan 2025, and the plugin depends on d2e-only patches
+# (rabbitInAHat --generateWordReport) that upstream OHDSI/WhiteRabbit lacks.
+FROM ghcr.io/data2evidence/whiterabbit@sha256:bfebf252d3c69d1c9e5b195964f85732d539c23e68760e2c3d492a4a0265d124 AS whiterabbit_base
+
 FROM ubuntu:24.04 AS staging
 RUN apt-get update && apt-get install -y --no-install-recommends python3 \
     && rm -rf /var/lib/apt/lists/*
@@ -126,6 +134,11 @@ RUN pixi install --locked --manifest-path /opt/worker/pyproject.toml
 COPY services/alp-dataflow-gen-worker/run-flow.sh /app/
 COPY services/alp-dataflow-gen-worker/entrypoint.sh /entrypoint.sh
 COPY plugins/flows/drivers /app/inst/drivers/
+# white_rabbit_plugin resolves /app/whiterabbit (white_rabbit_plugin/types.py).
+# csvfiles is the working dir CSV scans download into and WhiteRabbit writes
+# ScanReport.xlsx into. No chown needed: this image has no USER directive.
+COPY --from=whiterabbit_base /dist /app/whiterabbit/dist
+RUN mkdir -p /app/whiterabbit/csvfiles
 RUN chmod 755 /app/run-flow.sh /app/provision-envs.sh /entrypoint.sh
 
 # Light groups from their parallel stages (baked warm cache: release plugins

--- a/trex/plans/2026-08-17-whiterabbit-scan-restore.md
+++ b/trex/plans/2026-08-17-whiterabbit-scan-restore.md
@@ -1,0 +1,1373 @@
+# White Rabbit Scan Restore Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use devx:subagent-driven-development (recommended) or devx:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore White Rabbit scans on `develop` by re-provisioning the WhiteRabbit dist into the dataflow-gen worker image, and make any future scan failure visible instead of presenting as an infinite spinner.
+
+**Architecture:** Four independent changes. **Fix A** re-adds a standalone `whiterabbit_base` OCI stage to the worker Dockerfile and copies `/dist` to `/app/whiterabbit/dist`, restoring the exact layout `white_rabbit_plugin/types.py` already hardcodes. **Fix C** makes the flow task self-sufficient (`mkdir -p`, fail fast on a missing dist) and clears the shared CSV working directory so repeat scans cannot inherit stale tables. **Fix D** stops the scan-report download handler swallowing errors. **Fix E** fixes the progress dialog so poll failures and all Prefect terminal states are surfaced and the user is never trapped in the modal.
+
+**Tech Stack:** Docker/BuildKit multi-stage, Python 3.12 + Prefect 3.6 + pytest (pixi-managed env), Deno + Express (white-rabbit function), React 18 + RTK Query + MUI + Vitest (flow UI app).
+
+**Spec:** `trex/specs/2026-08-17-whiterabbit-dist-restore-design.md`
+
+---
+
+## Ordering rationale — read before starting
+
+Tasks are ordered **D → E → C → A** deliberately, not by fix letter.
+
+Fix A is what restores scans. Landing it last means the observability fixes (D, E) can be
+verified against a **genuinely broken** system, which is the only cheap way to exercise the
+failure paths. Once Fix A lands, you would have to deliberately break the image to test them.
+
+Do not reorder without re-reading Task 12.
+
+## Corrections to the source notes — do not re-derive these
+
+Both attached notes claim the infinite "Pending" spinner is caused by
+`scan-data.router.ts`'s bare `catch (error) {}`. **That is wrong**, and it was verified wrong by
+endpoint tracing:
+
+- `ScanDataRouter` is mounted at `/scan-report` (`plugins/functions/white-rabbit/src/routes.ts:15`),
+  so Fix D's handler serves `GET /white-rabbit/api/scan-report/result-as-resource/:conversionId`.
+- That endpoint is called **only** from `handleSaveReport`
+  (`ScanProgressDialog.tsx:73-79`), behind a button that is `disabled={!scanCompleted || scanFailed}`.
+  It is unreachable until a scan has already succeeded.
+- The progress dialog polls a **different** endpoint: `getFlowRunStatus` →
+  `white-rabbit/results/{flowRunId}` on the `jobplugins` base
+  (`dataflow-slice.ts:319-329`), every 3 s.
+
+So Fix D fixes the *Save report* download failing silently (a real bug), and **Fix E** is what
+fixes the spinner. Keep both, but do not conflate them.
+
+## Scope decisions
+
+| Item | Decision |
+| --- | --- |
+| Fix A — worker Dockerfile OCI copy | **In scope** (Task 11) |
+| Fix C — mkdir + fail-fast | **In scope** (Task 5) |
+| Fix C2 — shared `csvfiles` cleanup | **In scope** (Task 7) — required for safety, see below |
+| Fix D — `next(error)` | **In scope** (Task 1) |
+| Fix E — progress dialog | **In scope** (Tasks 8-10), **flow app only** |
+| Legacy `apps/mapping` ScanProgressDialog | **Out of scope** — team chose flow app only |
+| Fix B / plugin-local provisioning | **Out of scope** — needs a `d2e-WhiteRabbit` release first |
+| Upstream `OHDSI/WhiteRabbit` migration | **Out of scope** — upstream lacks `--generateWordReport` |
+| `PIXI_PROJECT_ROOT` refactor of `types.py` | **Out of scope** — belongs with Fix B |
+| Custom Express error middleware | **Out of scope** — built-in handler terminates the request |
+| **`/app/downloads` regression** | **Out of scope — flagged, not fixed. See below.** |
+
+### Why `csvfiles` cleanup is in scope, not optional
+
+Verified chain:
+
+- `SupabaseStorageAPI.download_file_to_path` writes `Path(filepath) / filename`
+  (`plugins/flows/_shared_flow_utils/api/SupabaseStorageAPI.py:88`) — **flat, no node scoping**.
+  `node_id` only selects the remote object.
+- `tasks.py:165` passes the same `WHITERABBIT_CSV_DIR` for every node.
+- There is no cleanup anywhere in `download_files_from_supabase_storage`.
+- Scans run with `tables_to_scan="*"`, commented *"Scan all csv files in the working directory"*
+  (`tasks.py:52`).
+- The directory lives in an image layer, not a volume, so it persists for the container's life.
+
+Consequence: every scan after the first includes CSVs left by prior scans **and by other ETL
+nodes**, and those stale tables propagate into `scannedSchema` / "Link tables". This has been
+unobservable since 18 Jul 2026 only because no scan completes at all — **Fix A re-exposes it**,
+and it would silently corrupt the Task 12 verification (first scan clean, second scan wrong).
+
+### `/app/downloads` — explicit out-of-scope note
+
+`a96fde35` also deleted `mkdir -p /app/downloads`. Nothing in the tree recreates it, and
+`plugins/flows/data_transformation/dataflow_ui_plugin/nodeutils/csvutils.py:60-62` still writes
+there with no `mkdir`:
+
+```python
+downloads_dir = "/app/downloads"
+csv_file_path = supabase_api.download_file_to_path(node_id, filename, downloads_dir)
+```
+
+Same failure class, same root-cause commit, **different plugin** (the dataflow-UI CSV node).
+`SupabaseStorageAPI.py:77` and `StrategusResultsStorageAPI.py:75` also default to
+`/app/downloads`; Strategus passes an explicit `work_dir` and is unaffected.
+
+**Recommendation: file this as a separate issue, do not fold it into this PR.** Reasoning:
+
+1. It is a different plugin and a different user-facing flow (dataflow CSV node, not White Rabbit),
+   so it shares no code path with Fixes A/C/D/E and cannot be verified by Task 12's scan.
+2. Its reachability has not been assessed — it is unknown whether the affected node path is
+   exercised in practice, which changes its severity and therefore its urgency.
+3. Bundling it widens this PR's blast radius from "restore one broken feature" to "audit every
+   `/app/*` directory the deleted Dockerfile used to create", which needs its own sweep.
+
+**This is a recommendation, not a decision.** If the team wants it folded in, it is a ~3-line
+change (`Path(downloads_dir).mkdir(parents=True, exist_ok=True)` plus a test) and belongs as a
+new task between Task 7 and Task 8.
+
+---
+
+## File Structure
+
+**Modified:**
+
+| File | Responsibility after change |
+| --- | --- |
+| `plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts` | Scan-report HTTP routes; all three handlers now propagate errors |
+| `plugins/flows/data_transformation/pyproject.toml` | Adds a `dev` dependency-group with pytest (matches sibling plugins) |
+| `plugins/flows/data_transformation/pixi.lock` | Regenerated by `pixi lock` |
+| `plugins/flows/data_transformation/white_rabbit_plugin/paths.py` | **NEW** — pure filesystem-precondition helpers, no Prefect import |
+| `plugins/flows/data_transformation/white_rabbit_plugin/tasks.py` | Flow tasks; delegates filesystem preconditions to `paths.py` |
+| `plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.ts` | **NEW** — pure Prefect-state classifier |
+| `plugins/ui/apps/flow/src/components/Dialog/ScanProgressDialog/ScanProgressDialog.tsx` | Progress dialog; surfaces poll errors, handles all terminal states, never traps the user |
+| `plugins/ui/apps/flow/vitest.config.ts` | **NEW** — test config |
+| `plugins/ui/apps/flow/package.json` | Adds `test:unit` script + test devDependencies |
+| `services/alp-dataflow-gen-worker/Dockerfile` | Worker image; provisions the WhiteRabbit dist |
+
+**New tests:**
+
+- `plugins/flows/data_transformation/white_rabbit_plugin/tests/__init__.py`
+- `plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py`
+- `plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.test.ts`
+
+Rationale for the two new pure modules: `tasks.py` imports Prefect at module load, and
+`ScanProgressDialog.tsx` needs a Redux store + MUI to render. Extracting the decision logic into
+dependency-free modules makes the important behaviour unit-testable in milliseconds without
+harnessing either framework.
+
+---
+
+## Task 1: Fix D — propagate errors from the scan-report download handler
+
+**Files:**
+- Modify: `plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts:63`
+
+This is a Deno package with no test harness and it is not in the
+`plugin-function-tests.yml` matrix (which covers only `strategus-analysis`, `jobplugins`,
+`dataset`). Adding Deno test infrastructure for a two-line change is not justified; verification
+is `deno check` plus the Task 12 manual step.
+
+- [ ] **Step 1: Read the current handler to confirm the exact text**
+
+Run: `sed -n '44,66p' plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts`
+
+Expected: the handler ends with `} catch (error) {}` on line 63.
+
+- [ ] **Step 2: Replace the empty catch**
+
+Replace exactly:
+
+```ts
+        } catch (error) {}
+```
+
+with:
+
+```ts
+        } catch (error) {
+          this.logger.error(
+            `Error when getting scan report: ${JSON.stringify(error)}`
+          );
+          next(error);
+        }
+```
+
+This matches the convention of the two sibling handlers in the same file (`:39-41` and
+`:85-89`). `next` is already in the handler signature and was simply unused.
+
+- [ ] **Step 3: Type-check the package**
+
+Run: `cd plugins/functions/white-rabbit && deno check index.ts`
+Expected: no errors. (If pre-existing unrelated errors appear, confirm they also appear on
+`git stash` — do not fix them here.)
+
+- [ ] **Step 4: Confirm no other empty catches remain in this file**
+
+Run: `grep -n "catch (error) {}" plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts
+git commit -m "fix(white-rabbit): propagate scan report download errors instead of swallowing them"
+```
+
+---
+
+## Task 2: Add pytest to the data_transformation pixi environment
+
+**Files:**
+- Modify: `plugins/flows/data_transformation/pyproject.toml`
+- Modify: `plugins/flows/data_transformation/pixi.lock` (generated)
+
+`data_transformation` is the only flow plugin with committed tests
+(`dataflow_ui_plugin/tests/`) but **no pytest dependency** — the `pytest` strings in its
+`pixi.lock` are all optional-extra metadata (`extra == 'dev'`), not installed packages. Sibling
+plugins (`base`, `hades`, `data_management`, `i2b2`, `loyalty_score`, `search_embedding`) all
+declare it the same way, so follow that convention.
+
+- [ ] **Step 1: Confirm pytest is genuinely absent**
+
+Run: `grep -nE "^\s*\"pytest" plugins/flows/data_transformation/pyproject.toml`
+Expected: no output.
+
+Run: `grep -n "dependency-groups" plugins/flows/base/pyproject.toml`
+Expected: shows the section to mirror (`base/pyproject.toml:40`).
+
+- [ ] **Step 2: Add the dependency group**
+
+In `plugins/flows/data_transformation/pyproject.toml`, insert immediately **before** the
+`[tool.pixi.workspace]` section (currently line 94):
+
+```toml
+[dependency-groups]
+dev = [
+    "pytest==9.0.3",
+]
+
+```
+
+Version pinned to `9.0.3` to match every sibling plugin.
+
+- [ ] **Step 3: Regenerate the lockfile**
+
+Run: `pixi lock --manifest-path plugins/flows/data_transformation/pyproject.toml`
+Expected: `pixi.lock` updated, exit 0.
+
+This is mandatory: `.github/workflows/_pixi-lock-check.yml` runs
+`pixi lock --check` for `plugins/flows/data_transformation` and fails the build if
+`pyproject.toml` changed without regenerating the lock.
+
+- [ ] **Step 4: Verify the lock check passes and no sdists were introduced**
+
+Run: `pixi lock --check --manifest-path plugins/flows/data_transformation/pyproject.toml`
+Expected: exit 0, reports the lock is up to date.
+
+Run:
+```bash
+grep -E 'pypi: https.*\.tar\.gz' plugins/flows/data_transformation/pixi.lock | grep -vE 'lzstring-|pandasql-'
+```
+Expected: no output. (Any hit fails CI — flow envs must stay binary-only.)
+
+- [ ] **Step 5: Confirm pytest now resolves in the env**
+
+Run: `pixi run --manifest-path plugins/flows/data_transformation/pyproject.toml python -m pytest --version`
+Expected: `pytest 9.0.3`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/flows/data_transformation/pyproject.toml plugins/flows/data_transformation/pixi.lock
+git commit -m "chore(data_transformation): add pytest to the plugin dev dependency group"
+```
+
+---
+
+## Task 3: Fix C — write the failing test for filesystem preconditions
+
+**Files:**
+- Create: `plugins/flows/data_transformation/white_rabbit_plugin/tests/__init__.py`
+- Create: `plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py`
+
+The helper goes in a new `paths.py` with **no Prefect import**, so the test does not need
+`prefect_test_harness`. Do not put these assertions in a test that imports `tasks.py`.
+
+- [ ] **Step 1: Create the test package marker**
+
+Create `plugins/flows/data_transformation/white_rabbit_plugin/tests/__init__.py` as an empty file.
+
+```bash
+touch plugins/flows/data_transformation/white_rabbit_plugin/tests/__init__.py
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py`:
+
+```python
+import pytest
+
+from white_rabbit_plugin.paths import (
+    ensure_whiterabbit_dirs,
+    require_whiterabbit_dist,
+    clear_csv_working_dir,
+)
+
+
+def test_ensure_creates_both_directories(tmp_path):
+    base = tmp_path / "whiterabbit"
+    csv_dir = base / "csvfiles"
+
+    ensure_whiterabbit_dirs(str(base), str(csv_dir))
+
+    assert base.is_dir()
+    assert csv_dir.is_dir()
+
+
+def test_ensure_is_idempotent(tmp_path):
+    base = tmp_path / "whiterabbit"
+    csv_dir = base / "csvfiles"
+
+    ensure_whiterabbit_dirs(str(base), str(csv_dir))
+    ensure_whiterabbit_dirs(str(base), str(csv_dir))
+
+    assert csv_dir.is_dir()
+
+
+def test_require_dist_raises_runtime_error_when_missing(tmp_path):
+    missing_bin = tmp_path / "whiterabbit" / "dist" / "bin"
+
+    with pytest.raises(RuntimeError) as excinfo:
+        require_whiterabbit_dist(str(missing_bin))
+
+    # The whole point of this fix: name the dist, not config.ini.
+    assert str(missing_bin) in str(excinfo.value)
+    assert "config.ini" not in str(excinfo.value)
+
+
+def test_require_dist_does_not_raise_when_present(tmp_path):
+    bin_dir = tmp_path / "whiterabbit" / "dist" / "bin"
+    bin_dir.mkdir(parents=True)
+
+    require_whiterabbit_dist(str(bin_dir))
+
+
+def test_clear_csv_working_dir_removes_only_csv_files(tmp_path):
+    csv_dir = tmp_path / "csvfiles"
+    csv_dir.mkdir()
+    (csv_dir / "stale_one.csv").write_text("a,b\n1,2\n")
+    (csv_dir / "stale_two.CSV").write_text("a,b\n3,4\n")
+    (csv_dir / "ScanReport.xlsx").write_bytes(b"not a csv")
+
+    removed = clear_csv_working_dir(str(csv_dir))
+
+    assert removed == 2
+    assert not (csv_dir / "stale_one.csv").exists()
+    assert not (csv_dir / "stale_two.CSV").exists()
+    assert (csv_dir / "ScanReport.xlsx").exists()
+
+
+def test_clear_csv_working_dir_tolerates_missing_dir(tmp_path):
+    assert clear_csv_working_dir(str(tmp_path / "nope")) == 0
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run:
+```bash
+cd plugins/flows/data_transformation && \
+  pixi run python -m pytest white_rabbit_plugin/tests/test_paths.py -v
+```
+Expected: FAIL — `ModuleNotFoundError: No module named 'white_rabbit_plugin.paths'`
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add plugins/flows/data_transformation/white_rabbit_plugin/tests/
+git commit -m "test(white_rabbit_plugin): add failing tests for filesystem preconditions"
+```
+
+---
+
+## Task 4: Fix C — implement `paths.py`
+
+**Files:**
+- Create: `plugins/flows/data_transformation/white_rabbit_plugin/paths.py`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `plugins/flows/data_transformation/white_rabbit_plugin/paths.py`:
+
+```python
+"""Filesystem preconditions for the WhiteRabbit plugin.
+
+Deliberately free of Prefect imports so these can be unit-tested without a
+flow-run harness. The WhiteRabbit dist is provisioned into the
+dataflow-gen-worker image (see services/alp-dataflow-gen-worker/Dockerfile);
+these helpers make the flow tasks self-sufficient and make a misprovisioned
+worker report itself clearly.
+"""
+
+from pathlib import Path
+
+
+def ensure_whiterabbit_dirs(dir_path: str, csv_dir: str) -> None:
+    """Create the WhiteRabbit working directories if they are absent.
+
+    open(path, "w") creates a file but never its parent, which is why a missing
+    directory previously surfaced as a FileNotFoundError naming config.ini.
+    """
+    Path(dir_path).mkdir(parents=True, exist_ok=True)
+    Path(csv_dir).mkdir(parents=True, exist_ok=True)
+
+
+def require_whiterabbit_dist(bin_path: str) -> None:
+    """Fail fast, and honestly, when the WhiteRabbit distribution is absent."""
+    if not Path(bin_path).exists():
+        raise RuntimeError(
+            f"WhiteRabbit distribution not found at {bin_path}. "
+            "The dist is provisioned into the dataflow-gen-worker image from "
+            "the whiterabbit OCI stage; a worker built without it cannot run "
+            "scans."
+        )
+
+
+def clear_csv_working_dir(csv_dir: str) -> int:
+    """Remove CSV files left in the shared scan working directory.
+
+    Every node's CSVs are downloaded into this one flat directory and scans run
+    with tables_to_scan="*", so without this a scan would report tables
+    belonging to previous scans and to other ETL nodes. Only *.csv is removed:
+    the directory is also the working folder WhiteRabbit writes ScanReport.xlsx
+    into.
+
+    Returns the number of files removed.
+    """
+    directory = Path(csv_dir)
+    if not directory.is_dir():
+        return 0
+
+    removed = 0
+    for entry in directory.iterdir():
+        if entry.is_file() and entry.suffix.lower() == ".csv":
+            entry.unlink()
+            removed += 1
+    return removed
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run:
+```bash
+cd plugins/flows/data_transformation && \
+  pixi run python -m pytest white_rabbit_plugin/tests/test_paths.py -v
+```
+Expected: PASS — 6 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/flows/data_transformation/white_rabbit_plugin/paths.py
+git commit -m "feat(white_rabbit_plugin): add filesystem precondition helpers"
+```
+
+---
+
+## Task 5: Fix C — wire preconditions into `create_white_rabbit_settings`
+
+**Files:**
+- Modify: `plugins/flows/data_transformation/white_rabbit_plugin/tasks.py:13` (imports)
+- Modify: `plugins/flows/data_transformation/white_rabbit_plugin/tasks.py:56-60` (before the write)
+
+- [ ] **Step 1: Add the import**
+
+After the existing line 13:
+
+```python
+from .types import WHITERABBIT_BIN_PATH, WHITERABBIT_CSV_DIR, WHITERABBIT_DIR_PATH  
+```
+
+add:
+
+```python
+from .paths import ensure_whiterabbit_dirs, require_whiterabbit_dist
+```
+
+- [ ] **Step 2: Insert the preconditions before the config write**
+
+Locate this block (currently `tasks.py:56-61`):
+
+```python
+    config_path = f"{WHITERABBIT_DIR_PATH}/config.ini"
+
+    logger.debug(f"Writing file config.ini to {config_path}...")
+    
+    with open(config_path, "w") as configfile:
+        config.write(configfile)
+```
+
+Replace it with:
+
+```python
+    config_path = f"{WHITERABBIT_DIR_PATH}/config.ini"
+
+    ensure_whiterabbit_dirs(WHITERABBIT_DIR_PATH, WHITERABBIT_CSV_DIR)
+    require_whiterabbit_dist(WHITERABBIT_BIN_PATH)
+
+    logger.debug(f"Writing file config.ini to {config_path}...")
+    
+    with open(config_path, "w") as configfile:
+        config.write(configfile)
+```
+
+Order matters: create the directories first (both are needed —
+`INISettings.working_folder` at `types.py:71-74` resolves to `WHITERABBIT_CSV_DIR` for
+`SCAN_REPORT_FILES` and `WHITERABBIT_DIR_PATH` for `SCAN_REPORT_DB`), then fail fast on a
+missing dist **before** writing any file.
+
+- [ ] **Step 3: Verify the module still imports**
+
+Run:
+```bash
+cd plugins/flows/data_transformation && \
+  pixi run python -c "import white_rabbit_plugin.tasks; print('ok')"
+```
+Expected: `ok`
+
+- [ ] **Step 4: Re-run the paths tests (regression check)**
+
+Run:
+```bash
+cd plugins/flows/data_transformation && \
+  pixi run python -m pytest white_rabbit_plugin/tests/ -v
+```
+Expected: PASS — 6 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/flows/data_transformation/white_rabbit_plugin/tasks.py
+git commit -m "fix(white_rabbit_plugin): create working dirs and fail fast on a missing dist"
+```
+
+---
+
+## Task 6: Fix C2 — write the failing test for CSV cleanup wiring
+
+**Files:**
+- Modify: `plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py`
+
+`clear_csv_working_dir` already exists and is tested (Task 3/4). This task tests that the
+download task actually *calls* it. `download_files_from_supabase_storage` is a Prefect `@task`,
+so call its `.fn` attribute to invoke the undecorated function without a flow harness.
+
+- [ ] **Step 1: Append the failing test**
+
+Add to the end of `plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py`:
+
+```python
+def test_download_task_clears_stale_csvs_before_downloading(tmp_path, monkeypatch):
+    """A scan must not inherit CSVs from a previous scan or another node."""
+    from white_rabbit_plugin import tasks
+
+    csv_dir = tmp_path / "csvfiles"
+    csv_dir.mkdir()
+    (csv_dir / "from_a_previous_scan.csv").write_text("a\n1\n")
+
+    monkeypatch.setattr(tasks, "WHITERABBIT_CSV_DIR", str(csv_dir))
+
+    downloaded = []
+
+    class FakeSupabaseAPI:
+        def list_files(self, node_id):
+            return [{"name": "current.csv", "type": "CSV"}]
+
+        def download_file_to_path(self, node_id, filename, filepath):
+            downloaded.append((filename, filepath))
+            (csv_dir / filename).write_text("b\n2\n")
+
+    result = tasks.download_files_from_supabase_storage.fn(
+        "node-1", FakeSupabaseAPI()
+    )
+
+    assert result is True
+    assert downloaded == [("current.csv", str(csv_dir))]
+    assert (csv_dir / "current.csv").exists()
+    assert not (csv_dir / "from_a_previous_scan.csv").exists()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+```bash
+cd plugins/flows/data_transformation && \
+  pixi run python -m pytest white_rabbit_plugin/tests/test_paths.py::test_download_task_clears_stale_csvs_before_downloading -v
+```
+Expected: FAIL — `assert not (csv_dir / "from_a_previous_scan.csv").exists()` fails, because the
+stale file is still present.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add plugins/flows/data_transformation/white_rabbit_plugin/tests/test_paths.py
+git commit -m "test(white_rabbit_plugin): add failing test for stale CSV cleanup"
+```
+
+---
+
+## Task 7: Fix C2 — clear the CSV working directory before downloading
+
+**Files:**
+- Modify: `plugins/flows/data_transformation/white_rabbit_plugin/tasks.py:13` (imports)
+- Modify: `plugins/flows/data_transformation/white_rabbit_plugin/tasks.py:149-170` (`download_files_from_supabase_storage`)
+
+- [ ] **Step 1: Extend the import added in Task 5**
+
+Change:
+
+```python
+from .paths import ensure_whiterabbit_dirs, require_whiterabbit_dist
+```
+
+to:
+
+```python
+from .paths import (
+    clear_csv_working_dir,
+    ensure_whiterabbit_dirs,
+    require_whiterabbit_dist,
+)
+```
+
+- [ ] **Step 2: Clear the directory before the download loop**
+
+In `download_files_from_supabase_storage`, locate:
+
+```python
+    logger = get_run_logger()
+    files_uploaded = supabase_api.list_files(node_id)
+```
+
+Replace with:
+
+```python
+    logger = get_run_logger()
+
+    # Every node downloads into this one flat directory and the scan runs with
+    # tables_to_scan="*", so leftovers from a previous scan (or another node)
+    # would silently appear as extra tables in this scan's report.
+    removed = clear_csv_working_dir(WHITERABBIT_CSV_DIR)
+    if removed:
+        logger.info(f"Removed {removed} stale CSV file(s) from {WHITERABBIT_CSV_DIR}")
+
+    files_uploaded = supabase_api.list_files(node_id)
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run:
+```bash
+cd plugins/flows/data_transformation && \
+  pixi run python -m pytest white_rabbit_plugin/tests/ -v
+```
+Expected: PASS — 7 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/flows/data_transformation/white_rabbit_plugin/tasks.py
+git commit -m "fix(white_rabbit_plugin): clear stale CSVs before a file scan"
+```
+
+---
+
+## Task 8: Fix E — add Vitest to the flow app
+
+**Files:**
+- Create: `plugins/ui/apps/flow/vitest.config.ts`
+- Modify: `plugins/ui/apps/flow/package.json`
+
+The flow app has no test runner. `apps/concept-mapping` is the React precedent to copy — and
+critically, its `vitest.config.ts` carries a comment explaining that a **callback-form**
+`vite.config.ts` must be invoked with a `configEnv` before merging. The flow app's
+`vite.config.ts` is also callback-form (`defineConfig(({ command, mode }) => ...)`), so use the
+concept-mapping shape, **not** the `apps/jobs` shape.
+
+- [ ] **Step 1: Create the Vitest config**
+
+Create `plugins/ui/apps/flow/vitest.config.ts`:
+
+```ts
+import { fileURLToPath } from "node:url";
+import { mergeConfig, defineConfig, configDefaults } from "vitest/config";
+import viteConfig from "./vite.config";
+
+// vite.config.ts exports a callback-form config, so it must be invoked with a
+// configEnv before merging — mergeConfig cannot merge a function directly.
+// Same constraint as apps/concept-mapping.
+export default defineConfig((configEnv) =>
+  mergeConfig(
+    viteConfig(configEnv),
+    defineConfig({
+      test: {
+        globals: true,
+        environment: "jsdom",
+        exclude: [...configDefaults.exclude],
+        root: fileURLToPath(new URL("./", import.meta.url)),
+      },
+    })
+  )
+);
+```
+
+No `setupFiles` entry: the tests added in this plan are pure-logic tests with no DOM assertions,
+so `@testing-library/jest-dom` is not needed.
+
+- [ ] **Step 2: Add the test script**
+
+In `plugins/ui/apps/flow/package.json`, in `"scripts"`, after the `"clean"` entry, add:
+
+```json
+    "test:unit": "vitest"
+```
+
+Remember to add a comma to the preceding `"clean"` line.
+
+- [ ] **Step 3: Add the test devDependencies**
+
+In `plugins/ui/apps/flow/package.json`, in `"devDependencies"`, add:
+
+```json
+    "jsdom": "^24.0.0",
+    "vitest": "^4.0.18",
+```
+
+Versions match `apps/concept-mapping` so the workspace resolves a single copy.
+
+- [ ] **Step 4: Install and verify the runner starts**
+
+Run: `cd plugins/ui && bun install`
+Expected: completes without errors.
+
+Run: `cd plugins/ui/apps/flow && bunx vitest run`
+Expected: exits reporting "No test files found". That is success — the runner is wired up.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/ui/apps/flow/vitest.config.ts plugins/ui/apps/flow/package.json plugins/ui/bun.lockb plugins/ui/package.json
+git commit -m "chore(flow-ui): add vitest to the flow app"
+```
+
+(If `bun install` did not modify `plugins/ui/bun.lockb` or `plugins/ui/package.json`, drop those
+paths from the `git add`.)
+
+---
+
+## Task 9: Fix E — write the failing test for the Prefect state classifier
+
+**Files:**
+- Create: `plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.test.ts`
+
+The dialog currently treats only `Completed`, `Failed`, and `Crashed` as terminal
+(`ScanProgressDialog.tsx:113-127`). Prefect also produces `Cancelled` and `TimedOut`, which
+today poll forever.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import {
+  classifyFlowState,
+  MAX_CONSECUTIVE_POLL_ERRORS,
+} from "./scan-progress-state";
+
+describe("classifyFlowState", () => {
+  test("Completed is terminal and successful", () => {
+    expect(classifyFlowState("Completed")).toEqual({
+      terminal: true,
+      failed: false,
+      progress: 100,
+    });
+  });
+
+  test.each(["Failed", "Crashed", "Cancelled", "TimedOut"])(
+    "%s is terminal and failed",
+    (state) => {
+      const result = classifyFlowState(state);
+      expect(result.terminal).toBe(true);
+      expect(result.failed).toBe(true);
+    }
+  );
+
+  test.each(["Scheduled", "Pending", "Running", "Paused", "Cancelling"])(
+    "%s is not terminal",
+    (state) => {
+      const result = classifyFlowState(state);
+      expect(result.terminal).toBe(false);
+      expect(result.failed).toBe(false);
+    }
+  );
+
+  test("known in-progress states carry a progress value", () => {
+    expect(classifyFlowState("Pending").progress).toBe(25);
+    expect(classifyFlowState("Running").progress).toBe(50);
+  });
+
+  test("an unknown state is treated as non-terminal with no progress", () => {
+    expect(classifyFlowState("SomeFutureState")).toEqual({
+      terminal: false,
+      failed: false,
+      progress: undefined,
+    });
+  });
+
+  test("poll error tolerance is a small positive number", () => {
+    expect(MAX_CONSECUTIVE_POLL_ERRORS).toBeGreaterThan(0);
+    expect(MAX_CONSECUTIVE_POLL_ERRORS).toBeLessThanOrEqual(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd plugins/ui/apps/flow && bunx vitest run src/features/flow/utils/scan-progress-state.test.ts`
+Expected: FAIL — cannot resolve `./scan-progress-state`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.test.ts
+git commit -m "test(flow-ui): add failing tests for Prefect scan state classification"
+```
+
+---
+
+## Task 10: Fix E — implement the state classifier
+
+**Files:**
+- Create: `plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+Create `plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.ts`:
+
+```ts
+/**
+ * Pure classification of Prefect flow-run state names for the Scan Data
+ * progress dialog. Kept dependency-free so it is unit-testable without a
+ * Redux store or a rendered component.
+ */
+
+export const FLOW_STATE_PROGRESS: Record<string, number> = {
+  Scheduled: 10,
+  Late: 10,
+  Pending: 25,
+  AwaitingRetry: 25,
+  Running: 50,
+  Retrying: 50,
+  Paused: 50,
+  Cancelling: 75,
+  Completed: 100,
+  Failed: 100,
+  Crashed: 100,
+  Cancelled: 100,
+  TimedOut: 100,
+};
+
+const TERMINAL_SUCCESS = "Completed";
+
+/**
+ * Prefect terminal failure states. The dialog previously handled only Failed
+ * and Crashed, so Cancelled and TimedOut runs left it polling forever.
+ */
+const TERMINAL_FAILURE = new Set([
+  "Failed",
+  "Crashed",
+  "Cancelled",
+  "TimedOut",
+]);
+
+/** Consecutive poll failures tolerated before the dialog gives up and reports. */
+export const MAX_CONSECUTIVE_POLL_ERRORS = 3;
+
+export interface ScanStateClassification {
+  terminal: boolean;
+  failed: boolean;
+  progress: number | undefined;
+}
+
+export function classifyFlowState(stateName: string): ScanStateClassification {
+  const progress = FLOW_STATE_PROGRESS[stateName];
+
+  if (stateName === TERMINAL_SUCCESS) {
+    return { terminal: true, failed: false, progress };
+  }
+  if (TERMINAL_FAILURE.has(stateName)) {
+    return { terminal: true, failed: true, progress };
+  }
+  return { terminal: false, failed: false, progress };
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+Run: `cd plugins/ui/apps/flow && bunx vitest run src/features/flow/utils/scan-progress-state.test.ts`
+Expected: PASS — all tests green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state.ts
+git commit -m "feat(flow-ui): add Prefect scan state classifier"
+```
+
+---
+
+## Task 11: Fix E — make the progress dialog surface failures and never trap the user
+
+**Files:**
+- Modify: `plugins/ui/apps/flow/src/components/Dialog/ScanProgressDialog/ScanProgressDialog.tsx`
+
+Four defects being fixed, all verified in the current file:
+
+1. `catch (e) { console.error(...) }` at `:134-136` swallows poll errors; the interval keeps
+   firing forever with no user-visible change.
+2. Only `Completed`/`Failed`/`Crashed` are terminal (`:113-127`).
+3. `Back` is `disabled={!scanCompleted || loading}` (`:178`), so when polling errors the user
+   cannot leave the modal at all.
+4. `log` shows the raw `state_name` and goes stale on an unmapped state.
+
+- [ ] **Step 1: Replace the local progress map with the shared classifier**
+
+Delete this block (currently `:29-34`):
+
+```tsx
+const FLOW_STATE_MAP = {
+  Scheduled: 10,
+  Pending: 25,
+  Running: 50,
+  Completed: 100,
+};
+```
+
+Add to the import block, after the `useLazyGetScanReportQuery` import group:
+
+```tsx
+import {
+  classifyFlowState,
+  MAX_CONSECUTIVE_POLL_ERRORS,
+} from "~/features/flow/utils/scan-progress-state";
+```
+
+- [ ] **Step 2: Add poll-error state**
+
+After the existing declaration:
+
+```tsx
+  const [log, setLog] = useState<string>("");
+```
+
+add:
+
+```tsx
+  const [pollError, setPollError] = useState<string>("");
+  const pollErrorCountRef = useRef(0);
+```
+
+- [ ] **Step 3: Reset the new state in `handleClear`**
+
+Change `handleClear` from:
+
+```tsx
+  const handleClear = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    setLog("");
+    setProgress(0);
+    setScanCompleted(false);
+  }, []);
+```
+
+to:
+
+```tsx
+  const handleClear = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+    setLog("");
+    setProgress(0);
+    setScanCompleted(false);
+    setScanFailed(false);
+    setPollError("");
+    pollErrorCountRef.current = 0;
+  }, []);
+```
+
+`setScanFailed(false)` is added because the old `handleClear` left `scanFailed` set, so
+re-opening the dialog after a failed scan kept "Save report" and "Link tables" disabled.
+
+- [ ] **Step 4: Rewrite `fetchScanProgress`**
+
+Replace the whole callback (currently `:109-137`) with:
+
+```tsx
+  const fetchScanProgress = useCallback(async () => {
+    try {
+      const status = await getFlowRunStatus(scanId).unwrap();
+
+      pollErrorCountRef.current = 0;
+      setPollError("");
+
+      const { terminal, failed, progress: statePercent } = classifyFlowState(
+        status.state_name,
+      );
+
+      if (terminal) {
+        setScanCompleted(true);
+        setScanFailed(failed);
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
+      }
+
+      setLog(status.state_name);
+      if (statePercent !== undefined) {
+        setProgress(statePercent);
+      }
+    } catch (e) {
+      pollErrorCountRef.current += 1;
+      console.error("Failed to fetch scan progress", e);
+
+      if (pollErrorCountRef.current >= MAX_CONSECUTIVE_POLL_ERRORS) {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
+        setPollError(
+          "Lost contact with the scan job. It may still be running — " +
+            "close this dialog and check the flow run status.",
+        );
+      }
+    }
+  }, [scanId]);
+```
+
+A single transient failure no longer aborts the dialog; three consecutive ones stop the polling
+and say so. Note the interval is **not** restarted after `pollError` — the user gets an explicit
+exit rather than an indefinite retry.
+
+- [ ] **Step 5: Surface the error and stop trapping the user**
+
+Change the log line (currently `:172`) from:
+
+```tsx
+        <div className="scan-progress-dialog__log">{log}</div>
+```
+
+to:
+
+```tsx
+        <div className="scan-progress-dialog__log">{pollError || log}</div>
+```
+
+Change the `Back` button (currently `:174-180`) from:
+
+```tsx
+        <Button
+          onClick={handleBack}
+          variant="outlined"
+          disabled={!scanCompleted || loading}
+        >
+          Back
+        </Button>
+```
+
+to:
+
+```tsx
+        <Button
+          onClick={handleBack}
+          variant="outlined"
+          disabled={loading}
+        >
+          Back
+        </Button>
+```
+
+Back is now always available unless a "Link tables" request is genuinely in flight. This is the
+fix for "cannot be dismissed with Escape; only a page reload escapes it".
+
+- [ ] **Step 6: Stop re-arming the interval after a poll error**
+
+Change the polling effect (currently `:144-157`) guard from:
+
+```tsx
+    if (open && scanId !== "" && !scanCompleted) {
+```
+
+to:
+
+```tsx
+    if (open && scanId !== "" && !scanCompleted && !pollError) {
+```
+
+and add `pollError` to the dependency array, so it reads:
+
+```tsx
+  }, [open, scanId, scanCompleted, pollError, fetchScanProgress]);
+```
+
+Without this, `fetchScanProgress` changing identity would restart the interval that the catch
+block just cleared.
+
+- [ ] **Step 7: Verify the classifier tests still pass and types check**
+
+Run: `cd plugins/ui/apps/flow && bunx vitest run`
+Expected: PASS — all tests green.
+
+Run: `cd plugins/ui/apps/flow && bunx tsc --noEmit -p tsconfig.json`
+Expected: no new errors. If pre-existing unrelated errors appear, confirm they also appear on
+`git stash` — do not fix them here.
+
+- [ ] **Step 8: Verify the dead local map is gone**
+
+Run: `grep -n "FLOW_STATE_MAP" plugins/ui/apps/flow/src/components/Dialog/ScanProgressDialog/ScanProgressDialog.tsx`
+Expected: no output.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add plugins/ui/apps/flow/src/components/Dialog/ScanProgressDialog/ScanProgressDialog.tsx
+git commit -m "fix(flow-ui): surface scan poll failures and stop trapping users in the dialog"
+```
+
+---
+
+## Task 12: Fix A — restore the WhiteRabbit dist in the worker image
+
+**Files:**
+- Modify: `services/alp-dataflow-gen-worker/Dockerfile`
+
+Do this **after** Tasks 1-11 so the observability fixes were exercised against a broken system.
+
+- [ ] **Step 1: Add the source stage**
+
+Insert immediately **before** the existing line 19 (`FROM ubuntu:24.04 AS staging`):
+
+```dockerfile
+# WhiteRabbit dist (Java) for data_transformation's white_rabbit_plugin.
+# Standalone stage, deliberately NOT part of the heavy-env FROM lineage, so
+# BuildKit pulls it concurrently and only the copied layer reaches the final
+# image. Pinned by digest: :master is a floating tag on a package last
+# published ~Jan 2025, and the plugin depends on d2e-only patches
+# (rabbitInAHat --generateWordReport) that upstream OHDSI/WhiteRabbit lacks.
+FROM ghcr.io/data2evidence/whiterabbit@sha256:bfebf252d3c69d1c9e5b195964f85732d539c23e68760e2c3d492a4a0265d124 AS whiterabbit_base
+
+```
+
+- [ ] **Step 2: Copy the dist in the final stage**
+
+In the final stage (`FROM env-data-transformation`, currently line 121), immediately after:
+
+```dockerfile
+COPY plugins/flows/drivers /app/inst/drivers/
+```
+
+add:
+
+```dockerfile
+# white_rabbit_plugin resolves /app/whiterabbit (white_rabbit_plugin/types.py).
+# csvfiles is the working dir CSV scans download into and WhiteRabbit writes
+# ScanReport.xlsx into. No chown needed: this image has no USER directive.
+COPY --from=whiterabbit_base /dist /app/whiterabbit/dist
+RUN mkdir -p /app/whiterabbit/csvfiles
+```
+
+Placement in the **final** stage, not in `env-data-transformation`, keeps the expensive
+data_transformation provisioning layer's cache key untouched.
+
+- [ ] **Step 3: Verify the digest resolves before building**
+
+Run:
+```bash
+docker manifest inspect ghcr.io/data2evidence/whiterabbit@sha256:bfebf252d3c69d1c9e5b195964f85732d539c23e68760e2c3d492a4a0265d124
+```
+Expected: a manifest JSON listing a `linux/amd64` platform.
+
+If this fails with a "manifest unknown" or auth error, **stop and report** — the fallback is the
+floating `:master` tag, but confirm with the team before switching, since the digest pin was a
+deliberate decision.
+
+- [ ] **Step 4: Build the worker image**
+
+Run:
+```bash
+docker build -f services/alp-dataflow-gen-worker/Dockerfile -t alp-dataflow-gen-worker:wr-test .
+```
+Expected: build succeeds. This is a long build (heavy R/pixi stages); expect tens of minutes on a
+cold cache.
+
+- [ ] **Step 5: Verify the layout inside the built image**
+
+Run:
+```bash
+docker run --rm alp-dataflow-gen-worker:wr-test ls /app/whiterabbit/dist/bin
+```
+Expected: includes `whiteRabbit` and `rabbitInAHat`.
+
+Run:
+```bash
+docker run --rm alp-dataflow-gen-worker:wr-test ls -d /app/whiterabbit/csvfiles
+```
+Expected: `/app/whiterabbit/csvfiles`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add services/alp-dataflow-gen-worker/Dockerfile
+git commit -m "fix(dataflow-worker): restore the WhiteRabbit dist in the worker image"
+```
+
+---
+
+## Task 13: End-to-end verification
+
+**Files:** none — verification only.
+
+Requires a docker host. This cannot be run from inside the agent sandbox (no docker CLI, no
+`/var/run/docker.sock`).
+
+- [ ] **Step 1: Restart the worker**
+
+The worker exited (code 1, not OOM) at `2026-08-17T05:00:53Z` with
+`RuntimeError: Service exceeded error threshold` / `provision-envs: deployment poll failed
+(HTTP 500)`. That is a **separate** Prefect deployment-poll defect; do not assume this work fixes it.
+
+Run: `docker start alp-dataflow-gen-worker`
+Expected: container running. Confirm with `docker ps | grep dataflow-gen-worker`.
+
+- [ ] **Step 2: Confirm the dist is present in the running worker**
+
+Run: `docker exec alp-dataflow-gen-worker ls /app/whiterabbit/dist/bin`
+Expected: includes `whiteRabbit` and `rabbitInAHat`.
+
+- [ ] **Step 3: Run a CSV scan through the portal**
+
+Navigate to `https://localhost:41100/d2e/portal/systemadmin/etl` (admin / `Updatepassword12345`).
+
+Admin Portal → ETL → add a White Rabbit node → *Configure White Rabbit* → *Scan data* → choose
+**CSV files** → upload `plugins/ui/apps/mapping/sampleCSV/healthcare_dataset.csv` →
+**SCAN TABLES** → select the file → **APPLY**.
+
+Expected: the progress dialog advances and reaches a terminal state (not stuck on "Pending").
+
+- [ ] **Step 4: Confirm the flow run succeeded**
+
+Run: `docker logs alp-dataflow-gen-worker --since 5m | grep -E "Run white rabbit|FileNotFound|RuntimeError"`
+Expected: the flow run completes; no `FileNotFoundError`, no `Finished in state Failed`.
+
+- [ ] **Step 5: Verify the CSV cleanup fix (the second-scan trap)**
+
+Run a **second** scan on a **different** White Rabbit node with a different CSV file.
+
+Expected: the second scan's report contains only the second node's table. Before Task 7 this
+would have included the first scan's table too.
+
+Confirm in the logs:
+Run: `docker logs alp-dataflow-gen-worker --since 5m | grep "stale CSV"`
+Expected: a line like `Removed 1 stale CSV file(s) from /app/whiterabbit/csvfiles`.
+
+- [ ] **Step 6: Verify Fix E — the user can escape a stalled scan**
+
+This exercises the exact hang the notes reported, without breaking the image.
+
+```bash
+docker stop alp-dataflow-gen-worker
+```
+
+Start a scan from the portal. The flow run is created but never picked up, so Prefect reports
+`Pending`/`Scheduled` indefinitely.
+
+Expected: the **Back** button is enabled and closes the dialog. Before Task 11 all three buttons
+were disabled and only a page reload escaped.
+
+Then restore the worker:
+```bash
+docker start alp-dataflow-gen-worker
+```
+
+- [ ] **Step 7: Record the results**
+
+Note in the PR description: whether the scan completed, the second-scan cleanup result, and the
+Back-button behaviour with the worker stopped.
+
+---
+
+## Task 14: Ship the branch
+
+- [ ] **Step 1: Commit the spec and this plan**
+
+```bash
+git add trex/specs/2026-08-17-whiterabbit-dist-restore-design.md trex/plans/2026-08-17-whiterabbit-scan-restore.md
+git commit -m "plan: restore White Rabbit scans"
+```
+
+- [ ] **Step 2: Confirm the full test suite passes**
+
+Run:
+```bash
+cd plugins/flows/data_transformation && pixi run python -m pytest white_rabbit_plugin/tests/ -v
+```
+Expected: 7 passed.
+
+Run:
+```bash
+cd plugins/ui/apps/flow && bunx vitest run
+```
+Expected: all green.
+
+- [ ] **Step 3: Review the full diff**
+
+Run: `git diff develop... --stat`
+Expected: only these files —
+`services/alp-dataflow-gen-worker/Dockerfile`,
+`plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts`,
+`plugins/flows/data_transformation/pyproject.toml`,
+`plugins/flows/data_transformation/pixi.lock`,
+`plugins/flows/data_transformation/white_rabbit_plugin/{paths.py,tasks.py}`,
+`plugins/flows/data_transformation/white_rabbit_plugin/tests/*`,
+`plugins/ui/apps/flow/{package.json,vitest.config.ts}`,
+`plugins/ui/apps/flow/src/features/flow/utils/scan-progress-state{.ts,.test.ts}`,
+`plugins/ui/apps/flow/src/components/Dialog/ScanProgressDialog/ScanProgressDialog.tsx`,
+`trex/specs/…`, `trex/plans/…`.
+
+- [ ] **Step 4: Open the PR**
+
+The description must state:
+
+1. **What broke and when** — `a96fde35` (18 Jul 2026) deleted the plugin Dockerfile that copied
+   the dist; scans have been broken on `develop` since.
+2. **The accepted architectural trade-off** — Fix A re-couples a flow-plugin asset to the worker
+   image, which the pixi migration explicitly decoupled ("installing or updating a flow plugin
+   never requires rebuilding this image"). This is knowingly temporary; migration plan Task 3.1
+   (publish the dist from `data2evidence/d2e-WhiteRabbit`, fetch it in `setup_assets.sh`)
+   supersedes it and should delete the `whiterabbit_base` stage.
+3. **The correction to the original triage** — the infinite spinner was *not* caused by
+   `scan-data.router.ts`; the progress dialog polls `jobplugins/white-rabbit/results/:id` and
+   swallowed its own errors client-side. Both were fixed.
+4. **Known follow-ups not in this PR** — the `/app/downloads` regression in
+   `dataflow_ui_plugin/nodeutils/csvutils.py`, the legacy `apps/mapping` copy of
+   ScanProgressDialog, and the separate Prefect deployment-poll worker crash.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section of `2026-08-17-whiterabbit-dist-restore-design.md` maps to a
+task: §3.1 → Task 12; §3.2 → Tasks 3-5; §3.3 → Task 1; §8.1 → Tasks 2-7; §8.3/§8.4 → Task 13.
+Two spec statements are **superseded by this plan** and must be corrected when the spec is next
+touched: §6's claim that Fix D makes the dialog reach a terminal state, and §8.4's "negative test
+for Fix D" — both rest on the endpoint confusion documented above. The spec also lists the shared
+`csvfiles` directory as a non-goal; this plan promotes it to Tasks 6-7.
+
+**Placeholder scan.** No TBD/TODO. Every code step contains complete code. Every command has an
+expected result.
+
+**Type consistency.** `classifyFlowState` returns `{terminal, failed, progress}` in Task 10 and
+is destructured with exactly those names in Task 11. `MAX_CONSECUTIVE_POLL_ERRORS` is exported in
+Task 10 and imported in Task 11. `ensure_whiterabbit_dirs(dir_path, csv_dir)`,
+`require_whiterabbit_dist(bin_path)`, and `clear_csv_working_dir(csv_dir)` are defined in Task 4
+and called with matching arity in Tasks 5 and 7. `clear_csv_working_dir` returns an `int` in
+Task 4 and is used as a count in both Task 6's assertion and Task 7's log line.
+
+## Open items requiring team input
+
+1. **Task 12 Step 3** — if the pinned digest does not resolve, confirm whether to fall back to
+   the floating `:master` tag.
+2. **`/app/downloads`** — confirm the recommendation to file it separately (see Scope decisions).
+3. **CI coverage** — this plan adds test runners but wires neither into CI. The flow app's Vitest
+   suite has no workflow (`apps/concept-mapping` and `apps/jobs` tests are also un-CI'd), and
+   `data_transformation`'s pytest suite has no workflow either. Adding both is a small, separate
+   change; confirm whether it belongs here.

--- a/trex/specs/2026-08-17-whiterabbit-dist-restore-design.md
+++ b/trex/specs/2026-08-17-whiterabbit-dist-restore-design.md
@@ -1,0 +1,342 @@
+# Restore White Rabbit scans: re-provision the dist in the worker image
+
+Date: 2026-08-17
+Status: design agreed (Option 1 + Fix C + Fix D), implementation not started
+Regressed in: `a96fde35` — "Pixi-managed flow plugin environments on a Prefect process worker (#2881)", merged 18 Jul 2026
+
+## 1. Problem
+
+White Rabbit scans launched from the Admin Portal ETL page have been non-functional on
+`develop` since 18 Jul 2026. The flow fails server-side with:
+
+```
+FileNotFoundError: [Errno 2] No such file or directory: '/app/whiterabbit/config.ini'
+```
+
+The error names `config.ini`, but the missing thing is the **parent directory**.
+`open(path, "w")` creates a file, never its parent.
+
+`a96fde35` deleted `plugins/flows/data_transformation/Dockerfile` (182 lines), which was the
+only thing that created `/app/whiterabbit` and populated it:
+
+```dockerfile
+FROM ghcr.io/data2evidence/whiterabbit:master AS whiterabbit_base
+RUN mkdir -p ... /app/whiterabbit ... && mkdir -p /app/whiterabbit/csvfiles ...
+COPY --chown=docker:docker --from=whiterabbit_base /dist /app/whiterabbit/dist
+```
+
+Flow assets are now provisioned by pixi via `setup_assets.sh`, which fetches over HTTP. The
+WhiteRabbit dist exists only inside an OCI image, so the `COPY --from` could not be ported and
+was dropped without replacement. `setup_assets.sh:6-9` records the decision as an OPEN ITEM
+(migration plan Task 3.1). Nothing gates or warns on it at runtime.
+
+The plugin still expects the old layout. `white_rabbit_plugin/types.py:6` hardcodes
+`/app/whiterabbit`, and a repo-wide grep confirms it is the **only** match — a consumer with no
+producer.
+
+Two independent defects compound this:
+
+- The failure mode is misleading (points at a config file that was never meant to exist yet).
+- The failure is **invisible to users**: `scan-data.router.ts:63` swallows the error with a bare
+  `catch (error) {}`, so the request never returns and the Scan Data dialog hangs on "Pending"
+  forever, not dismissable with Escape.
+
+## 2. Decision and scope
+
+Three changes land together:
+
+| ID | Change | Purpose |
+| --- | --- | --- |
+| **A** | Restore the OCI copy in the worker Dockerfile | Restores scans |
+| **C** | `mkdir -p` + fail-fast precondition in `create_white_rabbit_settings` | Honest errors |
+| **D** | `next(error)` in the `result-as-resource` handler | Kills the infinite spinner |
+
+### 2.1 Why Option 1 (build-time OCI copy)
+
+Two alternatives were evaluated and rejected for now:
+
+- **Plugin-local fetch of a published tarball** (migration plan Task 3.1) is the correct
+  long-term shape, but it is blocked on work in a *different repository*. The upstream
+  `OHDSI/WhiteRabbit` release zips cannot be substituted: `data2evidence/d2e-WhiteRabbit` is not
+  a fork or mirror of upstream — it descends from the SoftwareCountry/Arcadia Perseus
+  web-service fork (`org.ohdsi:leporidae:0.10.7` vs upstream `1.0.0`) and carries D2E-only
+  patches the plugin depends on. Most decisively, d2e commit `9c1a667` adds a
+  `--generateWordReport` CLI flag to RabbitInAHat that upstream does not have, and
+  `tasks.py:122` calls exactly that flag. Upstream's `RabbitInAHatMain` would fall through to
+  GUI mode and hang. Unblocking this route requires building and publishing the patched dist
+  from `d2e-WhiteRabbit` (last pushed Apr 2025).
+- **An OCI fetch tool (`oras`/`skopeo`) in the provisioner** would keep the plugin-local
+  decoupling without waiting on a release, but reintroduces the OCI dependency the migration set
+  out to remove and adds registry-auth handling to a path that today only runs plain `curl`.
+
+Option 1 uses the artifact that exists today, needs no cross-repo coordination, and restores
+pre-regression behaviour exactly.
+
+**Accepted trade-off, to be stated in the PR description:** this re-couples a *flow-plugin
+asset* to the *worker image*, which the pixi migration explicitly set out to decouple — the
+worker Dockerfile header states *"installing or updating a flow plugin never requires rebuilding
+this image."* That invariant is knowingly broken for this one asset, and the Task 3.1 follow-up
+supersedes it.
+
+### 2.2 Pre-established facts that reduce this to "only the dist is missing"
+
+- `openjdk = "17.*"` is already a dependency of the data_transformation pixi env
+  (`pyproject.toml:104`), so the JVM is present. No dependency work.
+- The worker image already installs `xvfb` (`Dockerfile:73`), with a comment at `:65` naming
+  `white_rabbit_plugin` as the reason. The runtime dependency survived the migration.
+- The virtual display is started **by the plugin itself**, not the image:
+  `white_rabbit_plugin/flow.py:17-20` wraps the run in `xvfbwrapper.Xvfb(display=...)`, and
+  `xvfbwrapper` is in the pixi env (`pyproject.toml:38`). There is no `DISPLAY`/`Xvfb`
+  entrypoint wiring to restore.
+- The worker runs as **root** — there is no `USER` directive in
+  `services/alp-dataflow-gen-worker/Dockerfile` — so the old `chown docker:docker` / `chmod 711`
+  dance is unnecessary.
+
+## 3. Architecture
+
+### 3.1 Fix A — worker Dockerfile
+
+`services/alp-dataflow-gen-worker/Dockerfile` has a deliberate build topology: R-heavy stages
+form a `FROM` lineage (`env-base` → `env-hades` → `env-data-transformation` → final) so each
+heavy env exists once as native layers, with light python-only groups built in parallel stages
+and `COPY`'d in. The header documents this at length; the change must not disturb it.
+
+Two additions:
+
+1. A **standalone top-level stage** declared near the other top-level `FROM`s (alongside
+   `FROM ubuntu:24.04 AS staging` at :19 and `FROM ubuntu:24.04 AS runtime-base` at :60):
+
+   ```dockerfile
+   FROM ghcr.io/data2evidence/whiterabbit:master AS whiterabbit_base
+   ```
+
+   Deliberately **not** part of the heavy-env lineage. BuildKit pulls it concurrently with the
+   other stages and only the copied layer reaches the final image.
+
+2. In the **final stage** (`FROM env-data-transformation`, :121), beside the existing
+   `COPY services/alp-dataflow-gen-worker/run-flow.sh /app/` at :126:
+
+   ```dockerfile
+   COPY --from=whiterabbit_base /dist /app/whiterabbit/dist
+   RUN mkdir -p /app/whiterabbit/csvfiles
+   ```
+
+Placement in the final stage (not in `env-data-transformation`) keeps the expensive
+data_transformation provisioning layer's cache key untouched by this change.
+
+**Digest pinning.** `:master` is a floating tag on a package last published ~Jan 2025. The spec
+recommends pinning by digest for a reproducible build:
+
+```dockerfile
+FROM ghcr.io/data2evidence/whiterabbit@sha256:bfebf252d3c69d1c9e5b195964f85732d539c23e68760e2c3d492a4a0265d124 AS whiterabbit_base
+```
+
+with the human-readable `:master` recorded in an adjacent comment. See open question Q1.
+
+### 3.2 Fix C — filesystem preconditions in the plugin
+
+`plugins/flows/data_transformation/white_rabbit_plugin/tasks.py`, in
+`create_white_rabbit_settings`, before the `open(config_path, "w")` at :60:
+
+```python
+Path(WHITERABBIT_DIR_PATH).mkdir(parents=True, exist_ok=True)
+Path(WHITERABBIT_CSV_DIR).mkdir(parents=True, exist_ok=True)
+if not Path(WHITERABBIT_BIN_PATH).exists():
+    raise RuntimeError(
+        f"WhiteRabbit distribution not found at {WHITERABBIT_BIN_PATH}. "
+        "The dist is provisioned into the dataflow-gen-worker image from the "
+        "whiterabbit OCI stage; a worker built without it cannot run scans."
+    )
+```
+
+`Path` is already imported (`tasks.py:2`). Both directories are created because
+`INISettings.working_folder` (`types.py:71-74`) resolves to `WHITERABBIT_CSV_DIR` for
+`SCAN_REPORT_FILES` and `WHITERABBIT_DIR_PATH` for `SCAN_REPORT_DB` — the scan's working folder
+is one or the other depending on scan type, and both must exist.
+
+This is intentionally redundant with the Dockerfile's `mkdir`. The image guarantees the
+directories at build time; Fix C makes the task self-sufficient and converts the "dist absent"
+case from a confusing `FileNotFoundError` about `config.ini` into a named, actionable error.
+
+### 3.3 Fix D — error propagation in the white-rabbit function
+
+`plugins/functions/white-rabbit/src/scan-data/scan-data.router.ts:63` ends the
+`result-as-resource` handler with `catch (error) {}`. The handler already receives `next` in its
+signature; `next` is simply unused. Both sibling handlers in the same file (:39-40 and :85-89)
+log and then call `next(error)`. Match that convention:
+
+```ts
+} catch (error) {
+  this.logger.error(
+    `Error when getting scan report: ${JSON.stringify(error)}`
+  );
+  next(error);
+}
+```
+
+Note on where `next(error)` lands: `main.ts` registers **no custom error-handling middleware**.
+The error therefore reaches Express's built-in final handler, which responds `500` and ends the
+request. That is sufficient — the defect is that the request never terminates at all, leaving
+the client waiting. Adding a custom error middleware is out of scope (§7).
+
+## 4. Interfaces and contracts
+
+The contract between the worker image and the plugin is a **filesystem layout**, consumed
+through three constants in `white_rabbit_plugin/types.py:6-8`:
+
+| Constant | Value | Producer | Consumer |
+| --- | --- | --- | --- |
+| `WHITERABBIT_DIR_PATH` | `/app/whiterabbit` | Dockerfile (`COPY`/`mkdir`) + Fix C | `config.ini`, docx output, DB-scan working folder |
+| `WHITERABBIT_BIN_PATH` | `/app/whiterabbit/dist/bin` | Dockerfile `COPY --from` | `whiteRabbit` (:84), `rabbitInAHat` (:122) |
+| `WHITERABBIT_CSV_DIR` | `/app/whiterabbit/csvfiles` | Dockerfile `mkdir` + Fix C | CSV download target (:165), file-scan working folder |
+
+The constants are **unchanged** by this work. Rebasing them onto `PIXI_PROJECT_ROOT` belongs to
+the Task 3.1 follow-up, not here.
+
+What the image stage supplies: the d2e WhiteRabbit image builds `/dist` with
+appassembler-maven-plugin (flat repository layout), producing `dist/bin/whiteRabbit`,
+`dist/bin/rabbitInAHat` (plus `.bat` variants) and a flat `dist/repo/*.jar` classpath. The
+launcher scripts resolve `java` from `PATH`, which the pixi env supplies as OpenJDK 17.
+
+HTTP contract touched by Fix D: `GET /white-rabbit/api/scan-data/result-as-resource/:conversionId`.
+Success is unchanged (`200`, `application/octet-stream`). Failure changes from *no response* to
+a terminated `5xx`.
+
+## 5. Data flow
+
+```
+Portal (ETL page) ──> CSV upload ──> supabase-storage        [already works, unchanged]
+        │
+        └─ APPLY ──> white-rabbit function ──> Prefect flow "Run white rabbit"
+                                                   │
+                     flow.py: start Xvfb (xvfbwrapper)
+                                                   │
+                     download_csv_files ──> /app/whiterabbit/csvfiles      [CSV scans]
+                                                   │
+                     create_white_rabbit_settings                          [Fix C here]
+                       ├─ mkdir -p dir + csvfiles
+                       ├─ assert dist/bin exists  ──(absent)──> RuntimeError, named
+                       └─ write /app/whiterabbit/config.ini
+                                                   │
+                     create_scan_report
+                       └─ /app/whiterabbit/dist/bin/whiteRabbit -ini config.ini   [Fix A supplies this]
+                                                   │
+                     ScanReport.xlsx in working_folder ──> upload
+                                                   │
+Portal <── result-as-resource ────────────────────┘                        [Fix D here]
+```
+
+The break today is strictly at `create_white_rabbit_settings`. Upload and file listing are
+confirmed working and are not touched.
+
+## 6. Error handling
+
+| Condition | Before | After |
+| --- | --- | --- |
+| Dist absent from image | `FileNotFoundError: '/app/whiterabbit/config.ini'` — points at the wrong artifact | `RuntimeError` naming `WHITERABBIT_BIN_PATH` and the provisioning source |
+| Directory absent, dist present | Same misleading `FileNotFoundError` | Directory created; run proceeds |
+| `config.ini` write fails for another reason (permissions, disk) | `FileNotFoundError` from the existing post-write check at :64-66 | Unchanged — still surfaces |
+| Scan report fetch throws | Silently swallowed; request hangs; UI spins forever | Logged, `next(error)` → `500`; dialog reaches a terminal state |
+
+Fix C's precondition is a **fail-fast**, deliberately raised before any file is written, so a
+misprovisioned worker reports the real cause on the first task rather than midway through.
+
+## 7. Non-goals
+
+- **Fix B / migration Task 3.1** — plugin-local provisioning from a published dist. Tracked
+  separately; requires a release cut from `data2evidence/d2e-WhiteRabbit` first.
+- **Migrating to upstream `OHDSI/WhiteRabbit`** — blocked by the missing `--generateWordReport`
+  patch (§2.1). Would require porting `9c1a667`, `4dfdbcf`, `7a1556f` onto 1.0.0.
+- **Rebasing `types.py` onto `PIXI_PROJECT_ROOT`** — belongs with Fix B.
+- **The Prefect worker crash** (`RuntimeError: Service exceeded error threshold`,
+  `provision-envs: deployment poll failed (HTTP 500)`, observed 2026-08-17T05:00:53Z). A
+  different failure; triaged separately. Restoring the dist is not assumed to fix it.
+- **Custom Express error middleware** for the white-rabbit function. The built-in handler is
+  sufficient to terminate the request.
+- **The shared `csvfiles` working directory.** All scans write into one directory and WhiteRabbit
+  scans `*` (all CSVs in the working folder), so concurrent or repeated scans can observe each
+  other's files. Pre-existing behaviour, unchanged by this work, worth its own issue.
+- **Multi-arch support.** The CI matrix that builds this image is `linux/amd64` only
+  (`docker-build-push.yaml:287`), matching the whiterabbit image's only published variant.
+
+## 8. Testing approach
+
+### 8.1 Fix C — unit tests (fully verifiable in-repo)
+
+`white_rabbit_plugin/` has no `tests/` directory today; `dataflow_ui_plugin/tests/` is the
+in-repo pattern to follow. Add `white_rabbit_plugin/tests/test_tasks.py` covering:
+
+1. Dist absent → raises `RuntimeError` whose message contains the bin path, and **not**
+   `FileNotFoundError`.
+2. Directories absent, dist present (faked) → both directories created, `config.ini` written.
+3. Directories already present → idempotent, no error (`exist_ok=True`).
+4. `working_folder` resolves to `csvfiles` for `SCAN_REPORT_FILES` and to the base dir for
+   `SCAN_REPORT_DB`.
+
+**Implementation note for tests:** `tasks.py:13` imports the constants *by value*
+(`from .types import WHITERABBIT_BIN_PATH, ...`), so tests must monkeypatch
+`white_rabbit_plugin.tasks.WHITERABBIT_*`, not `types.*`, and point them at a `tmp_path`.
+
+### 8.2 Fix D — see open question Q2
+
+`plugins/functions/white-rabbit` is a **Deno** package (`deno.json`, no `package.json`). It
+declares no `test` task and is **not** in the `plugin-function-tests.yml` CI matrix, which covers
+only `strategus-analysis`, `jobplugins`, `dataset`. A unit test therefore requires adding test
+infrastructure plus a matrix entry. Minimum bar without that: `deno check` on the changed file
+and manual verification via §8.4.
+
+### 8.3 Fix A — build-time verification (requires a docker host)
+
+```bash
+docker exec alp-dataflow-gen-worker ls /app/whiterabbit/dist/bin
+# expect: whiteRabbit  whiteRabbit.bat  rabbitInAHat  rabbitInAHat.bat
+docker exec alp-dataflow-gen-worker ls -d /app/whiterabbit/csvfiles
+```
+
+### 8.4 End-to-end (requires a docker host)
+
+Restart the worker first — it exited at 2026-08-17T05:00:53Z (`docker start alp-dataflow-gen-worker`).
+
+Admin Portal → ETL → add a White Rabbit node → *Configure White Rabbit* → *Scan data* → choose
+**CSV files**, upload `plugins/ui/apps/mapping/sampleCSV/healthcare_dataset.csv`, **SCAN TABLES**,
+select the file, **APPLY**.
+
+Expected: the progress dialog reaches a terminal state instead of sitting on "Pending", and
+
+```bash
+docker logs alp-dataflow-gen-worker --since 5m | grep -E "Run white rabbit|FileNotFound"
+```
+
+shows the flow run completing rather than `Finished in state Failed`.
+
+**Negative test for Fix D (do this while the dist is still absent, before Fix A lands):** trigger
+a scan and confirm the dialog now surfaces a failure instead of spinning indefinitely. Once Fix A
+lands, this path is hard to exercise without deliberately breaking the image.
+
+### 8.5 Environment constraint
+
+The agent sandbox has **no docker CLI and no docker socket** (`/var/run/docker.sock` absent).
+`alp-dataflow-gen-worker` resolves at `172.19.0.7`, but the image cannot be rebuilt, exec'd into,
+or restarted from inside it. §8.1 is verifiable in-sandbox; §8.3 and §8.4 require a docker host.
+See open question Q3.
+
+## 9. Risks
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| `ghcr.io/data2evidence/whiterabbit:master` is stale (published ~Jan 2025) and its old source URL `data2evidence/whiterabbit` now 404s (repo renamed `d2e-WhiteRabbit`) | Medium | Pin by digest (Q1); Fix B removes the dependency entirely |
+| Re-couples plugin asset to worker image, violating a documented invariant | Medium | Accepted and documented in the PR description; superseded by Fix B |
+| Image is `linux/amd64` only; a local `arm64` build could fail to resolve the stage | Low | CI is amd64-only. The dist is architecture-independent Java, so `--platform=linux/amd64` on the stage is a safe local-build guard if needed |
+| GHCR pull credentials in CI | Low | The package is publicly listed and CI already authenticates to GHCR |
+| Worker image grows by the dist (~100s of MB) | Low | Same size as pre-regression; single `COPY` layer in the final stage only |
+
+## 10. Open questions for the team
+
+- **Q1 — Pin the whiterabbit stage by digest, or keep the floating `:master` tag?**
+  Recommendation: pin by digest (`sha256:bfebf252…`) with `:master` in a comment, for a
+  reproducible build against a package that is no longer actively published.
+- **Q2 — Fix D test coverage.** Add Deno test infrastructure to
+  `plugins/functions/white-rabbit` and a `plugin-function-tests.yml` matrix entry, or ship the
+  one-line fix with `deno check` plus manual verification only?
+- **Q3 — Who runs the host-side rebuild and end-to-end verification?** The sandbox has no docker
+  daemon (§8.5). Fix C is verifiable here; Fix A and the e2e scan are not.


### PR DESCRIPTION
## What broke and when

`a96fde35` (18 Jul 2026) deleted the plugin Dockerfile that copied the WhiteRabbit dist into the
dataflow-gen worker image. Nothing in the tree recreated it, so `white_rabbit_plugin` has been
resolving `/app/whiterabbit/dist/bin` against a path that does not exist. **White Rabbit scans
have been broken on `develop` since that date**, presenting to users as an infinite "Pending"
spinner they could not dismiss without reloading the page.

## What this changes

**Fix A — restore the dist (`services/alp-dataflow-gen-worker/Dockerfile`)**
Re-adds a standalone `whiterabbit_base` OCI stage and copies `/dist` to `/app/whiterabbit/dist`,
restoring the exact layout `white_rabbit_plugin/types.py` hardcodes. The stage is deliberately
outside the heavy-env `FROM` lineage so BuildKit pulls it concurrently, and the COPY sits in the
final stage so the expensive data_transformation layer's cache key is untouched.

**Fix C2 — stale CSV cleanup (`white_rabbit_plugin/tasks.py`, `paths.py`)**
Every node downloads into one flat directory and scans run with `tables_to_scan="*"`, so without
cleanup each scan would report tables left by previous scans and by other ETL nodes. This has been
unobservable only because no scan completes at all — Fix A re-exposes it.

**Fix E — progress dialog (`ScanProgressDialog.tsx`, `scan-progress-state.ts`)**
Poll errors were swallowed client-side; only `Completed`/`Failed`/`Crashed` were treated as
terminal, so `Cancelled` and `TimedOut` polled forever; and `Back` was disabled until a scan
completed, trapping the user in the modal. All three are fixed, plus `handleClear` now resets
`scanFailed` so re-opening after a failure no longer leaves the action buttons dead.

## Correction to the original triage

The infinite spinner was **not** caused by `scan-data.router.ts`'s empty catch, as the source notes
claimed. That handler serves `/scan-report/result-as-resource/:conversionId`, which is only reachable
from *Save report* — a button disabled until a scan has already succeeded. The progress dialog polls
a different endpoint (`jobplugins/white-rabbit/results/{flowRunId}`) and swallowed its own errors.
Both bugs are real and both are fixed here, but they are not the same bug.

## Accepted architectural trade-off

Fix A re-couples a flow-plugin asset to the worker image, which the pixi migration explicitly
decoupled ("installing or updating a flow plugin never requires rebuilding this image"). This is
knowingly temporary: migration plan Task 3.1 (publish the dist from `data2evidence/d2e-WhiteRabbit`,
fetch it in `setup_assets.sh`) supersedes it and should delete the `whiterabbit_base` stage.

## Verification

- `pytest white_rabbit_plugin/tests/` — **7 passed**, red-then-green observed for each TDD step.
- Flow app **Vitest — 13 passed**.
- `tsc --noEmit` — **112 errors before, 112 after, zero new** (baselined against a scratch worktree
  at the pre-change commit; all pre-existing, from unbuilt `@portal/*` workspace libs).
- Flow app **production build succeeds** (12,455 modules); the new classifier and poll-error string
  are present in the bundle and the dead `FLOW_STATE_MAP` is gone.
- `deno check` on the white-rabbit function — 7 errors, confirmed pre-existing and none in the
  changed file.
- Pinned digest verified against GHCR: HTTP 200, `linux/amd64` manifest, and the layer tar contains
  `dist/bin/whiteRabbit` and `dist/bin/rabbitInAHat` — matching the paths in `types.py`.
- Docs site `npm run build` passes; the new page renders and registers in the sidebar.

### Not verified — needs a reviewer with a Docker host

**Live end-to-end scanning could not be exercised.** The agent sandbox has no Docker CLI and no
`/var/run/docker.sock`, so the worker image could not be rebuilt, restarted, or exec'd into. Plan
Task 13 (run a CSV scan through the portal, confirm the second-scan cleanup, confirm the Back button
escapes a stalled scan) is **outstanding** and should be run before merge.

## Docs

Adds `docs/website/docs/2-admin_guide/2-etl/README.md`. The ETL / White Rabbit feature had no
documentation at all; this covers the scan flow, the progress states, the failure and lost-contact
behaviour, repeat-scan cleanup, and the worker-image requirement.

## Scope note for reviewers

The agreed scope was Fix A + Fix C2 + Fix E. This branch also carries work committed in an earlier
session that sits outside that scope and should be confirmed keep-or-drop:

- `4f039e19e` Fix D — `next(error)` in `scan-data.router.ts`
- `fa358ed6d` / `4a9a020ea` / `590a741e8` Fix C — `paths.py` plus `mkdir`/fail-fast wiring
- `cf28cc7a1` — isolated pixi `test` environment (a deviation from the plan's `dev` dependency-group;
  reasoning is recorded in that commit message)

One file beyond the plan: `plugins/ui/apps/flow/tsconfig.json` excludes `**/*.test.ts(x)`. Without it
the new test file entered a legacy `es5`/`node`-resolution program and produced three new Vitest type
errors; the exclusion restores the exact prior tsc surface.

## Known follow-ups not in this PR

- The `/app/downloads` regression in `dataflow_ui_plugin/nodeutils/csvutils.py` — same root-cause
  commit, different plugin, deliberately left for a separate issue.
- The legacy `apps/mapping` copy of `ScanProgressDialog` — team chose flow app only.
- A separate Prefect deployment-poll worker crash (`Service exceeded error threshold`), unrelated to
  this work.
- Neither new test runner is wired into CI (per instruction not to touch CI wiring); the flow app's
  Vitest suite and `data_transformation`'s pytest suite both run locally only.
