### PR TITLE
test(tls): add internal-TLS smoke tests

### DIFF
--- a/tests/tls/README.md
+++ b/tests/tls/README.md
@@ -1,0 +1,75 @@
+# Internal-TLS smoke tests
+
+Fast checks that internal service-to-service TLS is actually being verified. Read-only —
+probes a running stack and changes nothing.
+
+```sh
+npm run start                    # a running stack is the only prerequisite
+./tests/tls/tls-smoke.sh
+```
+
+Exit 0 = all checks passed, 1 = at least one failed, 2 = could not run (no docker, or the
+probe container isn't up).
+
+## What it covers
+
+**A. Every internal TLS endpoint verifies both the chain and the hostname.**
+
+Endpoints are discovered from `docker-compose.yml` / `docker-compose-local.yml` by matching
+`https://${PROJECT_NAME…}-<svc>.${TLS__INTERNAL__DOMAIN…}:<port>`, so the list cannot rot as
+services move. Each is dialled from inside the network with:
+
+```sh
+openssl s_client -connect <host>:<port> -servername <host> \
+  -verify_hostname <host> -verify_return_error -CAfile <internal CA>
+```
+
+`-verify_hostname` is the load-bearing flag. Without it, `openssl s_client` checks nothing —
+`-servername` only sets SNI — so a certificate whose SAN does not cover the name being dialled
+would appear to pass. That exact mismatch (SAN `*.d2e.local` vs hostnames on `alp.local`) is
+the failure this group exists to catch.
+
+A **negative control** dials a real endpoint while verifying a name the certificate cannot
+cover, and requires that to be *rejected*. If the control ever passes, the other results in
+group A are meaningless and the suite fails.
+
+Endpoints that don't resolve or refuse the connection are reported `SKIP`, not `FAIL` — they
+are simply not deployed in the active compose profile.
+
+The number of endpoints therefore varies by branch and profile: a branch that moves more
+services onto internal TLS will have more of them. A run that discovers nothing, or reaches
+nothing, reports skips rather than a false pass — and the negative control is skipped too,
+since there is nothing reachable to prove the checks against.
+
+**B. Nothing disables TLS verification.**
+
+- No running container carries `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+- No compose file or Helm chart sets it either, so it's caught before anything starts.
+
+Host-side helper scripts (`scripts/setupdemo.mjs` and friends) do set that variable. They run
+on a developer's machine rather than in the platform, so they're printed as a `NOTE` and do
+not fail the run.
+
+## What it deliberately does not cover
+
+- **`rejectUnauthorized: false` in code.** Most occurrences are Postgres SSL under
+  `sslmode=require`, where encrypting without verifying is libpq's defined behaviour rather
+  than a defect — plus vendored `node_modules` defaults. Separating real bypasses from correct
+  ones needs per-call-site judgement, not a grep.
+- **Application-level behaviour** over these connections (OIDC discovery, file downloads).
+  A verified handshake is necessary but not sufficient; those belong in the integration tests.
+- **Certificate hygiene** beyond what verification implies — expiry windows, key sizes,
+  algorithm choice.
+
+## Configuration
+
+Values are read from `.env.local`, else `.env`, and can be overridden by the environment:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PROJECT_NAME` | `d2e` | Container name prefix |
+| `TLS__INTERNAL__DOMAIN` | `d2e.local` | Internal DNS domain the certificate must cover |
+| `PROBE_CONTAINER` | `${PROJECT_NAME}-trex` | Container the probes run from |
+| `CA_IN_PROBE` | `/usr/src/cert/ca.pem` | Internal CA path inside that container |
+
+Pass a specific env file with `-n <file>`.

--- a/tests/tls/tls-smoke.sh
+++ b/tests/tls/tls-smoke.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Internal-TLS smoke tests.
+#
+# Two things only:
+#   A. Every internal TLS endpoint completes a handshake that verifies BOTH the
+#      certificate chain (against the internal CA) AND the hostname. A cert whose
+#      SAN does not cover the name being dialled fails here.
+#   B. No deployment manifest or running container disables TLS verification.
+#
+# Requires a running stack. Read-only: probes existing containers, changes nothing.
+#
+#   ./tests/tls/tls-smoke.sh                  # uses .env.local, else .env
+#   ./tests/tls/tls-smoke.sh -n .env          # explicit env file
+#   PROBE_CONTAINER=alp-trex ./tests/tls/tls-smoke.sh
+#
+# Exit 0 = all checks passed. Exit 1 = at least one failed.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 2
+REPO_ROOT=$PWD
+
+ENV_FILE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n|--env-file) ENV_FILE="${2:-}"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$ENV_FILE" ] || { for f in .env.local .env; do [ -f "$f" ] && ENV_FILE=$f && break; done; }
+
+pass=0; fail=0; skip=0
+ok()   { printf '  PASS  %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  FAIL  %s%s\n' "$1" "${2:+  -> $2}"; fail=$((fail+1)); }
+na()   { printf '  SKIP  %s%s\n' "$1" "${2:+  -> $2}"; skip=$((skip+1)); }
+hdr()  { printf '\n== %s\n' "$1"; }
+
+# Read a variable from the env file without sourcing it (the file holds PEM
+# blocks and quoted values that a plain `source` would mangle).
+env_get() {
+  [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ] || return 1
+  sed -n "s/^$1=//p" "$ENV_FILE" | head -1 | sed "s/^['\"]//; s/['\"]$//"
+}
+
+PROJECT_NAME=${PROJECT_NAME:-$(env_get PROJECT_NAME)}; PROJECT_NAME=${PROJECT_NAME:-d2e}
+DOMAIN=${TLS__INTERNAL__DOMAIN:-$(env_get TLS__INTERNAL__DOMAIN)}; DOMAIN=${DOMAIN:-d2e.local}
+PROBE_CONTAINER=${PROBE_CONTAINER:-${PROJECT_NAME}-trex}
+CA_IN_PROBE=${CA_IN_PROBE:-/usr/src/cert/ca.pem}
+
+echo "internal-TLS smoke tests"
+echo "  env file:  ${ENV_FILE:-<none>}"
+echo "  project:   $PROJECT_NAME"
+echo "  domain:    $DOMAIN"
+echo "  probe via: $PROBE_CONTAINER (CA at $CA_IN_PROBE)"
+
+command -v docker >/dev/null 2>&1 || { echo "docker not found" >&2; exit 2; }
+if ! docker exec "$PROBE_CONTAINER" sh -c "test -s $CA_IN_PROBE" 2>/dev/null; then
+  echo
+  echo "cannot probe: $PROBE_CONTAINER is not running, or has no CA at $CA_IN_PROBE." >&2
+  echo "start the stack first (npm run start), or set PROBE_CONTAINER / CA_IN_PROBE." >&2
+  exit 2
+fi
+
+# Run openssl s_client inside the probe container. -verify_hostname is what makes
+# a SAN mismatch fail; -servername alone only sets SNI and verifies nothing.
+handshake() {
+  docker exec "$PROBE_CONTAINER" sh -c \
+    "printf '' | openssl s_client -connect $1:$2 -servername $1 -verify_hostname $1 \
+       -verify_return_error -CAfile $CA_IN_PROBE 2>&1" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+hdr "A. internal TLS endpoints verify chain AND hostname"
+
+# Discover endpoints from the compose files rather than hardcoding them, so the
+# list cannot rot as services move. Matches https://<project>-<svc>.<domain>:<port>.
+endpoints=$(grep -hoE 'https://\$\{PROJECT_NAME:-[a-z0-9]+\}-[a-z0-9-]+\.\$\{TLS__INTERNAL__DOMAIN:-[a-z0-9.]+\}:[0-9]+' \
+              docker-compose.yml docker-compose-local.yml 2>/dev/null |
+            sed -E "s|https://\\\$\{PROJECT_NAME:-[a-z0-9]+\}-|${PROJECT_NAME}-|; \
+                    s|\.\\\$\{TLS__INTERNAL__DOMAIN:-[a-z0-9.]+\}|.${DOMAIN}|" |
+            sort -u)
+
+if [ -z "$endpoints" ]; then
+  na "endpoint discovery" "no https://…\${TLS__INTERNAL__DOMAIN} endpoints found in the compose files"
+else
+  reachable=""
+  for ep in $endpoints; do
+    host=${ep%:*}; port=${ep##*:}
+    out=$(handshake "$host" "$port")
+    if grep -q 'Verify return code: 0 (ok)' <<<"$out"; then
+      [ -n "$reachable" ] || reachable=$ep
+      ok "$host:$port verifies (chain + hostname)"
+    elif grep -qE 'Connection refused|name resolution|resolve' <<<"$out"; then
+      # Not deployed in this profile — not a TLS failure.
+      na "$host:$port" "not reachable (service not running in this profile)"
+    else
+      bad "$host:$port should verify" "$(grep -E 'verify error|Verify return code' <<<"$out" | head -1)"
+    fi
+  done
+fi
+
+# Negative control: a name the cert cannot cover must FAIL, otherwise the checks
+# above prove nothing. Must use a *reachable* endpoint — against an unreachable one
+# the connection fails first and the control would report a false failure.
+if [ -z "${reachable:-}" ]; then
+  na "negative control" "no reachable TLS endpoint to test it against"
+else
+  fhost=${reachable%:*}; fport=${reachable##*:}
+  wrong="${fhost%%.*}.invalid-domain.test"
+  # Dial the real host but verify the wrong name — the wrong name has no DNS entry,
+  # and we want the verification to fail, not the connection.
+  out=$(docker exec "$PROBE_CONTAINER" sh -c \
+        "printf '' | openssl s_client -connect $fhost:$fport -servername $wrong -verify_hostname $wrong \
+           -verify_return_error -CAfile $CA_IN_PROBE 2>&1" 2>/dev/null)
+  if grep -qE 'hostname mismatch|Verify return code: (6[0-9]|[1-9][0-9])' <<<"$out"; then
+    ok "negative control: '$wrong' is correctly rejected (checks have teeth)"
+  else
+    bad "negative control failed" "verification did NOT reject '$wrong' — the checks above are meaningless"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+hdr "B. no TLS-verification bypass"
+
+# B1. Running containers must not carry NODE_TLS_REJECT_UNAUTHORIZED=0.
+offenders=""
+for c in $(docker ps --format '{{.Names}}' | grep "^${PROJECT_NAME}-" || true); do
+  if docker inspect "$c" --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null |
+       grep -q '^NODE_TLS_REJECT_UNAUTHORIZED=0$'; then
+    offenders="$offenders $c"
+  fi
+done
+if [ -n "$offenders" ]; then bad "no container may set NODE_TLS_REJECT_UNAUTHORIZED=0" "${offenders# }"
+else ok "no running container sets NODE_TLS_REJECT_UNAUTHORIZED=0"; fi
+
+# B2. Same, in the deployment manifests (catches it before anything starts).
+man_hits=$(grep -rn 'NODE_TLS_REJECT_UNAUTHORIZED' docker-compose.yml docker-compose-local.yml charts/ 2>/dev/null |
+             grep -vE '^\s*#|:\s*#' | grep -E '"0"|=0|: *0' || true)
+if [ -n "$man_hits" ]; then bad "no manifest may disable TLS verification" "$(head -1 <<<"$man_hits")"
+else ok "no compose/chart manifest disables TLS verification"; fi
+
+# Deliberately not asserted here: `rejectUnauthorized: false` in code. Most
+# occurrences are Postgres SSL under sslmode=require, where "encrypt without
+# verifying" is libpq's defined behaviour rather than a defect, plus vendored
+# node_modules defaults. Auditing those needs per-call-site judgement, not a grep.
+#
+# Informational only: host-side helper scripts set NODE_TLS_REJECT_UNAUTHORIZED.
+# They run on the developer's machine, not in the platform, so they are reported
+# but not failed.
+helper_hits=$(grep -rln 'NODE_TLS_REJECT_UNAUTHORIZED' scripts/ tests/ 2>/dev/null | grep -v '^tests/tls/' || true)
+if [ -n "$helper_hits" ]; then
+  printf '  NOTE  host-side helpers still set NODE_TLS_REJECT_UNAUTHORIZED (not a platform bypass):\n'
+  printf '          %s\n' $helper_hits
+fi
+
+printf '\n== summary: %d passed, %d failed, %d skipped\n' "$pass" "$fail" "$skip"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Two checks against a running stack, independent of any feature branch:

A. Every internal TLS endpoint completes a handshake that verifies the chain
   against the internal CA *and* the hostname. Endpoints are discovered from the
   compose files rather than hardcoded, so the list cannot rot as services move.

   -verify_hostname is the load-bearing flag: without it `openssl s_client`
   verifies nothing (-servername only sets SNI), so a certificate whose SAN does
   not cover the name being dialled looks like a pass. A negative control dials a
   real endpoint while verifying a name the certificate cannot cover and requires
   that to be rejected — if the control ever passes, group A proves nothing and
   the run fails.

B. No running container and no compose file or chart disables TLS verification
   via NODE_TLS_REJECT_UNAUTHORIZED. Host-side helper scripts that set it are
   reported as a NOTE, not a failure: they run on a developer machine, not in the
   platform.

Deliberately not asserted: `rejectUnauthorized: false` in code. Most occurrences are Postgres SSL under sslmode=require, where encrypting without verifying is libpq's defined behaviour rather than a defect, plus vendored node_modules defaults. Separating real bypasses from correct ones needs per-call-site judgement, not a grep.

Read-only, no dependencies beyond docker and openssl. Endpoints that are not deployed in the active profile are skipped rather than failed, so the suite is meaningful on any branch.

Verified: catches an injected NODE_TLS_REJECT_UNAUTHORIZED=0 container; catches that variable in a pre-fix compose file; and the negative control correctly rejects a name outside the certificate's SAN (hostname mismatch, code 62).

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)