### PR TITLE
Expose DQD run metadata in the overview response

### DIFF
--- a/plugins/functions/jobplugins/src/services/DqdService.ts
+++ b/plugins/functions/jobplugins/src/services/DqdService.ts
@@ -50,11 +50,36 @@ export class DqdService {
       return null;
     }
 
-    const artifactData = JSON.parse(artifacts[0].data);
+    const artifactData = JSON.parse(artifacts[0].data) as IDataQualityResult;
     const checkResults = artifactData.CheckResults;
     const derivedResults = this.dataQualityOverviewParser.parse(checkResults);
+    const dqdVersion = artifactData.Metadata?.[0]?.dqdVersion;
+    const timing = {
+      ...this.getArtifactTimingValue(
+        "startTimestamp",
+        artifactData.startTimestamp
+      ),
+      ...this.getArtifactTimingValue("endTimestamp", artifactData.endTimestamp),
+      ...this.getArtifactTimingValue(
+        "executionTime",
+        artifactData.executionTime
+      ),
+      ...this.getArtifactTimingValue(
+        "executionTimeSeconds",
+        artifactData.executionTimeSeconds
+      ),
+    };
 
-    return derivedResults;
+    return {
+      ...derivedResults,
+      ...(Object.keys(timing).length > 0 ? { timing } : {}),
+      ...(dqdVersion ? { dqdVersion } : {}),
+    };
+  }
+
+  private getArtifactTimingValue<T>(key: string, value?: T | T[]) {
+    const scalarValue = Array.isArray(value) ? value[0] : value;
+    return scalarValue === undefined ? {} : { [key]: scalarValue };
   }
 
   public async getLatestFlowRunWithoutCohort(datasetId: string, token: string) {

--- a/plugins/functions/jobplugins/src/services/__tests__/DqdService.test.ts
+++ b/plugins/functions/jobplugins/src/services/__tests__/DqdService.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, it } from "jsr:@std/testing@1.0.3/bdd";
+import { assertEquals } from "jsr:@std/assert@1.0.6";
+
+Deno.env.set(
+  "SERVICE_ROUTES",
+  JSON.stringify({ prefect: "http://prefect.test" }),
+);
+
+const { PrefectAPI } = await import("../../api/PrefectAPI.ts");
+const { DqdService } = await import("../DqdService.ts");
+
+const originalPollFlowRunCompletion =
+  PrefectAPI.prototype.pollFlowRunCompletion;
+const originalGetFlowRunsArtifactsByFlowRunId =
+  PrefectAPI.prototype.getFlowRunsArtifactsByFlowRunId;
+
+afterEach(() => {
+  PrefectAPI.prototype.pollFlowRunCompletion = originalPollFlowRunCompletion;
+  PrefectAPI.prototype.getFlowRunsArtifactsByFlowRunId =
+    originalGetFlowRunsArtifactsByFlowRunId;
+});
+
+describe("DqdService.getDataQualityOverview", () => {
+  it("adds DQD run metadata to the existing overview response", async () => {
+    PrefectAPI.prototype.pollFlowRunCompletion = () =>
+      Promise.resolve({ flowRunId: "completed-flow-run" });
+    PrefectAPI.prototype.getFlowRunsArtifactsByFlowRunId = () =>
+      Promise.resolve([
+        {
+          data: JSON.stringify({
+            startTimestamp: ["2026-08-18 01:02:03"],
+            endTimestamp: ["2026-08-18 03:02:03"],
+            executionTime: ["2 hours"],
+            executionTimeSeconds: [7200],
+            Metadata: [
+              {
+                cdmReleaseDate: "2026-08-01",
+                dqdVersion: "2.8.0",
+              },
+            ],
+            Overview: {},
+            CheckResults: [],
+          }),
+        },
+      ]);
+
+    const result = await new DqdService().getDataQualityOverview(
+      "requested-flow-run",
+      "Bearer test-token",
+    );
+
+    assertEquals(result?.timing, {
+      startTimestamp: "2026-08-18 01:02:03",
+      endTimestamp: "2026-08-18 03:02:03",
+      executionTime: "2 hours",
+      executionTimeSeconds: 7200,
+    });
+    assertEquals(result?.dqdVersion, "2.8.0");
+    assertEquals(Object.hasOwn(result!, "total"), true);
+    assertEquals(Object.hasOwn(result!, "validation"), true);
+    assertEquals(Object.hasOwn(result!, "verification"), true);
+  });
+
+  it("omits metadata keys when an older artifact does not contain them", async () => {
+    PrefectAPI.prototype.pollFlowRunCompletion = () =>
+      Promise.resolve({ flowRunId: "completed-flow-run" });
+    PrefectAPI.prototype.getFlowRunsArtifactsByFlowRunId = () =>
+      Promise.resolve([
+        {
+          data: JSON.stringify({
+            Metadata: [{ cdmReleaseDate: "2026-08-01" }],
+            Overview: {},
+            CheckResults: [],
+          }),
+        },
+      ]);
+
+    const result = await new DqdService().getDataQualityOverview(
+      "requested-flow-run",
+      "Bearer test-token",
+    );
+
+    assertEquals(Object.keys(result!).sort(), [
+      "total",
+      "validation",
+      "verification",
+    ]);
+  });
+});

--- a/plugins/functions/jobplugins/src/types.ts
+++ b/plugins/functions/jobplugins/src/types.ts
@@ -8,7 +8,13 @@ export interface IPrefectFlowRunDto {
   };
 }
 
+type IDataQualityArtifactScalar<T> = T | T[];
+
 export interface IDataQualityResult {
+  startTimestamp?: IDataQualityArtifactScalar<string>;
+  endTimestamp?: IDataQualityArtifactScalar<string>;
+  executionTime?: IDataQualityArtifactScalar<string>;
+  executionTimeSeconds?: IDataQualityArtifactScalar<number>;
   Overview: {
     countOverallFailed: number;
     countFailedPlausibility: number;
@@ -17,7 +23,8 @@ export interface IDataQualityResult {
   };
   Metadata: {
     cdmReleaseDate: string;
-  };
+    dqdVersion?: string;
+  }[];
   CheckResults: IDataQualityCheckResult[];
 }
 


### PR DESCRIPTION
## Summary

- Extend the existing DQD overview endpoint with optional run metadata from the Prefect artifact.
- Return timing fields under a single `timing` object and unwrap the one-element arrays emitted by the R JSON serializer.
- Expose `dqdVersion` alongside the existing `total`, `validation`, and `verification` keys.
- Preserve the original three-key response when an older artifact does not contain timing or version metadata.

This provides the backend data needed for #3110 and #3111 without adding another UI API call.

## Endpoint

```text
GET /d2e/jobplugins/dqd/data-quality/flow-run/:flowRunId/overview?datasetId=:datasetId
```

Local example:

https://localhost:41100/d2e/jobplugins/dqd/data-quality/flow-run/b5db6c1d-e4dc-4b03-9a6c-b60c1c51539e/overview?datasetId=6784a0b0-38ad-4590-aeb6-180abed48322

## Response shape

The existing summary values are abbreviated below:

```json
{
  "total": { "...": "..." },
  "validation": { "...": "..." },
  "verification": { "...": "..." },
  "timing": {
    "startTimestamp": "2026-06-12 03:32:16",
    "endTimestamp": "2026-06-12 03:35:25",
    "executionTime": "3 mins",
    "executionTimeSeconds": 189
  },
  "dqdVersion": "2.6.0"
}
```

`timing` and `dqdVersion` are omitted when the artifact does not contain them. Individual fields inside `timing` are also optional.

## Root cause

The overview service already fetched and parsed the complete DQD artifact, but returned only the derived summary counts and discarded the artifact's timing and version metadata.

## UI integration note: timestamp timezone

The timezone of the stored DQD timestamp cannot be confirmed from the artifact itself. DQD creates the value using the R worker's system time and serializes it without a timezone offset or `Z` suffix.

The UI should therefore display the supplied timestamp value directly. It should not apply a browser/local conversion such as `+8`, append a timezone label, or otherwise reinterpret the value as a confirmed UTC timestamp.

## Validation

- `deno test --config plugins/functions/jobplugins/deno.json --no-lock --no-check --allow-env plugins/functions/jobplugins/src/services/__tests__/DqdService.test.ts`
- Focused test passed: enriched artifact metadata and legacy artifact fallback.
- Loaded locally by restarting `d2e-trex`; Trex returned a healthy internal status.
