### PR TITLE
Add Wizard workflows to Atlas analyses

### DIFF
--- a/plugins/atlas/plugins.standalone.json
+++ b/plugins/atlas/plugins.standalone.json
@@ -41,6 +41,24 @@
       "metadata": { "author": "OHDSI", "description": "Strategus Analysis Specification Builder" }
     },
     {
+      "id": "wizards",
+      "name": "Wizard",
+      "version": "1.0.0",
+      "entryPoint": "/resources/wizards/lifecycles.js",
+      "menuItems": [],
+      "mountPoints": [
+        {
+          "id": "wizards",
+          "surface": "analysis-tabs",
+          "name": "Wizard",
+          "icon": "mdi-auto-fix",
+          "hint": "Create analyses with guided D2E workflows.",
+          "insertBefore": "feature-analyses"
+        }
+      ],
+      "metadata": { "author": "D2E", "description": "Guided D2E analysis workflows" }
+    },
+    {
       "id": "notebook-plugin",
       "name": "Notebooks",
       "version": "0.1.0",

--- a/plugins/atlas/plugins.standalone.json
+++ b/plugins/atlas/plugins.standalone.json
@@ -52,7 +52,6 @@
           "surface": "analysis-tabs",
           "name": "Wizard",
           "icon": "mdi-auto-fix",
-          "hint": "Create analyses with guided D2E workflows.",
           "insertBefore": "feature-analyses"
         }
       ],

--- a/plugins/atlas/scripts/postinstall.js
+++ b/plugins/atlas/scripts/postinstall.js
@@ -102,7 +102,8 @@ if (existsSync(landingImageSrc)) {
 //  - login-guard.js: silent-SSO guard; runs first, blocks the WebAPI HS256 fallback.
 //  - user-link.js: routes the navbar user menu to the d2e portal account page.
 //  - token-keeper.js: refreshes the Logto bearerToken before expiry.
-const headScripts = ['login-guard.js', 'user-link.js', 'token-keeper.js'];
+//  - analysis-default.js: opens the Wizard when entering the Analysis hub.
+const headScripts = ['login-guard.js', 'user-link.js', 'token-keeper.js', 'analysis-default.js'];
 let indexHtml = readFileSync(join(resourcesDir, 'index.html'), 'utf8');
 let indexChanged = false;
 for (const script of headScripts) {

--- a/plugins/atlas/scripts/verify-plugins.js
+++ b/plugins/atlas/scripts/verify-plugins.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Prepack guard: every plugin registered in the served plugins.json must have its
- * entryPoint present under resources/atlas/plugins.
+ * Prepack guard: every Atlas-bundled plugin registered in the served plugins.json
+ * must have its entryPoint present under resources/atlas/plugins. Root-relative
+ * entry points are served by another Trex UI route and are not checked here.
  *
  * The Atlas3 shell reads config/plugins.json to build its menu, then SystemJS-imports
  * each entryPoint on navigation. A registered plugin whose bundle was never staged
@@ -26,9 +27,16 @@ if (!existsSync(configPath)) {
 }
 
 const { plugins = [] } = JSON.parse(readFileSync(configPath, 'utf8'));
-const missing = plugins.filter(p => p.entryPoint && !existsSync(join(pluginsDir, p.entryPoint)));
+const isTrexRoute = entryPoint => entryPoint.startsWith('/');
+const missing = plugins.filter(
+  p => p.entryPoint && !isTrexRoute(p.entryPoint) && !existsSync(join(pluginsDir, p.entryPoint))
+);
 
 for (const p of plugins) {
+  if (isTrexRoute(p.entryPoint)) {
+    console.log(`[verify-plugins] ROUTE ${p.id} -> ${p.entryPoint}`);
+    continue;
+  }
   const ok = !missing.includes(p);
   console.log(`[verify-plugins] ${ok ? 'OK  ' : 'MISS'} ${p.id} -> plugins/${p.entryPoint}`);
 }
@@ -43,4 +51,4 @@ if (missing.length) {
   process.exit(1);
 }
 
-console.log(`[verify-plugins] All ${plugins.length} registered plugins have a bundle.`);
+console.log('[verify-plugins] All bundled plugin entry points are present.');

--- a/plugins/atlas/token-keeper/analysis-default.js
+++ b/plugins/atlas/token-keeper/analysis-default.js
@@ -1,0 +1,26 @@
+(function () {
+  'use strict'
+
+  var wizardHash = '#/analysis/x/wizards/wizards'
+
+  function isAnalysisHash(hash) {
+    return hash === '#/analysis' || hash.indexOf('#/analysis/') === 0
+  }
+
+  function isBuiltInDefaultHash(hash) {
+    return hash === '#/analysis' || hash === '#/analysis/' || hash === '#/analysis/feature-analyses'
+  }
+
+  document.addEventListener('click', function (event) {
+    if (isAnalysisHash(window.location.hash) || !(event.target instanceof Element)) return
+
+    // nav-bar__nav-link is owned by Atlas. Wait for its asynchronous redirect,
+    // then replace only the built-in Analysis default with the Wizard route.
+    if (!event.target.closest('.nav-bar__nav-link')) return
+    window.setTimeout(function () {
+      if (isBuiltInDefaultHash(window.location.hash)) {
+        window.location.replace(wizardHash)
+      }
+    }, 100)
+  }, true)
+})()

--- a/plugins/ui/apps/wizards/public/lifecycles.css
+++ b/plugins/ui/apps/wizards/public/lifecycles.css
@@ -1,0 +1,1 @@
+/* Atlas probes for a sibling stylesheet; Wizard styles are injected by lifecycles.js. */

--- a/plugins/ui/apps/wizards/src/App.tsx
+++ b/plugins/ui/apps/wizards/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { PortalProps } from "./types/portal";
 import { WizardProvider } from "./context/WizardContext";
 import { WizardShell } from "./components/WizardShell";
+import { isWizardPropsChangeForApp } from "./utils/portalProps";
 import "./global.css";
 
 function AppContent() {
@@ -12,9 +13,12 @@ export default function App(props: PortalProps) {
   const [customProps, setCustomProps] = useState<Partial<PortalProps>>({});
 
   useEffect(() => {
+    // Atlas publishes this event when its global source changes. The embedded
+    // Wizard selector also uses it to update this app immediately; Atlas does
+    // not consume events published by the Wizard.
     const handlePropsChange = (event: Event) => {
       const { appId, ...newProps } = (event as CustomEvent).detail || {};
-      if (appId === props.appId) {
+      if (isWizardPropsChangeForApp(appId, props.appId)) {
         setCustomProps(newProps);
       }
     };

--- a/plugins/ui/apps/wizards/src/api/__tests__/atlasSourceApi.test.ts
+++ b/plugins/ui/apps/wizards/src/api/__tests__/atlasSourceApi.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import client from "../../axios/request";
+import { listAtlasSources, publishAtlasSourceSelection, resolveAtlasSourceKey } from "../atlasSourceApi";
+
+vi.mock("../../axios/request", () => ({
+  default: { get: vi.fn() },
+}));
+
+const mockedGet = vi.mocked(client.get);
+
+describe("Atlas source API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists valid Atlas data sources with the host token", async () => {
+    mockedGet.mockResolvedValue({
+      data: [
+        {
+          sourceId: 17,
+          sourceKey: "dataset-1",
+          sourceName: "Demo dataset",
+          sourceDialect: "postgresql",
+        },
+      ],
+    });
+
+    await expect(listAtlasSources(async () => "token-1")).resolves.toEqual([
+      {
+        sourceId: 17,
+        sourceKey: "dataset-1",
+        sourceName: "Demo dataset",
+        sourceDialect: "postgresql",
+      },
+    ]);
+    expect(mockedGet).toHaveBeenCalledWith("/WebAPI/source/sources", {
+      headers: { Authorization: "Bearer token-1" },
+    });
+  });
+
+  it("rejects a malformed Atlas source response", async () => {
+    mockedGet.mockResolvedValue({ data: { sourceKey: "dataset-1" } });
+
+    await expect(listAtlasSources()).rejects.toThrow("invalid data-source list");
+  });
+
+  it("keeps a selected Atlas source when it is present in the source list", () => {
+    const sources = [
+      { sourceId: 1, sourceKey: "dataset-1", sourceName: "Dataset 1", sourceDialect: "postgresql" },
+      { sourceId: 2, sourceKey: "dataset-2", sourceName: "Dataset 2", sourceDialect: "postgresql" },
+    ];
+
+    expect(resolveAtlasSourceKey(sources, "dataset-2")).toBe("dataset-2");
+  });
+
+  it("falls back to the first Atlas source when no valid selection is available", () => {
+    const sources = [
+      { sourceId: 1, sourceKey: "dataset-1", sourceName: "Dataset 1", sourceDialect: "postgresql" },
+      { sourceId: 2, sourceKey: "dataset-2", sourceName: "Dataset 2", sourceDialect: "postgresql" },
+    ];
+
+    expect(resolveAtlasSourceKey(sources)).toBe("dataset-1");
+    expect(resolveAtlasSourceKey(sources, "missing-dataset")).toBe("dataset-1");
+  });
+
+  it("publishes sourceKey as the Wizard dataset id", () => {
+    const setStoredSourceKey = vi.fn();
+    const dispatchPropsChange = vi.fn();
+
+    expect(
+      publishAtlasSourceSelection("wizards", "dataset-1", {
+        setStoredSourceKey,
+        dispatchPropsChange,
+      }),
+    ).toEqual({ appId: "wizards", datasetId: "dataset-1" });
+    expect(setStoredSourceKey).toHaveBeenCalledWith("dataset-1");
+    expect(dispatchPropsChange).toHaveBeenCalledWith({ appId: "wizards", datasetId: "dataset-1" });
+  });
+});

--- a/plugins/ui/apps/wizards/src/api/atlasSourceApi.ts
+++ b/plugins/ui/apps/wizards/src/api/atlasSourceApi.ts
@@ -1,0 +1,75 @@
+import client from "../axios/request";
+
+export interface AtlasSource {
+  sourceId: number;
+  sourceKey: string;
+  sourceName: string;
+  sourceDialect: string;
+}
+
+interface AtlasSourceSelectionRuntime {
+  setStoredSourceKey: (sourceKey: string) => void;
+  dispatchPropsChange: (detail: { appId: string; datasetId: string }) => void;
+}
+
+function isAtlasSource(value: unknown): value is AtlasSource {
+  if (!value || typeof value !== "object") return false;
+  const source = value as Partial<AtlasSource>;
+  return (
+    typeof source.sourceId === "number" &&
+    typeof source.sourceKey === "string" &&
+    source.sourceKey.trim().length > 0 &&
+    typeof source.sourceName === "string" &&
+    typeof source.sourceDialect === "string"
+  );
+}
+
+export async function listAtlasSources(getToken?: () => Promise<string>): Promise<AtlasSource[]> {
+  const token = await getToken?.();
+  const response = await client.get<unknown>("/WebAPI/source/sources", {
+    ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+  });
+
+  if (!Array.isArray(response.data)) {
+    throw new Error("Atlas returned an invalid data-source list");
+  }
+
+  return response.data.filter(isAtlasSource);
+}
+
+export function resolveAtlasSourceKey(sources: AtlasSource[], selectedSourceKey?: string): string | undefined {
+  const selectedSourceExists = sources.some((source) => source.sourceKey === selectedSourceKey);
+  return selectedSourceExists ? selectedSourceKey : sources[0]?.sourceKey;
+}
+
+function getBrowserSelectionRuntime(): AtlasSourceSelectionRuntime | undefined {
+  if (typeof window === "undefined") return undefined;
+
+  return {
+    setStoredSourceKey: (sourceKey) => {
+      try {
+        // Persist the choice for Atlas remounts/reloads. This does not update
+        // Atlas's reactive source store in the current page.
+        window.localStorage.setItem("selectedVocabulary", sourceKey);
+      } catch {
+        // The prop-change event still updates Wizards when storage is unavailable.
+      }
+    },
+    dispatchPropsChange: (detail) => {
+      // Notify the Wizard listener immediately. Atlas publishes the same event
+      // for host source changes, but does not listen to Wizard-published events.
+      window.dispatchEvent(new CustomEvent("custom-props-changed", { detail }));
+    },
+  };
+}
+
+export function publishAtlasSourceSelection(
+  appId: string | undefined,
+  sourceKey: string,
+  runtime: AtlasSourceSelectionRuntime | undefined = getBrowserSelectionRuntime(),
+): { appId: string; datasetId: string } {
+  const detail = { appId: appId || "wizards", datasetId: sourceKey };
+  runtime?.setStoredSourceKey(sourceKey);
+  runtime?.dispatchPropsChange(detail);
+  return detail;
+}

--- a/plugins/ui/apps/wizards/src/components/StepForm.module.css
+++ b/plugins/ui/apps/wizards/src/components/StepForm.module.css
@@ -16,11 +16,18 @@
   font-weight: 600;
 }
 
+.titleBar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 8px;
+}
+
 .titleRow {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
 }
 
 .titleRow h2 {
@@ -615,6 +622,10 @@
 }
 
 @media (max-width: 768px) {
+  .titleBar {
+    flex-wrap: wrap;
+  }
+
   .twoColumns,
   .threeColumns {
     grid-template-columns: minmax(0, 1fr);

--- a/plugins/ui/apps/wizards/src/components/StepForm.tsx
+++ b/plugins/ui/apps/wizards/src/components/StepForm.tsx
@@ -5,6 +5,7 @@ import type { FieldDefinition, FormStepConfig } from "../types/wizard";
 import { buildWizardSubmitPayload, generateFormSubmitDeepLink } from "../utils/deepLinks";
 import { fetchCdwConfig } from "../config/cdwConfig";
 import type { ConfigMeta } from "../config/cdwConfig";
+import { listAtlasSources, resolveAtlasSourceKey } from "../api/atlasSourceApi";
 import { TypeaheadField } from "./TypeaheadField";
 import { AnalyticsIcon } from "./icons/AnalyticsIcon";
 import { WizardDashboardModal } from "./WizardDashboardModal";
@@ -18,6 +19,7 @@ import {
 import type { ResolvedWizardFieldGroup } from "../utils/wizardSections";
 import { resolveWizardFormNote } from "../config/wizardDefinitions";
 import styles from "./StepForm.module.css";
+import sourceStyles from "./StepSelection.module.css";
 
 // Keep the legacy Cohort Builder action available for a one-line re-enable.
 // Standalone Wizards currently exposes only the direct dashboard action.
@@ -32,6 +34,7 @@ export function StepForm() {
     formData,
     updateFormData,
     goBack,
+    resetWizard,
     goForward,
     getCurrentStepConfig,
     portalProps,
@@ -40,6 +43,7 @@ export function StepForm() {
   } = useWizardContext();
   const stepConfig = getCurrentStepConfig();
   const [configMeta, setConfigMeta] = useState<ConfigMeta | null>(null);
+  const [atlasSourceName, setAtlasSourceName] = useState("");
   const displayValuesRef = useRef<Record<string, string>>({});
   const defaultFormValues = { ...formData };
   const dashboardFlow = useWizardDashboardFlow({
@@ -71,6 +75,28 @@ export function StepForm() {
   useEffect(() => {
     fetchCdwConfig(portalProps.datasetId).then(({ meta }) => setConfigMeta(meta));
   }, [portalProps.datasetId]);
+
+  useEffect(() => {
+    if (portalProps.isAtlas !== true) return;
+
+    let active = true;
+    setAtlasSourceName("");
+    listAtlasSources(portalProps.getToken)
+      .then((sources) => {
+        if (!active) return;
+        const sourceKey = resolveAtlasSourceKey(sources, portalProps.datasetId);
+        setAtlasSourceName(
+          sources.find((source) => source.sourceKey === sourceKey)?.sourceName || "Data source unavailable",
+        );
+      })
+      .catch(() => {
+        if (active) setAtlasSourceName("Data source unavailable");
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [portalProps.datasetId, portalProps.getToken, portalProps.isAtlas]);
 
   const {
     register,
@@ -473,6 +499,7 @@ export function StepForm() {
 
   const submitLabel = stepConfig ? (stepConfig.config as FormStepConfig)?.submitLabel || "Next" : "Next";
   const formNote = resolveWizardFormNote(selectedWizard.formNote);
+  const handleBack = portalProps.isAtlas === true ? resetWizard : goBack;
 
   const renderFields = (fields: FieldDefinition[], containingGroup?: ResolvedWizardFieldGroup) => {
     return fields.map((field) => renderField(field, containingGroup));
@@ -561,19 +588,36 @@ export function StepForm() {
 
   return (
     <div className={styles.container}>
-      <div className={styles.titleRow}>
-        <button
-          type="button"
-          onClick={goBack}
-          className={styles.backIconButton}
-          aria-label="Back to wizard selection"
-          title="Back to wizard selection"
-        >
-          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
-            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.42-1.41L7.83 13H20v-2Z" />
-          </svg>
-        </button>
-        <h2>{selectedWizard.name}</h2>
+      <div className={styles.titleBar}>
+        <div className={styles.titleRow}>
+          <button
+            type="button"
+            onClick={handleBack}
+            className={styles.backIconButton}
+            aria-label="Back to wizard selection"
+            title="Back to wizard selection"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+              <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.42-1.41L7.83 13H20v-2Z" />
+            </svg>
+          </button>
+          <h2>{selectedWizard.name}</h2>
+        </div>
+        {portalProps.isAtlas === true ? (
+          <div
+            className={`${sourceStyles.sourceSelector} ${sourceStyles.sourceSelectorReadOnly}`}
+            aria-label="Data source"
+          >
+            <span className={sourceStyles.sourceLabel}>Data source</span>
+            <svg className={sourceStyles.sourceIcon} viewBox="0 0 24 24" aria-hidden="true">
+              <ellipse cx="12" cy="5" rx="8" ry="3" />
+              <path d="M4 5v5c0 1.7 3.6 3 8 3s8-1.3 8-3V5" />
+              <path d="M4 10v5c0 1.7 3.6 3 8 3s8-1.3 8-3v-5" />
+              <path d="M4 15v4c0 1.7 3.6 3 8 3s8-1.3 8-3v-4" />
+            </svg>
+            <span className={sourceStyles.sourceValue}>{atlasSourceName || "Loading data source..."}</span>
+          </div>
+        ) : null}
       </div>
 
       {selectedWizard.description && <div className={styles.description}>{selectedWizard.description}</div>}
@@ -595,7 +639,7 @@ export function StepForm() {
         {renderConfiguredFields()}
 
         <div className={styles.buttonRow}>
-          <button type="button" onClick={goBack} className={styles.button}>
+          <button type="button" onClick={handleBack} className={styles.button}>
             Back
           </button>
           <div className={styles.primaryActions}>

--- a/plugins/ui/apps/wizards/src/components/StepSelection.module.css
+++ b/plugins/ui/apps/wizards/src/components/StepSelection.module.css
@@ -6,9 +6,14 @@
   box-sizing: border-box;
 }
 
+/* Atlas currently appends analysis plugin tabs after its built-in tabs. */
+:global(.analysis-hub__tabs-rail .v-tab[value="plugin:wizards:wizards"]) {
+  order: -1;
+}
+
 .header {
   margin-top: 20px;
-  margin-bottom: 48px;
+  margin-bottom: 24px;
 }
 
 .header h2 {
@@ -25,6 +30,75 @@
   margin: 0;
   color: #666;
   font-size: 14px;
+}
+
+.sourceToolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.sourceSelector {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: min(100%, 260px);
+  min-height: 48px;
+  border: 1px solid #b7b7b7;
+  border-radius: 8px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.sourceSelector:focus-within {
+  border-color: #000080;
+  box-shadow: 0 0 0 1px #000080;
+}
+
+.sourceLabel {
+  position: absolute;
+  top: -9px;
+  left: 42px;
+  padding: 0 6px;
+  background: #fff;
+  color: #666;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.sourceIcon {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  margin-left: 14px;
+  fill: #666;
+  stroke: #666;
+  stroke-width: 1.2;
+}
+
+.sourceControl {
+  width: 100%;
+  min-width: 0;
+  height: 46px;
+  padding: 8px 38px 6px 10px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #222;
+  font: inherit;
+  cursor: pointer;
+}
+
+.sourceControl:disabled {
+  color: #777;
+  cursor: default;
+}
+
+.sourceError {
+  color: #c00;
+  font-size: 13px;
 }
 
 .grid {

--- a/plugins/ui/apps/wizards/src/components/StepSelection.module.css
+++ b/plugins/ui/apps/wizards/src/components/StepSelection.module.css
@@ -6,9 +6,61 @@
   box-sizing: border-box;
 }
 
+.atlasContainer {
+  max-width: none;
+  margin: 0;
+  padding: 20px 32px 32px;
+}
+
 /* Atlas currently appends analysis plugin tabs after its built-in tabs. */
+:global(.analysis-hub__tabs-rail) {
+  border-bottom-color: #ddd;
+}
+
+:global(.analysis-hub__tabs-rail .v-tabs) {
+  height: 52px;
+}
+
 :global(.analysis-hub__tabs-rail .v-tab[value="plugin:wizards:wizards"]) {
   order: -1;
+}
+
+:global(.analysis-hub__tabs-rail .v-tab--selected .v-tab__slider) {
+  height: 4px;
+  background: #000080;
+}
+
+/* Keep transitions aligned with the Wizard tab's visual first position. */
+:global(
+  .analysis-hub .v-window__container:has(.v-window-x-reverse-transition-leave-active .plugin-parcel-outlet)
+    .v-window-x-reverse-transition-enter-active
+) {
+  animation: atlasWizardEnterFromRight 300ms cubic-bezier(0.25, 0.8, 0.5, 1);
+}
+
+:global(.analysis-hub .v-window-x-reverse-transition-leave-to:has(.plugin-parcel-outlet)) {
+  transform: translateX(-100%);
+}
+
+:global(.analysis-hub .v-window-x-transition-enter-from:has(.plugin-parcel-outlet)) {
+  transform: translateX(-100%);
+}
+
+:global(
+  .analysis-hub .v-window__container:has(.v-window-x-transition-enter-active .plugin-parcel-outlet)
+    .v-window-x-transition-leave-to
+) {
+  transform: translateX(100%);
+}
+
+@keyframes atlasWizardEnterFromRight {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
 }
 
 .header {
@@ -26,18 +78,126 @@
   color: #666;
 }
 
+.atlasIntro {
+  margin: 0 0 20px;
+  color: #222;
+  font-size: 16px;
+  line-height: 1.5;
+}
+
 .progress {
   margin: 0;
   color: #666;
   font-size: 14px;
 }
 
-.sourceToolbar {
+.toolbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 20px;
+}
+
+.searchBox {
+  display: flex;
+  align-items: center;
+  flex: 1 1 480px;
+  max-width: 560px;
+  height: 48px;
+  border: 1px solid #b7b7b7;
+  border-radius: 4px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.searchBox:focus-within {
+  border-color: #000080;
+  box-shadow: 0 0 0 1px #000080;
+}
+
+.searchBox input {
+  width: 100%;
+  height: 100%;
+  padding: 0 14px 0 6px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #222;
+  font: inherit;
+}
+
+.searchBox input::placeholder {
+  color: #999;
+}
+
+.searchIcon {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  margin-left: 14px;
+  fill: none;
+  stroke: #777;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+
+.toolbarActions {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.viewToggle {
+  display: flex;
+  height: 48px;
+  padding: 2px;
+  border: 1px solid #c8cae8;
+  border-radius: 8px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.viewButton,
+.viewButtonActive {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 42px;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: #000080;
+  cursor: pointer;
+}
+
+.viewButtonActive {
+  background: #000080;
+  color: #fff;
+}
+
+.viewButton:focus-visible,
+.viewButtonActive:focus-visible {
+  outline: 2px solid #000080;
+  outline-offset: 2px;
+}
+
+.viewButton svg,
+.viewButtonActive svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.sourceField {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
   gap: 6px;
-  margin-bottom: 20px;
 }
 
 .sourceSelector {
@@ -55,6 +215,18 @@
 .sourceSelector:focus-within {
   border-color: #000080;
   box-shadow: 0 0 0 1px #000080;
+}
+
+.sourceSelector:has(.sourceControl)::after {
+  position: absolute;
+  right: 16px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #595757;
+  border-bottom: 2px solid #595757;
+  content: "";
+  pointer-events: none;
+  transform: translateY(-2px) rotate(45deg);
 }
 
 .sourceLabel {
@@ -89,11 +261,30 @@
   color: #222;
   font: inherit;
   cursor: pointer;
+  appearance: none;
 }
 
 .sourceControl:disabled {
   color: #777;
   cursor: default;
+}
+
+.sourceSelectorReadOnly {
+  width: 220px;
+}
+
+.sourceValue {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 46px;
+  align-items: center;
+  padding: 8px 14px 6px 10px;
+  overflow: hidden;
+  color: #222;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  box-sizing: border-box;
 }
 
 .sourceError {
@@ -107,6 +298,58 @@
   gap: 16px;
 }
 
+.list {
+  width: 100%;
+}
+
+.listHeader,
+.listRow {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+  column-gap: 24px;
+  align-items: center;
+}
+
+.listHeader {
+  min-height: 40px;
+  padding: 0 10px;
+  border-bottom: 1px solid #ddd;
+  color: #555;
+  font-weight: 600;
+  box-sizing: border-box;
+}
+
+.listRow {
+  width: 100%;
+  min-height: 70px;
+  padding: 12px 10px;
+  border: 0;
+  border-bottom: 1px solid #ddd;
+  background: #fff;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.listRow:hover {
+  background: #faf8f8;
+}
+
+.listRow:focus-visible {
+  outline: 2px solid #000080;
+  outline-offset: -2px;
+}
+
+.listName {
+  color: #000080;
+  font-weight: 600;
+}
+
+.listDescription {
+  line-height: 1.45;
+}
+
 .card {
   border: 1px solid #ddd;
   border-radius: 4px;
@@ -115,6 +358,47 @@
   transition: all 0.2s ease;
   background: #fff;
   min-height: 250px;
+}
+
+.atlasContainer .grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.atlasContainer .card {
+  min-height: 250px;
+  padding: 28px;
+  border-color: #efebed;
+  border-radius: 16px;
+  background: #faf8f8;
+  box-shadow: none;
+}
+
+.atlasContainer .card:hover {
+  border-color: #aeb4df;
+  box-shadow: 0 2px 8px rgba(0, 0, 128, 0.08);
+}
+
+.atlasContainer .cardTitle {
+  color: #000080;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.atlasContainer .cardDescription {
+  color: #626262;
+  font-size: 17px;
+  line-height: 1.55;
+}
+
+.atlasContainer .listHeader {
+  min-height: 48px;
+  padding: 0 8px;
+}
+
+.atlasContainer .listRow {
+  min-height: 72px;
+  padding: 14px 8px;
 }
 
 .card:hover {
@@ -169,4 +453,47 @@
 .retryButton:focus {
   outline: 2px solid #0066cc;
   outline-offset: 2px;
+}
+
+@media (max-width: 800px) {
+  .toolbar {
+    flex-direction: column;
+  }
+
+  .searchBox {
+    flex-basis: auto;
+    width: 100%;
+    max-width: none;
+  }
+
+  .toolbarActions {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .listHeader,
+  .listRow {
+    grid-template-columns: 1fr;
+    row-gap: 8px;
+  }
+
+  .listHeader span:last-child {
+    display: none;
+  }
+}
+
+@media (max-width: 1100px) {
+  .atlasContainer .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .atlasContainer {
+    padding-inline: 20px;
+  }
+
+  .atlasContainer .grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/plugins/ui/apps/wizards/src/components/StepSelection.tsx
+++ b/plugins/ui/apps/wizards/src/components/StepSelection.tsx
@@ -1,22 +1,29 @@
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState, useEffect, useMemo } from "react";
 import { getWizardDefinitions, isWizardVisibleOnSurface } from "../config/wizardDefinitions";
 import { useWizardContext } from "../context/WizardContext";
 import type { WizardDefinition } from "../types/wizard";
 import { listAtlasSources, publishAtlasSourceSelection, resolveAtlasSourceKey } from "../api/atlasSourceApi";
 import type { AtlasSource } from "../api/atlasSourceApi";
+import { filterWizards } from "../utils/wizardSearch";
 import styles from "./StepSelection.module.css";
+
+type ViewMode = "tiles" | "list";
 
 /**
  * Wizard selection grid.
  */
 export function StepSelection() {
   const { selectWizard, portalProps } = useWizardContext();
+  const isAtlas = portalProps.isAtlas === true;
   const [wizards, setWizards] = useState<WizardDefinition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sources, setSources] = useState<AtlasSource[]>([]);
   const [sourcesLoading, setSourcesLoading] = useState(portalProps.isAtlas === true);
   const [sourcesError, setSourcesError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [viewMode, setViewMode] = useState<ViewMode>("tiles");
+  const filteredWizards = useMemo(() => filterWizards(wizards, searchQuery), [searchQuery, wizards]);
 
   const selectSource = useCallback(
     (sourceKey: string) => {
@@ -134,9 +141,36 @@ export function StepSelection() {
       return <div className={styles.empty}>No wizards available</div>;
     }
 
+    if (filteredWizards.length === 0) {
+      return <div className={styles.empty}>No wizards match your search</div>;
+    }
+
+    if (viewMode === "list") {
+      return (
+        <div className={styles.list}>
+          <div className={styles.listHeader} aria-hidden="true">
+            <span>Name</span>
+            <span>Descriptions</span>
+          </div>
+          {filteredWizards.map((wizard) => (
+            <button
+              key={wizard.id}
+              type="button"
+              className={styles.listRow}
+              onClick={() => handleWizardSelect(wizard.id)}
+              aria-label={`Select ${wizard.name} wizard`}
+            >
+              <span className={styles.listName}>{wizard.name}</span>
+              <span className={styles.listDescription}>{wizard.description}</span>
+            </button>
+          ))}
+        </div>
+      );
+    }
+
     return (
       <div className={styles.grid}>
-        {wizards.map((wizard) => (
+        {filteredWizards.map((wizard) => (
           <div
             key={wizard.id}
             className={styles.card}
@@ -155,45 +189,99 @@ export function StepSelection() {
   };
 
   return (
-    <div className={styles.container}>
-      <div className={styles.header}>
-        <h2>Getting started</h2>
-        <p className={styles.subtitle}>We've built some pre-configured scenarios to get you started</p>
-      </div>
-      {portalProps.isAtlas === true ? (
-        <div className={styles.sourceToolbar}>
-          <label className={styles.sourceSelector}>
-            <span className={styles.sourceLabel}>Data source</span>
-            <svg className={styles.sourceIcon} viewBox="0 0 24 24" aria-hidden="true">
-              <ellipse cx="12" cy="5" rx="8" ry="3" />
-              <path d="M4 5v5c0 1.7 3.6 3 8 3s8-1.3 8-3V5" />
-              <path d="M4 10v5c0 1.7 3.6 3 8 3s8-1.3 8-3v-5" />
-              <path d="M4 15v4c0 1.7 3.6 3 8 3s8-1.3 8-3v-4" />
-            </svg>
-            <select
-              className={styles.sourceControl}
-              value={portalProps.datasetId || ""}
-              disabled={sourcesLoading || sources.length === 0}
-              onChange={(event) => selectSource(event.target.value)}
-              aria-label="Data source"
-            >
-              <option value="" disabled>
-                {sourcesLoading
-                  ? "Loading data sources..."
-                  : sources.length > 0
-                    ? "Select a data source"
-                    : "No data sources available"}
-              </option>
-              {sources.map((source) => (
-                <option key={source.sourceKey} value={source.sourceKey}>
-                  {source.sourceName}
-                </option>
-              ))}
-            </select>
-          </label>
-          {sourcesError ? <span className={styles.sourceError}>{sourcesError}</span> : null}
+    <div className={`${styles.container} ${isAtlas ? styles.atlasContainer : ""}`}>
+      {isAtlas ? (
+        <p className={styles.atlasIntro}>
+          We've prepared a set of pre-built scenarios to jumpstart your analysis.{" "}
+          <strong>Select an analysis type below to generate results, no coding needed.</strong>
+        </p>
+      ) : (
+        <div className={styles.header}>
+          <h2>Getting started</h2>
+          <p className={styles.subtitle}>We've built some pre-configured scenarios to get you started</p>
         </div>
-      ) : null}
+      )}
+      <div className={styles.toolbar}>
+        <label className={styles.searchBox}>
+          <svg className={styles.searchIcon} viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="10.5" cy="10.5" r="6.5" />
+            <path d="m15.5 15.5 5 5" />
+          </svg>
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search"
+            aria-label="Search wizards"
+          />
+        </label>
+        <div className={styles.toolbarActions}>
+          <div className={styles.viewToggle} role="group" aria-label="Wizard view">
+            <button
+              type="button"
+              className={viewMode === "tiles" ? styles.viewButtonActive : styles.viewButton}
+              onClick={() => setViewMode("tiles")}
+              aria-label="Tile view"
+              aria-pressed={viewMode === "tiles"}
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="4" y="4" width="6" height="6" />
+                <rect x="14" y="4" width="6" height="6" />
+                <rect x="4" y="14" width="6" height="6" />
+                <rect x="14" y="14" width="6" height="6" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              className={viewMode === "list" ? styles.viewButtonActive : styles.viewButton}
+              onClick={() => setViewMode("list")}
+              aria-label="List view"
+              aria-pressed={viewMode === "list"}
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="5" cy="6" r="1" />
+                <circle cx="5" cy="12" r="1" />
+                <circle cx="5" cy="18" r="1" />
+                <path d="M9 6h11M9 12h11M9 18h11" />
+              </svg>
+            </button>
+          </div>
+          {portalProps.isAtlas === true ? (
+            <div className={styles.sourceField}>
+              <label className={styles.sourceSelector}>
+                <span className={styles.sourceLabel}>Data source</span>
+                <svg className={styles.sourceIcon} viewBox="0 0 24 24" aria-hidden="true">
+                  <ellipse cx="12" cy="5" rx="8" ry="3" />
+                  <path d="M4 5v5c0 1.7 3.6 3 8 3s8-1.3 8-3V5" />
+                  <path d="M4 10v5c0 1.7 3.6 3 8 3s8-1.3 8-3v-5" />
+                  <path d="M4 15v4c0 1.7 3.6 3 8 3s8-1.3 8-3v-4" />
+                </svg>
+                <select
+                  className={styles.sourceControl}
+                  value={portalProps.datasetId || ""}
+                  disabled={sourcesLoading || sources.length === 0}
+                  onChange={(event) => selectSource(event.target.value)}
+                  aria-label="Data source"
+                >
+                  <option value="" disabled>
+                    {sourcesLoading
+                      ? "Loading data sources..."
+                      : sources.length > 0
+                        ? "Select a data source"
+                        : "No data sources available"}
+                  </option>
+                  {sources.map((source) => (
+                    <option key={source.sourceKey} value={source.sourceKey}>
+                      {source.sourceName}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {sourcesError ? <span className={styles.sourceError}>{sourcesError}</span> : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
       {renderContent()}
     </div>
   );

--- a/plugins/ui/apps/wizards/src/components/StepSelection.tsx
+++ b/plugins/ui/apps/wizards/src/components/StepSelection.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { getWizardDefinitions, isWizardVisibleOnSurface } from "../config/wizardDefinitions";
 import { useWizardContext } from "../context/WizardContext";
 import type { WizardDefinition } from "../types/wizard";
+import { listAtlasSources, publishAtlasSourceSelection, resolveAtlasSourceKey } from "../api/atlasSourceApi";
+import type { AtlasSource } from "../api/atlasSourceApi";
 import styles from "./StepSelection.module.css";
 
 /**
@@ -12,8 +14,60 @@ export function StepSelection() {
   const [wizards, setWizards] = useState<WizardDefinition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [sources, setSources] = useState<AtlasSource[]>([]);
+  const [sourcesLoading, setSourcesLoading] = useState(portalProps.isAtlas === true);
+  const [sourcesError, setSourcesError] = useState<string | null>(null);
+
+  const selectSource = useCallback(
+    (sourceKey: string) => {
+      if (!sourceKey || sourceKey === portalProps.datasetId) return;
+      publishAtlasSourceSelection(portalProps.appId, sourceKey);
+    },
+    [portalProps.appId, portalProps.datasetId],
+  );
+
+  useEffect(() => {
+    if (portalProps.isAtlas !== true) return;
+
+    let active = true;
+    setSourcesLoading(true);
+    setSourcesError(null);
+
+    listAtlasSources(portalProps.getToken)
+      .then((availableSources) => {
+        if (!active) return;
+        setSources(availableSources);
+      })
+      .catch((sourceError) => {
+        if (!active) return;
+        console.error("[Wizards] Failed to load Atlas data sources:", sourceError);
+        setSourcesError("Unable to load data sources");
+      })
+      .finally(() => {
+        if (active) setSourcesLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [portalProps.getToken, portalProps.isAtlas]);
+
+  useEffect(() => {
+    if (portalProps.isAtlas !== true || sourcesLoading) return;
+
+    const sourceKey = resolveAtlasSourceKey(sources, portalProps.datasetId);
+    if (sourceKey && sourceKey !== portalProps.datasetId) {
+      selectSource(sourceKey);
+    }
+  }, [portalProps.datasetId, portalProps.isAtlas, selectSource, sources, sourcesLoading]);
 
   const loadWizards = async () => {
+    if (portalProps.isAtlas === true && !portalProps.datasetId) {
+      setLoading(false);
+      setWizards([]);
+      return;
+    }
+
     try {
       setLoading(true);
       setError(null);
@@ -74,6 +128,9 @@ export function StepSelection() {
     }
 
     if (wizards.length === 0) {
+      if (portalProps.isAtlas === true && !portalProps.datasetId) {
+        return <div className={styles.empty}>Select a data source to view wizards</div>;
+      }
       return <div className={styles.empty}>No wizards available</div>;
     }
 
@@ -103,6 +160,40 @@ export function StepSelection() {
         <h2>Getting started</h2>
         <p className={styles.subtitle}>We've built some pre-configured scenarios to get you started</p>
       </div>
+      {portalProps.isAtlas === true ? (
+        <div className={styles.sourceToolbar}>
+          <label className={styles.sourceSelector}>
+            <span className={styles.sourceLabel}>Data source</span>
+            <svg className={styles.sourceIcon} viewBox="0 0 24 24" aria-hidden="true">
+              <ellipse cx="12" cy="5" rx="8" ry="3" />
+              <path d="M4 5v5c0 1.7 3.6 3 8 3s8-1.3 8-3V5" />
+              <path d="M4 10v5c0 1.7 3.6 3 8 3s8-1.3 8-3v-5" />
+              <path d="M4 15v4c0 1.7 3.6 3 8 3s8-1.3 8-3v-4" />
+            </svg>
+            <select
+              className={styles.sourceControl}
+              value={portalProps.datasetId || ""}
+              disabled={sourcesLoading || sources.length === 0}
+              onChange={(event) => selectSource(event.target.value)}
+              aria-label="Data source"
+            >
+              <option value="" disabled>
+                {sourcesLoading
+                  ? "Loading data sources..."
+                  : sources.length > 0
+                    ? "Select a data source"
+                    : "No data sources available"}
+              </option>
+              {sources.map((source) => (
+                <option key={source.sourceKey} value={source.sourceKey}>
+                  {source.sourceName}
+                </option>
+              ))}
+            </select>
+          </label>
+          {sourcesError ? <span className={styles.sourceError}>{sourcesError}</span> : null}
+        </div>
+      ) : null}
       {renderContent()}
     </div>
   );

--- a/plugins/ui/apps/wizards/src/components/WizardShell.module.css
+++ b/plugins/ui/apps/wizards/src/components/WizardShell.module.css
@@ -1,7 +1,7 @@
 .shell {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 56px);
+  height: var(--wizard-shell-height, calc(100vh - 56px));
   overflow-y: auto;
   background-color: rgb(242, 240, 241);
   font-family: var(--wizard-font-family);
@@ -15,6 +15,23 @@
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
   display: flex;
   flex-direction: column;
+}
+
+/* Atlas already supplies the page background and card around analysis tabs. */
+.atlasShell {
+  background: transparent;
+}
+
+.atlasShell > .content {
+  margin: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+:global(.page-card:has(.v-window-item--active [data-atlas-wizard-step]) .page-header),
+:global(.page-card:has(.v-window-item--active [data-atlas-wizard-step]) .analysis-hub__tabs-rail) {
+  display: none;
 }
 
 .breadcrumb {

--- a/plugins/ui/apps/wizards/src/components/WizardShell.tsx
+++ b/plugins/ui/apps/wizards/src/components/WizardShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { useWizardContext } from "../context/WizardContext";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { StepSelection } from "./StepSelection";
@@ -23,8 +23,43 @@ const stepTypeRegistry: Record<StepType, React.ComponentType> = {
  * Main wizard renderer using step type registry.
  */
 export function WizardShell() {
-  const { currentStepIndex, selectedWizard, getCurrentStepConfig, setCurrentStepIndex, resetWizard } =
+  const { currentStepIndex, selectedWizard, getCurrentStepConfig, setCurrentStepIndex, resetWizard, portalProps } =
     useWizardContext();
+  const shellRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const shell = shellRef.current;
+    if (!shell || portalProps.isAtlas !== true) return;
+
+    // page-card is owned by Atlas and supplies the outer spacing used here.
+    const pageCard = shell.closest<HTMLElement>(".page-card");
+
+    const fitShellToViewport = () => {
+      // Atlas owns the outer page and card spacing. Fit the Wizard between its
+      // mount point and the card's visible bottom so only the Wizard scrolls.
+      const pageWrapper = shell.closest<HTMLElement>(".page-wrapper");
+      const shellTop = shell.getBoundingClientRect().top;
+      const viewportBottom = Math.min(pageWrapper?.getBoundingClientRect().bottom ?? window.innerHeight, window.innerHeight);
+      const wrapperBottomPadding = Number.parseFloat(
+        pageWrapper ? window.getComputedStyle(pageWrapper).paddingBottom : "0",
+      );
+      const cardBottomPadding = Number.parseFloat(pageCard ? window.getComputedStyle(pageCard).paddingBottom : "0");
+      const availableHeight = Math.max(320, viewportBottom - shellTop - wrapperBottomPadding - cardBottomPadding);
+      shell.style.setProperty("--wizard-shell-height", `${availableHeight}px`);
+    };
+
+    const pageWrapper = shell.closest<HTMLElement>(".page-wrapper");
+    const resizeObserver = pageWrapper ? new ResizeObserver(fitShellToViewport) : undefined;
+    resizeObserver?.observe(pageWrapper);
+    const animationFrame = window.requestAnimationFrame(fitShellToViewport);
+    window.addEventListener("resize", fitShellToViewport);
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", fitShellToViewport);
+      shell.style.removeProperty("--wizard-shell-height");
+    };
+  }, [currentStepIndex, portalProps.isAtlas]);
 
   // Handle invalid state: index > -1 but no wizard selected
   useEffect(() => {
@@ -84,7 +119,11 @@ export function WizardShell() {
   };
 
   return (
-    <div className={styles.shell}>
+    <div
+      ref={shellRef}
+      className={`${styles.shell} ${portalProps.isAtlas === true ? styles.atlasShell : ""}`}
+      data-atlas-wizard-step={portalProps.isAtlas === true && currentStepIndex >= 0 ? "" : undefined}
+    >
       <main className={styles.content}>
         <ErrorBoundary onReset={resetWizard}>{renderStep()}</ErrorBoundary>
       </main>

--- a/plugins/ui/apps/wizards/src/lifecycles.tsx
+++ b/plugins/ui/apps/wizards/src/lifecycles.tsx
@@ -3,11 +3,12 @@ import ReactDOMClient from "react-dom/client";
 import singleSpaReact from "single-spa-react";
 import App from "./App";
 import { PortalProps } from "./types/portal";
+import { normalizeWizardPortalProps } from "./utils/portalProps";
 
 const lifecycles = singleSpaReact({
   React,
   ReactDOMClient,
-  rootComponent: (props: PortalProps) => <App {...props} />,
+  rootComponent: (props: PortalProps) => <App {...normalizeWizardPortalProps(props)} />,
   errorBoundary: (err, info) => {
     console.error("[Wizards] Error:", err, info);
 
@@ -24,6 +25,10 @@ const lifecycles = singleSpaReact({
     );
   },
   domElementGetter: (props: any): HTMLElement => {
+    if (props?.domElement) {
+      return props.domElement;
+    }
+
     const containerId = props?.containerId;
 
     if (containerId) {
@@ -39,4 +44,4 @@ const lifecycles = singleSpaReact({
   },
 });
 
-export const { bootstrap, mount, unmount } = lifecycles;
+export const { bootstrap, mount, unmount, update } = lifecycles;

--- a/plugins/ui/apps/wizards/src/types/portal.ts
+++ b/plugins/ui/apps/wizards/src/types/portal.ts
@@ -8,6 +8,12 @@ export interface AtlasPluginHostContext {
   permissions?: string[];
 }
 
+export interface AtlasPluginAuthContext {
+  user?: {
+    username?: string;
+  } | null;
+}
+
 export interface PortalProps extends Partial<ParcelProps> {
   appId?: string;
   getToken?: () => Promise<string>;
@@ -15,6 +21,7 @@ export interface PortalProps extends Partial<ParcelProps> {
   datasetId?: string;
   locale?: string;
   isAtlas?: boolean;
+  authContext?: AtlasPluginAuthContext;
   hostContext?: AtlasPluginHostContext;
   // Atlas supplies the parcel mount target directly instead of a Portal containerId.
   domElement?: HTMLElement;

--- a/plugins/ui/apps/wizards/src/types/portal.ts
+++ b/plugins/ui/apps/wizards/src/types/portal.ts
@@ -1,5 +1,13 @@
 import { ParcelProps } from "single-spa";
 
+export interface AtlasPluginHostContext {
+  surface?: string;
+  itemId?: string;
+  sourceKey?: string;
+  locale?: string;
+  permissions?: string[];
+}
+
 export interface PortalProps extends Partial<ParcelProps> {
   appId?: string;
   getToken?: () => Promise<string>;
@@ -7,4 +15,7 @@ export interface PortalProps extends Partial<ParcelProps> {
   datasetId?: string;
   locale?: string;
   isAtlas?: boolean;
+  hostContext?: AtlasPluginHostContext;
+  // Atlas supplies the parcel mount target directly instead of a Portal containerId.
+  domElement?: HTMLElement;
 }

--- a/plugins/ui/apps/wizards/src/utils/__tests__/portalProps.test.ts
+++ b/plugins/ui/apps/wizards/src/utils/__tests__/portalProps.test.ts
@@ -70,6 +70,26 @@ describe("normalizeWizardPortalProps", () => {
     ).toBe("host-atlas-dataset");
   });
 
+  it("uses the authenticated Atlas username when the parcel omits the top-level username", () => {
+    expect(
+      normalizeWizardPortalProps({
+        isAtlas: true,
+        authContext: { user: { username: "atlas-researcher" } },
+      }).username,
+    ).toBe("atlas-researcher");
+  });
+
+  it("preserves the username supplied directly by the portal", () => {
+    const props: PortalProps = {
+      username: "portal-researcher",
+      isAtlas: false,
+      authContext: { user: { username: "atlas-researcher" } },
+    };
+
+    expect(normalizeWizardPortalProps(props)).toBe(props);
+    expect(normalizeWizardPortalProps(props).username).toBe("portal-researcher");
+  });
+
   it("does not treat an Atlas source key as a portal dataset id", () => {
     const props: PortalProps = {
       isAtlas: false,

--- a/plugins/ui/apps/wizards/src/utils/__tests__/portalProps.test.ts
+++ b/plugins/ui/apps/wizards/src/utils/__tests__/portalProps.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { PortalProps } from "../../types/portal";
+import { normalizeWizardPortalProps } from "../portalProps";
+
+describe("normalizeWizardPortalProps", () => {
+  it("preserves the dataset id supplied by the portal", () => {
+    const props: PortalProps = {
+      datasetId: "portal-dataset",
+      isAtlas: false,
+      hostContext: { sourceKey: "atlas-source" },
+    };
+
+    expect(normalizeWizardPortalProps(props)).toBe(props);
+    expect(normalizeWizardPortalProps(props).datasetId).toBe("portal-dataset");
+  });
+
+  it("uses the Atlas source key as the D2E dataset id", () => {
+    const props: PortalProps = {
+      isAtlas: true,
+      hostContext: { sourceKey: "dataset-from-atlas" },
+    };
+
+    expect(normalizeWizardPortalProps(props)).toEqual({
+      ...props,
+      datasetId: "dataset-from-atlas",
+    });
+  });
+
+  it("resolves a new dataset id when Atlas updates the source key", () => {
+    const initialProps = normalizeWizardPortalProps({
+      isAtlas: true,
+      hostContext: { sourceKey: "dataset-a" },
+    });
+    const updatedProps = normalizeWizardPortalProps({
+      isAtlas: true,
+      hostContext: { sourceKey: "dataset-b" },
+    });
+
+    expect(initialProps.datasetId).toBe("dataset-a");
+    expect(updatedProps.datasetId).toBe("dataset-b");
+  });
+
+  it("does not treat an Atlas source key as a portal dataset id", () => {
+    const props: PortalProps = {
+      isAtlas: false,
+      hostContext: { sourceKey: "atlas-source" },
+    };
+
+    expect(normalizeWizardPortalProps(props)).toBe(props);
+    expect(normalizeWizardPortalProps(props).datasetId).toBeUndefined();
+  });
+
+  it("ignores empty Atlas source keys", () => {
+    const props: PortalProps = {
+      isAtlas: true,
+      hostContext: { sourceKey: "   " },
+    };
+
+    expect(normalizeWizardPortalProps(props)).toBe(props);
+  });
+});

--- a/plugins/ui/apps/wizards/src/utils/__tests__/portalProps.test.ts
+++ b/plugins/ui/apps/wizards/src/utils/__tests__/portalProps.test.ts
@@ -1,8 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PortalProps } from "../../types/portal";
-import { normalizeWizardPortalProps } from "../portalProps";
+import { isWizardPropsChangeForApp, normalizeWizardPortalProps } from "../portalProps";
 
 describe("normalizeWizardPortalProps", () => {
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("preserves the dataset id supplied by the portal", () => {
     const props: PortalProps = {
       datasetId: "portal-dataset",
@@ -40,6 +53,23 @@ describe("normalizeWizardPortalProps", () => {
     expect(updatedProps.datasetId).toBe("dataset-b");
   });
 
+  it("uses Atlas's persisted vocabulary source on initial mount", () => {
+    localStorage.setItem("selectedVocabulary", "stored-atlas-dataset");
+
+    expect(normalizeWizardPortalProps({ isAtlas: true }).datasetId).toBe("stored-atlas-dataset");
+  });
+
+  it("prefers the Atlas host context over the persisted vocabulary source", () => {
+    localStorage.setItem("selectedVocabulary", "stored-atlas-dataset");
+
+    expect(
+      normalizeWizardPortalProps({
+        isAtlas: true,
+        hostContext: { sourceKey: "host-atlas-dataset" },
+      }).datasetId,
+    ).toBe("host-atlas-dataset");
+  });
+
   it("does not treat an Atlas source key as a portal dataset id", () => {
     const props: PortalProps = {
       isAtlas: false,
@@ -57,5 +87,15 @@ describe("normalizeWizardPortalProps", () => {
     };
 
     expect(normalizeWizardPortalProps(props)).toBe(props);
+  });
+
+  it("matches Atlas prop changes when Atlas omits the app id", () => {
+    expect(isWizardPropsChangeForApp("wizards")).toBe(true);
+    expect(isWizardPropsChangeForApp("another-app")).toBe(false);
+  });
+
+  it("uses the Portal app id when one is supplied", () => {
+    expect(isWizardPropsChangeForApp("portal-wizards", "portal-wizards")).toBe(true);
+    expect(isWizardPropsChangeForApp("wizards", "portal-wizards")).toBe(false);
   });
 });

--- a/plugins/ui/apps/wizards/src/utils/__tests__/wizardSearch.test.ts
+++ b/plugins/ui/apps/wizards/src/utils/__tests__/wizardSearch.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import type { WizardDefinition } from "../../types/wizard";
+import { filterWizards } from "../wizardSearch";
+
+function wizard(id: string, name: string, description: string): WizardDefinition {
+  return { id, name, description, fields: [], steps: [] };
+}
+
+const wizards = [
+  wizard("incidence", "Calculate incidence", "Find the first occurrence of a clinical condition."),
+  wizard("mortality", "Calculate mortality", "Calculate rates using death dates."),
+];
+
+describe("filterWizards", () => {
+  it("returns all wizards for an empty search", () => {
+    expect(filterWizards(wizards, "  ")).toBe(wizards);
+  });
+
+  it("matches wizard names without regard to case", () => {
+    expect(filterWizards(wizards, "INCIDENCE")).toEqual([wizards[0]]);
+  });
+
+  it("matches wizard descriptions", () => {
+    expect(filterWizards(wizards, "death dates")).toEqual([wizards[1]]);
+  });
+});

--- a/plugins/ui/apps/wizards/src/utils/portalProps.ts
+++ b/plugins/ui/apps/wizards/src/utils/portalProps.ts
@@ -6,12 +6,24 @@ function getNonEmptyString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function getAtlasStoredDatasetId(): string | undefined {
+  if (typeof localStorage === "undefined") return undefined;
+
+  try {
+    return getNonEmptyString(localStorage.getItem("selectedVocabulary"));
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Normalize the host-specific dataset context consumed by Wizards.
  *
  * The portal already supplies datasetId directly. D2E WebAPI exposes Atlas
  * sources with sourceKey equal to the D2E dataset id, so an Atlas parcel can
- * use hostContext.sourceKey without another lookup or request interceptor.
+ * use hostContext.sourceKey without another lookup or request interceptor. The
+ * installed AnalysisHub does not yet pass sourceKey on initial mount, so use
+ * Atlas's persisted vocabulary selection as a compatibility fallback.
  */
 export function normalizeWizardPortalProps(props: PortalProps): PortalProps {
   const datasetId = getNonEmptyString(props.datasetId);
@@ -21,6 +33,12 @@ export function normalizeWizardPortalProps(props: PortalProps): PortalProps {
 
   if (props.isAtlas !== true) return props;
 
-  const sourceKey = getNonEmptyString(props.hostContext?.sourceKey);
+  const sourceKey = getNonEmptyString(props.hostContext?.sourceKey) ?? getAtlasStoredDatasetId();
   return sourceKey ? { ...props, datasetId: sourceKey } : props;
+}
+
+// Atlas labels Wizard events with the manifest id but omits appId from the
+// mount props. Portal supplies its generated appId, which must match exactly.
+export function isWizardPropsChangeForApp(eventAppId: unknown, appId?: string): boolean {
+  return eventAppId === (appId || "wizards");
 }

--- a/plugins/ui/apps/wizards/src/utils/portalProps.ts
+++ b/plugins/ui/apps/wizards/src/utils/portalProps.ts
@@ -17,24 +17,33 @@ function getAtlasStoredDatasetId(): string | undefined {
 }
 
 /**
- * Normalize the host-specific dataset context consumed by Wizards.
+ * Normalize the host-specific context consumed by Wizards.
  *
- * The portal already supplies datasetId directly. D2E WebAPI exposes Atlas
+ * The portal already supplies datasetId and username directly. D2E WebAPI exposes Atlas
  * sources with sourceKey equal to the D2E dataset id, so an Atlas parcel can
  * use hostContext.sourceKey without another lookup or request interceptor. The
  * installed AnalysisHub does not yet pass sourceKey on initial mount, so use
- * Atlas's persisted vocabulary selection as a compatibility fallback.
+ * Atlas's persisted vocabulary selection as a compatibility fallback. Atlas
+ * parcels expose the signed-in user through authContext but do not currently
+ * copy that username to the top-level Wizard props.
  */
 export function normalizeWizardPortalProps(props: PortalProps): PortalProps {
   const datasetId = getNonEmptyString(props.datasetId);
-  if (datasetId) {
-    return datasetId === props.datasetId ? props : { ...props, datasetId };
+  if (props.isAtlas !== true) {
+    return datasetId && datasetId !== props.datasetId ? { ...props, datasetId } : props;
   }
 
-  if (props.isAtlas !== true) return props;
+  const resolvedDatasetId =
+    datasetId ?? getNonEmptyString(props.hostContext?.sourceKey) ?? getAtlasStoredDatasetId();
+  const username = getNonEmptyString(props.username) ?? getNonEmptyString(props.authContext?.user?.username);
 
-  const sourceKey = getNonEmptyString(props.hostContext?.sourceKey) ?? getAtlasStoredDatasetId();
-  return sourceKey ? { ...props, datasetId: sourceKey } : props;
+  if (resolvedDatasetId === props.datasetId && username === props.username) return props;
+
+  return {
+    ...props,
+    ...(resolvedDatasetId ? { datasetId: resolvedDatasetId } : {}),
+    ...(username ? { username } : {}),
+  };
 }
 
 // Atlas labels Wizard events with the manifest id but omits appId from the

--- a/plugins/ui/apps/wizards/src/utils/portalProps.ts
+++ b/plugins/ui/apps/wizards/src/utils/portalProps.ts
@@ -1,0 +1,26 @@
+import type { PortalProps } from "../types/portal";
+
+function getNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Normalize the host-specific dataset context consumed by Wizards.
+ *
+ * The portal already supplies datasetId directly. D2E WebAPI exposes Atlas
+ * sources with sourceKey equal to the D2E dataset id, so an Atlas parcel can
+ * use hostContext.sourceKey without another lookup or request interceptor.
+ */
+export function normalizeWizardPortalProps(props: PortalProps): PortalProps {
+  const datasetId = getNonEmptyString(props.datasetId);
+  if (datasetId) {
+    return datasetId === props.datasetId ? props : { ...props, datasetId };
+  }
+
+  if (props.isAtlas !== true) return props;
+
+  const sourceKey = getNonEmptyString(props.hostContext?.sourceKey);
+  return sourceKey ? { ...props, datasetId: sourceKey } : props;
+}

--- a/plugins/ui/apps/wizards/src/utils/wizardSearch.ts
+++ b/plugins/ui/apps/wizards/src/utils/wizardSearch.ts
@@ -1,0 +1,10 @@
+import type { WizardDefinition } from "../types/wizard";
+
+export function filterWizards(wizards: WizardDefinition[], query: string): WizardDefinition[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return wizards;
+
+  return wizards.filter((wizard) =>
+    `${wizard.name} ${wizard.description}`.toLocaleLowerCase().includes(normalizedQuery),
+  );
+}


### PR DESCRIPTION
Closes #3126

## Summary

- register Wizard as the first Atlas Analysis tab and open it by default when entering Analyses
- synchronize the Atlas data-source selection with the D2E dataset context, including source changes
- use the authenticated Atlas username for Wizard bookmark and cohort operations while preserving Portal behavior
- add the Atlas-only data-source selector, search, tile/list views, and mockup-aligned Wizard layout
- keep the selected source read-only inside a Wizard form
- fix Wizard form scrolling, Atlas header visibility, tab transitions, and browser/back navigation

## Implementation notes

Portal continues to supply `datasetId` and `username` directly. Atlas-specific normalization derives the dataset from the WebAPI source key and derives the username from the parcel's existing `authContext` when top-level props are omitted.

[atlas-wizard-feature-walkthrough.webm](https://github.com/user-attachments/assets/eda9729b-98ce-4037-af34-bfd50891b557)

