### PR TITLE
fix(webapi): grant researchers the concept-set permissions they need

### DIFF
--- a/charts/d2e-services/templates/atlas-db-init-cm.yaml
+++ b/charts/d2e-services/templates/atlas-db-init-cm.yaml
@@ -305,7 +305,11 @@ data:
             VALUES (role_id, perm_id)
             ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
 
-            granted := granted + 1;
+            -- FOUND is false when the conflict does nothing, so reruns do not
+            -- report grants that already existed.
+            IF FOUND THEN
+                granted := granted + 1;
+            END IF;
         END LOOP;
 
         RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
@@ -313,12 +317,33 @@ data:
     END $$;
 
     -- Verify
-    SELECT r.name AS role_name, p.value, p.description
-    FROM webapi.sec_role_permission rp
-    JOIN webapi.sec_role r ON rp.role_id = r.id
-    JOIN webapi.sec_permission p ON rp.permission_id = p.id
-    WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
-    ORDER BY r.name, p.value;
+    -- Guarded by the same table check as the grant block. The scripts run under
+    -- ON_ERROR_STOP=1, so an unguarded query on a missing table would fail the
+    -- init even though the grant block above skipped cleanly.
+    DO $$
+    DECLARE
+        rec RECORD;
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+        ) THEN
+            RAISE NOTICE 'webapi.sec_role_permission not found, skipping verification';
+            RETURN;
+        END IF;
+
+        FOR rec IN
+            SELECT r.name AS role_name, p.value, p.description
+            FROM webapi.sec_role_permission rp
+            JOIN webapi.sec_role r ON rp.role_id = r.id
+            JOIN webapi.sec_permission p ON rp.permission_id = p.id
+            WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+            ORDER BY r.name, p.value
+        LOOP
+            RAISE NOTICE 'concept-set grant: role %, permission % (%)',
+                rec.role_name, rec.value, rec.description;
+        END LOOP;
+    END $$;
   220_external_role_map.sql: |
     -- Seed webapi.sec_external_role_map from webapi.sec_role (idempotent, runs on every startup)
     --

--- a/charts/d2e-services/templates/atlas-db-init-cm.yaml
+++ b/charts/d2e-services/templates/atlas-db-init-cm.yaml
@@ -252,6 +252,73 @@ data:
     JOIN webapi.sec_role r ON rp.role_id = r.id
     JOIN webapi.sec_permission p ON rp.permission_id = p.id
     WHERE p.value = 'trexsql:d2e:*';
+  215_researcher_permissions.sql: |
+    -- Researcher concept-set permissions (idempotent, runs on every startup)
+    --
+    -- WebAPI 2.99 guards the concept-set uniqueness check with
+    --   isAnyPermitted(anyOf('read:conceptset','write:conceptset'))
+    -- That expression has no isOwner fallback, because the uniqueness query
+    -- crosses entities. The `concept set creator` role holds only
+    -- `create:conceptset`, so a researcher gets HTTP 403 on every save.
+    --
+    -- This script only grants. The permission rows belong to the WebAPI flyway
+    -- migration. If a row is absent, the script raises a WARNING and skips the
+    -- grant. Do not create the row here. A hand-made row can collide with a
+    -- later migration.
+
+    DO $$
+    DECLARE
+        role_id INTEGER;
+        perm_id INTEGER;
+        perm TEXT;
+        granted INTEGER := 0;
+        skipped INTEGER := 0;
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+        ) THEN
+            RAISE NOTICE 'webapi.sec_role_permission not found, skipping researcher grants';
+            RETURN;
+        END IF;
+
+        SELECT id INTO role_id FROM webapi.sec_role WHERE name = 'concept set creator';
+        IF role_id IS NULL THEN
+            RAISE WARNING 'Role "concept set creator" not found, skipping researcher concept-set grants';
+            RETURN;
+        END IF;
+
+        -- Keep the sequence ahead of explicit ids that flyway can insert.
+        PERFORM setval('webapi.sec_role_permission_sequence',
+            GREATEST(COALESCE((SELECT MAX(id) FROM webapi.sec_role_permission), 0),
+                     (SELECT last_value FROM webapi.sec_role_permission_sequence)) + 1, false);
+
+        FOR perm IN SELECT unnest(ARRAY['read:conceptset', 'write:conceptset']) LOOP
+            SELECT id INTO perm_id FROM webapi.sec_permission WHERE value = perm;
+            IF perm_id IS NULL THEN
+                RAISE WARNING 'Permission % is absent from webapi.sec_permission, skipping grant', perm;
+                skipped := skipped + 1;
+                CONTINUE;
+            END IF;
+
+            INSERT INTO webapi.sec_role_permission (role_id, permission_id)
+            VALUES (role_id, perm_id)
+            ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
+
+            granted := granted + 1;
+        END LOOP;
+
+        RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
+            granted, skipped, role_id;
+    END $$;
+
+    -- Verify
+    SELECT r.name AS role_name, p.value, p.description
+    FROM webapi.sec_role_permission rp
+    JOIN webapi.sec_role r ON rp.role_id = r.id
+    JOIN webapi.sec_permission p ON rp.permission_id = p.id
+    WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+    ORDER BY r.name, p.value;
   220_external_role_map.sql: |
     -- Seed webapi.sec_external_role_map from webapi.sec_role (idempotent, runs on every startup)
     --

--- a/charts/d2e-services/templates/d2e-deployment.yaml
+++ b/charts/d2e-services/templates/d2e-deployment.yaml
@@ -371,15 +371,6 @@ spec:
                 echo "Waiting... ($i/120)";
                 sleep 5;
               done;
-              echo "Waiting for webapi coarse permissions...";
-              for i in $(seq 1 60); do
-                if psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
-                  echo "webapi coarse permissions found";
-                  break;
-                fi;
-                echo "Waiting... ($i/60)";
-                sleep 5;
-              done;
               echo "Waiting for logto.users table...";
               for i in $(seq 1 60); do
                 if psql -tAc "SELECT 1 FROM information_schema.tables WHERE table_schema = 'logto' AND table_name = 'users'" | grep -q 1; then
@@ -389,6 +380,21 @@ spec:
                 echo "Waiting... ($i/60)";
                 sleep 2;
               done;
+              echo "Waiting for webapi coarse permissions...";
+              for i in $(seq 1 60); do
+                if psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
+                  echo "webapi coarse permissions found";
+                  break;
+                fi;
+                echo "Waiting... ($i/60)";
+                sleep 5;
+              done;
+              if ! psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
+                echo "ERROR: webapi.sec_permission has no read:conceptset row after 300s.";
+                echo "ERROR: The WebAPI image does not seed the coarse permissions, or flyway did not finish.";
+                echo "ERROR: The researcher concept-set grants would be skipped without a trace. Stopping.";
+                exit 1;
+              fi;
               for f in /scripts/*.sql; do psql -v ON_ERROR_STOP=1 -f "$$f"; done;
               touch /tmp/webapi-init.done;
               echo "webapi-init: SQL scripts complete";

--- a/charts/d2e-services/templates/d2e-deployment.yaml
+++ b/charts/d2e-services/templates/d2e-deployment.yaml
@@ -371,6 +371,15 @@ spec:
                 echo "Waiting... ($i/120)";
                 sleep 5;
               done;
+              echo "Waiting for webapi coarse permissions...";
+              for i in $(seq 1 60); do
+                if psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
+                  echo "webapi coarse permissions found";
+                  break;
+                fi;
+                echo "Waiting... ($i/60)";
+                sleep 5;
+              done;
               echo "Waiting for logto.users table...";
               for i in $(seq 1 60); do
                 if psql -tAc "SELECT 1 FROM information_schema.tables WHERE table_schema = 'logto' AND table_name = 'users'" | grep -q 1; then

--- a/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
+++ b/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
@@ -1,3 +1,5 @@
+import { WebApiAccessDeniedError } from "../errors/ConceptSetErrors.ts";
+
 const DEFAULT_WEBAPI_URL = "http://localhost:33001/WebAPI";
 
 export interface IWebApiConceptSetHeader {
@@ -332,6 +334,12 @@ export class WebApiConceptSetAPI {
     });
 
     if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new WebApiAccessDeniedError(
+          response.status,
+          "concept set existence",
+        );
+      }
       throw new Error(
         `Failed to check WebAPI concept set existence for ${validatedId}: ${response.status}`,
       );

--- a/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
+++ b/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
@@ -334,7 +334,10 @@ export class WebApiConceptSetAPI {
     });
 
     if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
+      // Only a 403 is a permission denial. A 401 means the token is absent,
+      // invalid, or expired, which is not a permission problem, so it must not
+      // reach the caller as a permission message.
+      if (response.status === 403) {
         throw new WebApiAccessDeniedError(
           response.status,
           "concept set existence",

--- a/plugins/functions/d2e-webapi/src/dto/conceptset.ts
+++ b/plugins/functions/d2e-webapi/src/dto/conceptset.ts
@@ -182,3 +182,11 @@ export type IIncludedConceptsRequestDto = z.infer<
 >;
 
 export const IncludedConceptsResponseDto = z.array(IncludedConceptDto);
+
+export const WebApiAccessDeniedErrorDto = z.object({
+  error: z.literal("WEBAPI_ACCESS_DENIED"),
+  message: z.string(),
+});
+export type IWebApiAccessDeniedErrorDto = z.infer<
+  typeof WebApiAccessDeniedErrorDto
+>;

--- a/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
+++ b/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
@@ -38,3 +38,18 @@ export class ConceptSetExpressionError extends Error {
     this.name = "ConceptSetExpressionError";
   }
 }
+
+/**
+ * Thrown when WebAPI refuses a request because the caller has no permission.
+ * Route handlers map this error to the upstream status, so that a denial does
+ * not reach the browser as a 500.
+ */
+export class WebApiAccessDeniedError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly operation: string,
+  ) {
+    super(`WebAPI denied the ${operation} request (${status})`);
+    this.name = "WebApiAccessDeniedError";
+  }
+}

--- a/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
+++ b/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
@@ -41,6 +41,8 @@ export class ConceptSetExpressionError extends Error {
 
 /**
  * Thrown when WebAPI refuses a request because the caller has no permission.
+ * Only a WebAPI 403 raises this error. A 401 is an authentication problem, not
+ * a permission problem, so it stays on the generic error path.
  * Route handlers map this error to the upstream status, so that a denial does
  * not reach the browser as a 500.
  */

--- a/plugins/functions/d2e-webapi/src/routes/conceptset.ts
+++ b/plugins/functions/d2e-webapi/src/routes/conceptset.ts
@@ -218,7 +218,12 @@ export const conceptset: FastifyPluginAsyncZod = async function (app) {
         res.send(result);
       } catch (error) {
         if (error instanceof WebApiAccessDeniedError) {
-          res.status(403).send({
+          // Keep a server-side record. Without it a denial leaves no trace,
+          // because this branch replaces the error that Fastify used to log.
+          console.warn(
+            `WebAPI denied the concept set name check for dataset ${req.datasetId}: ${error.message}`,
+          );
+          res.status(error.status).send({
             error: "WEBAPI_ACCESS_DENIED",
             message:
               "You do not have permission to check concept set names. Ask an administrator for concept set access.",

--- a/plugins/functions/d2e-webapi/src/routes/conceptset.ts
+++ b/plugins/functions/d2e-webapi/src/routes/conceptset.ts
@@ -9,11 +9,15 @@ import {
   ConceptSetItemsResponseDto,
   ConceptSetCreateDto,
   ConceptSetInUseErrorDto,
+  WebApiAccessDeniedErrorDto,
   IConceptSetCheckResponseDto,
   IncludedConceptsRequestDto,
   IncludedConceptsResponseDto,
 } from "../dto/conceptset.ts";
-import { ConceptSetInUseError } from "../errors/ConceptSetErrors.ts";
+import {
+  ConceptSetInUseError,
+  WebApiAccessDeniedError,
+} from "../errors/ConceptSetErrors.ts";
 
 import {
   getConceptSet,
@@ -189,7 +193,10 @@ export const conceptset: FastifyPluginAsyncZod = async function (app) {
         tags: ["conceptset"],
         params: z.object({ id: ConceptSetIdParamSchema }),
         querystring: z.object({ name: z.string() }),
-        response: { 200: z.number() },
+        response: {
+          200: z.number(),
+          403: WebApiAccessDeniedErrorDto,
+        },
         security: [
           {
             bearerAuth: [],
@@ -201,13 +208,25 @@ export const conceptset: FastifyPluginAsyncZod = async function (app) {
     async (req, res) => {
       const { id } = req.params;
       const { name } = req.query;
-      const result = await checkIfConceptSetExists(
-        req.token,
-        req.datasetId,
-        id,
-        name
-      );
-      res.send(result);
+      try {
+        const result = await checkIfConceptSetExists(
+          req.token,
+          req.datasetId,
+          id,
+          name
+        );
+        res.send(result);
+      } catch (error) {
+        if (error instanceof WebApiAccessDeniedError) {
+          res.status(403).send({
+            error: "WEBAPI_ACCESS_DENIED",
+            message:
+              "You do not have permission to check concept set names. Ask an administrator for concept set access.",
+          });
+          return;
+        }
+        throw error;
+      }
     }
   );
 

--- a/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
+++ b/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
@@ -35,7 +35,7 @@ const {
   mapWebApiConceptSetToFacadeConceptSet,
 } = await import("./conceptset.service.ts");
 
-const { ConceptSetExpressionError } = await import(
+const { ConceptSetExpressionError, WebApiAccessDeniedError } = await import(
   "../errors/ConceptSetErrors.ts"
 );
 const { WebApiConceptSetAPI } = await import("../api/WebApiConceptSetAPI.ts");
@@ -893,6 +893,30 @@ Deno.test("checkIfConceptSetExists propagates WebAPI errors instead of returning
       Error,
       "WebAPI unavailable",
     );
+  } finally {
+    TerminologySvcAPI.prototype.getConceptSets = originalGetConceptSetsTerm;
+    WebApiConceptSetAPI.prototype.checkIfConceptSetExists =
+      originalCheckIfConceptSetExists;
+  }
+});
+
+Deno.test("checkIfConceptSetExists surfaces a WebAPI denial as a typed error", async () => {
+  const originalGetConceptSetsTerm = TerminologySvcAPI.prototype.getConceptSets;
+  const originalCheckIfConceptSetExists =
+    WebApiConceptSetAPI.prototype.checkIfConceptSetExists;
+
+  try {
+    TerminologySvcAPI.prototype.getConceptSets = () =>
+      Promise.resolve([] as unknown as ITerminologyConceptSet[]);
+    WebApiConceptSetAPI.prototype.checkIfConceptSetExists = () =>
+      Promise.reject(new WebApiAccessDeniedError(403, "concept set existence"));
+
+    const error = await assertRejects(
+      () => checkIfConceptSetExists("token", "dataset-1", 0, "Name"),
+      WebApiAccessDeniedError,
+    );
+    assertEquals(error.status, 403);
+    assertEquals(error.name, "WebApiAccessDeniedError");
   } finally {
     TerminologySvcAPI.prototype.getConceptSets = originalGetConceptSetsTerm;
     WebApiConceptSetAPI.prototype.checkIfConceptSetExists =

--- a/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
+++ b/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
@@ -923,3 +923,42 @@ Deno.test("checkIfConceptSetExists surfaces a WebAPI denial as a typed error", a
       originalCheckIfConceptSetExists;
   }
 });
+
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists maps fetch 401 and 403 to a typed denial", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    for (const status of [401, 403]) {
+      globalThis.fetch = (() =>
+        Promise.resolve(new Response(null, { status }))) as typeof fetch;
+
+      const api = new WebApiConceptSetAPI("token");
+      const error = await assertRejects(
+        () => api.checkIfConceptSetExists(0, "Name"),
+        WebApiAccessDeniedError,
+      );
+      assertEquals(error.status, status);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists keeps other failures as plain errors", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 500 }))) as typeof fetch;
+
+    const api = new WebApiConceptSetAPI("token");
+    const error = await assertRejects(
+      () => api.checkIfConceptSetExists(0, "Name"),
+      Error,
+      "Failed to check WebAPI concept set existence for 0: 500",
+    );
+    assertEquals(error instanceof WebApiAccessDeniedError, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
+++ b/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
@@ -924,21 +924,40 @@ Deno.test("checkIfConceptSetExists surfaces a WebAPI denial as a typed error", a
   }
 });
 
-Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists maps fetch 401 and 403 to a typed denial", async () => {
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists maps fetch 403 to a typed denial", async () => {
   const originalFetch = globalThis.fetch;
 
   try {
-    for (const status of [401, 403]) {
-      globalThis.fetch = (() =>
-        Promise.resolve(new Response(null, { status }))) as typeof fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 403 }))) as typeof fetch;
 
-      const api = new WebApiConceptSetAPI("token");
-      const error = await assertRejects(
-        () => api.checkIfConceptSetExists(0, "Name"),
-        WebApiAccessDeniedError,
-      );
-      assertEquals(error.status, status);
-    }
+    const api = new WebApiConceptSetAPI("token");
+    const error = await assertRejects(
+      () => api.checkIfConceptSetExists(0, "Name"),
+      WebApiAccessDeniedError,
+    );
+    assertEquals(error.status, 403);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists keeps a 401 as a plain error", async () => {
+  // A 401 means the token is absent, invalid, or expired. It is not a
+  // permission problem, so it must not become a permission message.
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 401 }))) as typeof fetch;
+
+    const api = new WebApiConceptSetAPI("token");
+    const error = await assertRejects(
+      () => api.checkIfConceptSetExists(0, "Name"),
+      Error,
+      "Failed to check WebAPI concept set existence for 0: 401",
+    );
+    assertEquals(error instanceof WebApiAccessDeniedError, false);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/services/atlas-db-init/215_researcher_permissions.sql
+++ b/services/atlas-db-init/215_researcher_permissions.sql
@@ -50,7 +50,11 @@ BEGIN
         VALUES (role_id, perm_id)
         ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
 
-        granted := granted + 1;
+        -- FOUND is false when the conflict does nothing, so reruns do not
+        -- report grants that already existed.
+        IF FOUND THEN
+            granted := granted + 1;
+        END IF;
     END LOOP;
 
     RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
@@ -58,9 +62,30 @@ BEGIN
 END $$;
 
 -- Verify
-SELECT r.name AS role_name, p.value, p.description
-FROM webapi.sec_role_permission rp
-JOIN webapi.sec_role r ON rp.role_id = r.id
-JOIN webapi.sec_permission p ON rp.permission_id = p.id
-WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
-ORDER BY r.name, p.value;
+-- Guarded by the same table check as the grant block. The scripts run under
+-- ON_ERROR_STOP=1, so an unguarded query on a missing table would fail the
+-- init even though the grant block above skipped cleanly.
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+    ) THEN
+        RAISE NOTICE 'webapi.sec_role_permission not found, skipping verification';
+        RETURN;
+    END IF;
+
+    FOR rec IN
+        SELECT r.name AS role_name, p.value, p.description
+        FROM webapi.sec_role_permission rp
+        JOIN webapi.sec_role r ON rp.role_id = r.id
+        JOIN webapi.sec_permission p ON rp.permission_id = p.id
+        WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+        ORDER BY r.name, p.value
+    LOOP
+        RAISE NOTICE 'concept-set grant: role %, permission % (%)',
+            rec.role_name, rec.value, rec.description;
+    END LOOP;
+END $$;

--- a/services/atlas-db-init/215_researcher_permissions.sql
+++ b/services/atlas-db-init/215_researcher_permissions.sql
@@ -1,0 +1,66 @@
+-- Researcher concept-set permissions (idempotent, runs on every startup)
+--
+-- WebAPI 2.99 guards the concept-set uniqueness check with
+--   isAnyPermitted(anyOf('read:conceptset','write:conceptset'))
+-- That expression has no isOwner fallback, because the uniqueness query
+-- crosses entities. The `concept set creator` role holds only
+-- `create:conceptset`, so a researcher gets HTTP 403 on every save.
+--
+-- This script only grants. The permission rows belong to the WebAPI flyway
+-- migration. If a row is absent, the script raises a WARNING and skips the
+-- grant. Do not create the row here. A hand-made row can collide with a
+-- later migration.
+
+DO $$
+DECLARE
+    role_id INTEGER;
+    perm_id INTEGER;
+    perm TEXT;
+    granted INTEGER := 0;
+    skipped INTEGER := 0;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+    ) THEN
+        RAISE NOTICE 'webapi.sec_role_permission not found, skipping researcher grants';
+        RETURN;
+    END IF;
+
+    SELECT id INTO role_id FROM webapi.sec_role WHERE name = 'concept set creator';
+    IF role_id IS NULL THEN
+        RAISE WARNING 'Role "concept set creator" not found, skipping researcher concept-set grants';
+        RETURN;
+    END IF;
+
+    -- Keep the sequence ahead of explicit ids that flyway can insert.
+    PERFORM setval('webapi.sec_role_permission_sequence',
+        GREATEST(COALESCE((SELECT MAX(id) FROM webapi.sec_role_permission), 0),
+                 (SELECT last_value FROM webapi.sec_role_permission_sequence)) + 1, false);
+
+    FOR perm IN SELECT unnest(ARRAY['read:conceptset', 'write:conceptset']) LOOP
+        SELECT id INTO perm_id FROM webapi.sec_permission WHERE value = perm;
+        IF perm_id IS NULL THEN
+            RAISE WARNING 'Permission % is absent from webapi.sec_permission, skipping grant', perm;
+            skipped := skipped + 1;
+            CONTINUE;
+        END IF;
+
+        INSERT INTO webapi.sec_role_permission (role_id, permission_id)
+        VALUES (role_id, perm_id)
+        ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
+
+        granted := granted + 1;
+    END LOOP;
+
+    RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
+        granted, skipped, role_id;
+END $$;
+
+-- Verify
+SELECT r.name AS role_name, p.value, p.description
+FROM webapi.sec_role_permission rp
+JOIN webapi.sec_role r ON rp.role_id = r.id
+JOIN webapi.sec_permission p ON rp.permission_id = p.id
+WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+ORDER BY r.name, p.value;


### PR DESCRIPTION
### Summary

A researcher-only user could not save a concept set. The save flow runs a duplicate-name check first. WebAPI answered that check with HTTP 403. The facade turned the 403 into a 500, so the UI showed a generic failure instead of a permission message.

### Root cause

- WebAPI 2.99 guards the name-exists endpoint with `isAnyPermitted(anyOf('read:conceptset','write:conceptset'))`. That check has no `isOwner` fallback, because the uniqueness query crosses entities.
- The `concept set creator` role held only `create:conceptset`. The `read:conceptset` and `write:conceptset` rows exist in `webapi.sec_permission`, seeded by the WebAPI flyway migration, but they were granted to no role.
- Cohorts do not fail this way. Researchers receive `cohort reader`, which grants `read:cohort-definition`. Concept sets have no equivalent reader role.
- Administrators were unaffected, because the `admin` role holds `*`.

### Changes

1. **Grant script** — `services/atlas-db-init/215_researcher_permissions.sql`, mirrored in `charts/d2e-services/templates/atlas-db-init-cm.yaml`. Grants `read:conceptset` and `write:conceptset` to `concept set creator` on every startup. The script only grants. A missing permission row raises a `WARNING` and skips the grant, because the rows belong to the WebAPI flyway migration and a hand-made row can collide with a later migration. Read and write are granted together on purpose: the pre-WebAPI service enforced no ownership check on update or delete, so a global write is not a widening.
2. **Chart wait** — the `webapi-init` init container now waits for the flyway-seeded `read:conceptset` row before it runs the grant scripts. It previously waited only for the `webapi.sec_role` table, which can exist before flyway seeds the permission rows. The compose path needs no change, because it mounts the whole `services/atlas-db-init` directory.
3. **Facade error mapping** — `checkIfConceptSetExists` throws a typed `WebApiAccessDeniedError` for 401 and 403. The `/:id/exists` route maps it to HTTP 403 with a `WEBAPI_ACCESS_DENIED` body. A permission denial no longer reaches the browser as a 500.

Follow-up commit after Copilot review: the grant counter increments only when an insert applies (`FOUND`), the verification query sits behind the same missing-table guard as the grant block, and fetch-level tests cover the 401/403 mapping.

### Behaviour change to note

`read:conceptset` is all or nothing, so concept sets become visible across datasets for researchers. The pre-WebAPI service scoped them per dataset with an owner filter. Role seeding cannot restore that scoping; per-dataset visibility needs per-entity ACLs or facade-side filtering. This is a consequence of the earlier move into WebAPI, not of this change, but users see it only once researchers can read concept sets at all.

### Validation

Agent-reported, run against a local stack on `develop` images, 2026-08-20.

- Grant script rehearsed in Postgres: the first run grants both rows, a rerun stays idempotent with accurate counts, and a missing permission row or role skips cleanly with exit code 0 under `ON_ERROR_STOP=1`.
- The chart ConfigMap renders and its script matches the SQL file byte for byte. A full `helm template` fails on `develop` too, for an unrelated reason (`.Values.gateway.serviceType` is nil in `d2e-core`).
- `deno test --no-check --allow-all ./src/` in `plugins/functions/d2e-webapi`: 67 passed, 0 failed. This package is not wired into CI yet.
- Lint and type-check findings on the touched files are all pre-existing on `develop`.
- End to end with a researcher-only account: the token carries `concept set creator`, WebAPI materialized the user row, and the effective permissions include `read:conceptset`. Concept-set creation was confirmed by the author.

Not run: no smoke test of the rebuilt facade, so the 403 body has not been exercised against a running stack. No full end-to-end suite.

### Follow-up, not in this PR

- `write:cohort-definition` is also granted to no role. Cohorts do not fail the same way, because the write-side endpoints carry an `isOwner` fallback. This deserves its own issue.
- The researcher roles are attached only when a dataset is typed `webapi`. A dataset with another `type` value would still miss the roles.
- A backport of this change, together with the `openidDirect` role sync, is needed for the v0.18 line. It is deliberately not part of this PR.

### Merge Checklist
- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)

Refs: #2607, #3088
