### PR TITLE
fix(webapi): grant researcher concept-set permissions (v0.18 backport)

### DIFF
--- a/charts/d2e-services/templates/atlas-db-init-cm.yaml
+++ b/charts/d2e-services/templates/atlas-db-init-cm.yaml
@@ -305,7 +305,11 @@ data:
             VALUES (role_id, perm_id)
             ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
 
-            granted := granted + 1;
+            -- FOUND is false when the conflict does nothing, so reruns do not
+            -- report grants that already existed.
+            IF FOUND THEN
+                granted := granted + 1;
+            END IF;
         END LOOP;
 
         RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
@@ -313,12 +317,33 @@ data:
     END $$;
 
     -- Verify
-    SELECT r.name AS role_name, p.value, p.description
-    FROM webapi.sec_role_permission rp
-    JOIN webapi.sec_role r ON rp.role_id = r.id
-    JOIN webapi.sec_permission p ON rp.permission_id = p.id
-    WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
-    ORDER BY r.name, p.value;
+    -- Guarded by the same table check as the grant block. The scripts run under
+    -- ON_ERROR_STOP=1, so an unguarded query on a missing table would fail the
+    -- init even though the grant block above skipped cleanly.
+    DO $$
+    DECLARE
+        rec RECORD;
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+        ) THEN
+            RAISE NOTICE 'webapi.sec_role_permission not found, skipping verification';
+            RETURN;
+        END IF;
+
+        FOR rec IN
+            SELECT r.name AS role_name, p.value, p.description
+            FROM webapi.sec_role_permission rp
+            JOIN webapi.sec_role r ON rp.role_id = r.id
+            JOIN webapi.sec_permission p ON rp.permission_id = p.id
+            WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+            ORDER BY r.name, p.value
+        LOOP
+            RAISE NOTICE 'concept-set grant: role %, permission % (%)',
+                rec.role_name, rec.value, rec.description;
+        END LOOP;
+    END $$;
   220_external_role_map.sql: |
     -- Seed webapi.sec_external_role_map from webapi.sec_role (idempotent, runs on every startup)
     --

--- a/charts/d2e-services/templates/atlas-db-init-cm.yaml
+++ b/charts/d2e-services/templates/atlas-db-init-cm.yaml
@@ -252,6 +252,73 @@ data:
     JOIN webapi.sec_role r ON rp.role_id = r.id
     JOIN webapi.sec_permission p ON rp.permission_id = p.id
     WHERE p.value = 'trexsql:d2e:*';
+  215_researcher_permissions.sql: |
+    -- Researcher concept-set permissions (idempotent, runs on every startup)
+    --
+    -- WebAPI 2.99 guards the concept-set uniqueness check with
+    --   isAnyPermitted(anyOf('read:conceptset','write:conceptset'))
+    -- That expression has no isOwner fallback, because the uniqueness query
+    -- crosses entities. The `concept set creator` role holds only
+    -- `create:conceptset`, so a researcher gets HTTP 403 on every save.
+    --
+    -- This script only grants. The permission rows belong to the WebAPI flyway
+    -- migration. If a row is absent, the script raises a WARNING and skips the
+    -- grant. Do not create the row here. A hand-made row can collide with a
+    -- later migration.
+
+    DO $$
+    DECLARE
+        role_id INTEGER;
+        perm_id INTEGER;
+        perm TEXT;
+        granted INTEGER := 0;
+        skipped INTEGER := 0;
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+        ) THEN
+            RAISE NOTICE 'webapi.sec_role_permission not found, skipping researcher grants';
+            RETURN;
+        END IF;
+
+        SELECT id INTO role_id FROM webapi.sec_role WHERE name = 'concept set creator';
+        IF role_id IS NULL THEN
+            RAISE WARNING 'Role "concept set creator" not found, skipping researcher concept-set grants';
+            RETURN;
+        END IF;
+
+        -- Keep the sequence ahead of explicit ids that flyway can insert.
+        PERFORM setval('webapi.sec_role_permission_sequence',
+            GREATEST(COALESCE((SELECT MAX(id) FROM webapi.sec_role_permission), 0),
+                     (SELECT last_value FROM webapi.sec_role_permission_sequence)) + 1, false);
+
+        FOR perm IN SELECT unnest(ARRAY['read:conceptset', 'write:conceptset']) LOOP
+            SELECT id INTO perm_id FROM webapi.sec_permission WHERE value = perm;
+            IF perm_id IS NULL THEN
+                RAISE WARNING 'Permission % is absent from webapi.sec_permission, skipping grant', perm;
+                skipped := skipped + 1;
+                CONTINUE;
+            END IF;
+
+            INSERT INTO webapi.sec_role_permission (role_id, permission_id)
+            VALUES (role_id, perm_id)
+            ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
+
+            granted := granted + 1;
+        END LOOP;
+
+        RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
+            granted, skipped, role_id;
+    END $$;
+
+    -- Verify
+    SELECT r.name AS role_name, p.value, p.description
+    FROM webapi.sec_role_permission rp
+    JOIN webapi.sec_role r ON rp.role_id = r.id
+    JOIN webapi.sec_permission p ON rp.permission_id = p.id
+    WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+    ORDER BY r.name, p.value;
   220_external_role_map.sql: |
     -- Seed webapi.sec_external_role_map from webapi.sec_role (idempotent, runs on every startup)
     --

--- a/charts/d2e-services/templates/d2e-deployment.yaml
+++ b/charts/d2e-services/templates/d2e-deployment.yaml
@@ -371,15 +371,6 @@ spec:
                 echo "Waiting... ($i/120)";
                 sleep 5;
               done;
-              echo "Waiting for webapi coarse permissions...";
-              for i in $(seq 1 60); do
-                if psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
-                  echo "webapi coarse permissions found";
-                  break;
-                fi;
-                echo "Waiting... ($i/60)";
-                sleep 5;
-              done;
               echo "Waiting for logto.users table...";
               for i in $(seq 1 60); do
                 if psql -tAc "SELECT 1 FROM information_schema.tables WHERE table_schema = 'logto' AND table_name = 'users'" | grep -q 1; then
@@ -389,6 +380,21 @@ spec:
                 echo "Waiting... ($i/60)";
                 sleep 2;
               done;
+              echo "Waiting for webapi coarse permissions...";
+              for i in $(seq 1 60); do
+                if psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
+                  echo "webapi coarse permissions found";
+                  break;
+                fi;
+                echo "Waiting... ($i/60)";
+                sleep 5;
+              done;
+              if ! psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
+                echo "ERROR: webapi.sec_permission has no read:conceptset row after 300s.";
+                echo "ERROR: The WebAPI image does not seed the coarse permissions, or flyway did not finish.";
+                echo "ERROR: The researcher concept-set grants would be skipped without a trace. Stopping.";
+                exit 1;
+              fi;
               for f in /scripts/*.sql; do psql -v ON_ERROR_STOP=1 -f "$$f"; done;
               touch /tmp/webapi-init.done;
               echo "webapi-init: SQL scripts complete";

--- a/charts/d2e-services/templates/d2e-deployment.yaml
+++ b/charts/d2e-services/templates/d2e-deployment.yaml
@@ -371,6 +371,15 @@ spec:
                 echo "Waiting... ($i/120)";
                 sleep 5;
               done;
+              echo "Waiting for webapi coarse permissions...";
+              for i in $(seq 1 60); do
+                if psql -tAc "SELECT 1 FROM webapi.sec_permission WHERE value = 'read:conceptset'" | grep -q 1; then
+                  echo "webapi coarse permissions found";
+                  break;
+                fi;
+                echo "Waiting... ($i/60)";
+                sleep 5;
+              done;
               echo "Waiting for logto.users table...";
               for i in $(seq 1 60); do
                 if psql -tAc "SELECT 1 FROM information_schema.tables WHERE table_schema = 'logto' AND table_name = 'users'" | grep -q 1; then

--- a/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
+++ b/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
@@ -1,3 +1,5 @@
+import { WebApiAccessDeniedError } from "../errors/ConceptSetErrors.ts";
+
 const DEFAULT_WEBAPI_URL = "http://localhost:33001/WebAPI";
 
 export interface IWebApiConceptSetHeader {
@@ -332,6 +334,12 @@ export class WebApiConceptSetAPI {
     });
 
     if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new WebApiAccessDeniedError(
+          response.status,
+          "concept set existence",
+        );
+      }
       throw new Error(
         `Failed to check WebAPI concept set existence for ${validatedId}: ${response.status}`,
       );

--- a/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
+++ b/plugins/functions/d2e-webapi/src/api/WebApiConceptSetAPI.ts
@@ -334,7 +334,10 @@ export class WebApiConceptSetAPI {
     });
 
     if (!response.ok) {
-      if (response.status === 401 || response.status === 403) {
+      // Only a 403 is a permission denial. A 401 means the token is absent,
+      // invalid, or expired, which is not a permission problem, so it must not
+      // reach the caller as a permission message.
+      if (response.status === 403) {
         throw new WebApiAccessDeniedError(
           response.status,
           "concept set existence",

--- a/plugins/functions/d2e-webapi/src/dto/conceptset.ts
+++ b/plugins/functions/d2e-webapi/src/dto/conceptset.ts
@@ -182,3 +182,11 @@ export type IIncludedConceptsRequestDto = z.infer<
 >;
 
 export const IncludedConceptsResponseDto = z.array(IncludedConceptDto);
+
+export const WebApiAccessDeniedErrorDto = z.object({
+  error: z.literal("WEBAPI_ACCESS_DENIED"),
+  message: z.string(),
+});
+export type IWebApiAccessDeniedErrorDto = z.infer<
+  typeof WebApiAccessDeniedErrorDto
+>;

--- a/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
+++ b/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
@@ -38,3 +38,18 @@ export class ConceptSetExpressionError extends Error {
     this.name = "ConceptSetExpressionError";
   }
 }
+
+/**
+ * Thrown when WebAPI refuses a request because the caller has no permission.
+ * Route handlers map this error to the upstream status, so that a denial does
+ * not reach the browser as a 500.
+ */
+export class WebApiAccessDeniedError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly operation: string,
+  ) {
+    super(`WebAPI denied the ${operation} request (${status})`);
+    this.name = "WebApiAccessDeniedError";
+  }
+}

--- a/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
+++ b/plugins/functions/d2e-webapi/src/errors/ConceptSetErrors.ts
@@ -41,6 +41,8 @@ export class ConceptSetExpressionError extends Error {
 
 /**
  * Thrown when WebAPI refuses a request because the caller has no permission.
+ * Only a WebAPI 403 raises this error. A 401 is an authentication problem, not
+ * a permission problem, so it stays on the generic error path.
  * Route handlers map this error to the upstream status, so that a denial does
  * not reach the browser as a 500.
  */

--- a/plugins/functions/d2e-webapi/src/routes/conceptset.ts
+++ b/plugins/functions/d2e-webapi/src/routes/conceptset.ts
@@ -218,7 +218,12 @@ export const conceptset: FastifyPluginAsyncZod = async function (app) {
         res.send(result);
       } catch (error) {
         if (error instanceof WebApiAccessDeniedError) {
-          res.status(403).send({
+          // Keep a server-side record. Without it a denial leaves no trace,
+          // because this branch replaces the error that Fastify used to log.
+          console.warn(
+            `WebAPI denied the concept set name check for dataset ${req.datasetId}: ${error.message}`,
+          );
+          res.status(error.status).send({
             error: "WEBAPI_ACCESS_DENIED",
             message:
               "You do not have permission to check concept set names. Ask an administrator for concept set access.",

--- a/plugins/functions/d2e-webapi/src/routes/conceptset.ts
+++ b/plugins/functions/d2e-webapi/src/routes/conceptset.ts
@@ -9,11 +9,15 @@ import {
   ConceptSetItemsResponseDto,
   ConceptSetCreateDto,
   ConceptSetInUseErrorDto,
+  WebApiAccessDeniedErrorDto,
   IConceptSetCheckResponseDto,
   IncludedConceptsRequestDto,
   IncludedConceptsResponseDto,
 } from "../dto/conceptset.ts";
-import { ConceptSetInUseError } from "../errors/ConceptSetErrors.ts";
+import {
+  ConceptSetInUseError,
+  WebApiAccessDeniedError,
+} from "../errors/ConceptSetErrors.ts";
 
 import {
   getConceptSet,
@@ -189,7 +193,10 @@ export const conceptset: FastifyPluginAsyncZod = async function (app) {
         tags: ["conceptset"],
         params: z.object({ id: ConceptSetIdParamSchema }),
         querystring: z.object({ name: z.string() }),
-        response: { 200: z.number() },
+        response: {
+          200: z.number(),
+          403: WebApiAccessDeniedErrorDto,
+        },
         security: [
           {
             bearerAuth: [],
@@ -201,13 +208,25 @@ export const conceptset: FastifyPluginAsyncZod = async function (app) {
     async (req, res) => {
       const { id } = req.params;
       const { name } = req.query;
-      const result = await checkIfConceptSetExists(
-        req.token,
-        req.datasetId,
-        id,
-        name
-      );
-      res.send(result);
+      try {
+        const result = await checkIfConceptSetExists(
+          req.token,
+          req.datasetId,
+          id,
+          name
+        );
+        res.send(result);
+      } catch (error) {
+        if (error instanceof WebApiAccessDeniedError) {
+          res.status(403).send({
+            error: "WEBAPI_ACCESS_DENIED",
+            message:
+              "You do not have permission to check concept set names. Ask an administrator for concept set access.",
+          });
+          return;
+        }
+        throw error;
+      }
     }
   );
 

--- a/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
+++ b/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
@@ -35,7 +35,7 @@ const {
   mapWebApiConceptSetToFacadeConceptSet,
 } = await import("./conceptset.service.ts");
 
-const { ConceptSetExpressionError } = await import(
+const { ConceptSetExpressionError, WebApiAccessDeniedError } = await import(
   "../errors/ConceptSetErrors.ts"
 );
 const { WebApiConceptSetAPI } = await import("../api/WebApiConceptSetAPI.ts");
@@ -893,6 +893,30 @@ Deno.test("checkIfConceptSetExists propagates WebAPI errors instead of returning
       Error,
       "WebAPI unavailable",
     );
+  } finally {
+    TerminologySvcAPI.prototype.getConceptSets = originalGetConceptSetsTerm;
+    WebApiConceptSetAPI.prototype.checkIfConceptSetExists =
+      originalCheckIfConceptSetExists;
+  }
+});
+
+Deno.test("checkIfConceptSetExists surfaces a WebAPI denial as a typed error", async () => {
+  const originalGetConceptSetsTerm = TerminologySvcAPI.prototype.getConceptSets;
+  const originalCheckIfConceptSetExists =
+    WebApiConceptSetAPI.prototype.checkIfConceptSetExists;
+
+  try {
+    TerminologySvcAPI.prototype.getConceptSets = () =>
+      Promise.resolve([] as unknown as ITerminologyConceptSet[]);
+    WebApiConceptSetAPI.prototype.checkIfConceptSetExists = () =>
+      Promise.reject(new WebApiAccessDeniedError(403, "concept set existence"));
+
+    const error = await assertRejects(
+      () => checkIfConceptSetExists("token", "dataset-1", 0, "Name"),
+      WebApiAccessDeniedError,
+    );
+    assertEquals(error.status, 403);
+    assertEquals(error.name, "WebApiAccessDeniedError");
   } finally {
     TerminologySvcAPI.prototype.getConceptSets = originalGetConceptSetsTerm;
     WebApiConceptSetAPI.prototype.checkIfConceptSetExists =

--- a/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
+++ b/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
@@ -923,3 +923,42 @@ Deno.test("checkIfConceptSetExists surfaces a WebAPI denial as a typed error", a
       originalCheckIfConceptSetExists;
   }
 });
+
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists maps fetch 401 and 403 to a typed denial", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    for (const status of [401, 403]) {
+      globalThis.fetch = (() =>
+        Promise.resolve(new Response(null, { status }))) as typeof fetch;
+
+      const api = new WebApiConceptSetAPI("token");
+      const error = await assertRejects(
+        () => api.checkIfConceptSetExists(0, "Name"),
+        WebApiAccessDeniedError,
+      );
+      assertEquals(error.status, status);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists keeps other failures as plain errors", async () => {
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 500 }))) as typeof fetch;
+
+    const api = new WebApiConceptSetAPI("token");
+    const error = await assertRejects(
+      () => api.checkIfConceptSetExists(0, "Name"),
+      Error,
+      "Failed to check WebAPI concept set existence for 0: 500",
+    );
+    assertEquals(error instanceof WebApiAccessDeniedError, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
+++ b/plugins/functions/d2e-webapi/src/services/conceptset.service.test.ts
@@ -924,21 +924,40 @@ Deno.test("checkIfConceptSetExists surfaces a WebAPI denial as a typed error", a
   }
 });
 
-Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists maps fetch 401 and 403 to a typed denial", async () => {
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists maps fetch 403 to a typed denial", async () => {
   const originalFetch = globalThis.fetch;
 
   try {
-    for (const status of [401, 403]) {
-      globalThis.fetch = (() =>
-        Promise.resolve(new Response(null, { status }))) as typeof fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 403 }))) as typeof fetch;
 
-      const api = new WebApiConceptSetAPI("token");
-      const error = await assertRejects(
-        () => api.checkIfConceptSetExists(0, "Name"),
-        WebApiAccessDeniedError,
-      );
-      assertEquals(error.status, status);
-    }
+    const api = new WebApiConceptSetAPI("token");
+    const error = await assertRejects(
+      () => api.checkIfConceptSetExists(0, "Name"),
+      WebApiAccessDeniedError,
+    );
+    assertEquals(error.status, 403);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("WebApiConceptSetAPI.checkIfConceptSetExists keeps a 401 as a plain error", async () => {
+  // A 401 means the token is absent, invalid, or expired. It is not a
+  // permission problem, so it must not become a permission message.
+  const originalFetch = globalThis.fetch;
+
+  try {
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response(null, { status: 401 }))) as typeof fetch;
+
+    const api = new WebApiConceptSetAPI("token");
+    const error = await assertRejects(
+      () => api.checkIfConceptSetExists(0, "Name"),
+      Error,
+      "Failed to check WebAPI concept set existence for 0: 401",
+    );
+    assertEquals(error instanceof WebApiAccessDeniedError, false);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/services/atlas-db-init/215_researcher_permissions.sql
+++ b/services/atlas-db-init/215_researcher_permissions.sql
@@ -50,7 +50,11 @@ BEGIN
         VALUES (role_id, perm_id)
         ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
 
-        granted := granted + 1;
+        -- FOUND is false when the conflict does nothing, so reruns do not
+        -- report grants that already existed.
+        IF FOUND THEN
+            granted := granted + 1;
+        END IF;
     END LOOP;
 
     RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
@@ -58,9 +62,30 @@ BEGIN
 END $$;
 
 -- Verify
-SELECT r.name AS role_name, p.value, p.description
-FROM webapi.sec_role_permission rp
-JOIN webapi.sec_role r ON rp.role_id = r.id
-JOIN webapi.sec_permission p ON rp.permission_id = p.id
-WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
-ORDER BY r.name, p.value;
+-- Guarded by the same table check as the grant block. The scripts run under
+-- ON_ERROR_STOP=1, so an unguarded query on a missing table would fail the
+-- init even though the grant block above skipped cleanly.
+DO $$
+DECLARE
+    rec RECORD;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+    ) THEN
+        RAISE NOTICE 'webapi.sec_role_permission not found, skipping verification';
+        RETURN;
+    END IF;
+
+    FOR rec IN
+        SELECT r.name AS role_name, p.value, p.description
+        FROM webapi.sec_role_permission rp
+        JOIN webapi.sec_role r ON rp.role_id = r.id
+        JOIN webapi.sec_permission p ON rp.permission_id = p.id
+        WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+        ORDER BY r.name, p.value
+    LOOP
+        RAISE NOTICE 'concept-set grant: role %, permission % (%)',
+            rec.role_name, rec.value, rec.description;
+    END LOOP;
+END $$;

--- a/services/atlas-db-init/215_researcher_permissions.sql
+++ b/services/atlas-db-init/215_researcher_permissions.sql
@@ -1,0 +1,66 @@
+-- Researcher concept-set permissions (idempotent, runs on every startup)
+--
+-- WebAPI 2.99 guards the concept-set uniqueness check with
+--   isAnyPermitted(anyOf('read:conceptset','write:conceptset'))
+-- That expression has no isOwner fallback, because the uniqueness query
+-- crosses entities. The `concept set creator` role holds only
+-- `create:conceptset`, so a researcher gets HTTP 403 on every save.
+--
+-- This script only grants. The permission rows belong to the WebAPI flyway
+-- migration. If a row is absent, the script raises a WARNING and skips the
+-- grant. Do not create the row here. A hand-made row can collide with a
+-- later migration.
+
+DO $$
+DECLARE
+    role_id INTEGER;
+    perm_id INTEGER;
+    perm TEXT;
+    granted INTEGER := 0;
+    skipped INTEGER := 0;
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'webapi' AND table_name = 'sec_role_permission'
+    ) THEN
+        RAISE NOTICE 'webapi.sec_role_permission not found, skipping researcher grants';
+        RETURN;
+    END IF;
+
+    SELECT id INTO role_id FROM webapi.sec_role WHERE name = 'concept set creator';
+    IF role_id IS NULL THEN
+        RAISE WARNING 'Role "concept set creator" not found, skipping researcher concept-set grants';
+        RETURN;
+    END IF;
+
+    -- Keep the sequence ahead of explicit ids that flyway can insert.
+    PERFORM setval('webapi.sec_role_permission_sequence',
+        GREATEST(COALESCE((SELECT MAX(id) FROM webapi.sec_role_permission), 0),
+                 (SELECT last_value FROM webapi.sec_role_permission_sequence)) + 1, false);
+
+    FOR perm IN SELECT unnest(ARRAY['read:conceptset', 'write:conceptset']) LOOP
+        SELECT id INTO perm_id FROM webapi.sec_permission WHERE value = perm;
+        IF perm_id IS NULL THEN
+            RAISE WARNING 'Permission % is absent from webapi.sec_permission, skipping grant', perm;
+            skipped := skipped + 1;
+            CONTINUE;
+        END IF;
+
+        INSERT INTO webapi.sec_role_permission (role_id, permission_id)
+        VALUES (role_id, perm_id)
+        ON CONFLICT ON CONSTRAINT role_permission_unique DO NOTHING;
+
+        granted := granted + 1;
+    END LOOP;
+
+    RAISE NOTICE 'Researcher concept-set grants: % applied, % skipped, role_id %',
+        granted, skipped, role_id;
+END $$;
+
+-- Verify
+SELECT r.name AS role_name, p.value, p.description
+FROM webapi.sec_role_permission rp
+JOIN webapi.sec_role r ON rp.role_id = r.id
+JOIN webapi.sec_permission p ON rp.permission_id = p.id
+WHERE p.value IN ('create:conceptset', 'read:conceptset', 'write:conceptset')
+ORDER BY r.name, p.value;


### PR DESCRIPTION
Backport of the researcher concept-set permission fix to `release/v0.18.0-beta`.

## Problem

A user with the researcher role only cannot create a concept set. The save fails
on the duplicate-name check:

```
GET /d2e/d2e-webapi/conceptset/0/exists?name=Test%201
500  "Failed to check WebAPI concept set existence for 0: 403"
```

The server log shows the denial:

```
AuthorizationDeniedException: Access Denied
  at org.ohdsi.webapi.conceptset.ConceptSetService.getCountCSetWithSameName
```

Administrators are not affected, because the `admin` role holds the `*`
permission. Researchers do most concept-set work, so the feature is unusable for
its main audience.

## Root cause

WebAPI authorizes the uniqueness check with:

```
isAnyPermitted(anyOf('read:conceptset','write:conceptset'))
```

That expression has no `isOwner` fallback, because the uniqueness query crosses
entities.

`read:conceptset` and `write:conceptset` exist in `webapi.sec_permission`, because
the WebAPI flyway migration seeds them. They are granted to no role. The
`concept set creator` role holds `create:conceptset` only.

Cohorts do not fail the same way, because `cohort reader` grants
`read:cohort-definition`. Concept sets have no equivalent reader role.

## Changes

| # | Change | Files |
|---|---|---|
| 1 | New `services/atlas-db-init/215_researcher_permissions.sql`. Grants `read:conceptset` and `write:conceptset` to `concept set creator`. | 1 new file |
| 2 | Mirror the script into the Helm configmap, and wait for the flyway-seeded permission row in the `webapi-init` init container. | 2 files |
| 3 | Map a WebAPI 401 or 403 to HTTP 403 in the `d2e-webapi` facade, instead of a 500. | 5 files |

Change 3 turns a 500 into a 403, which is the correct status for a denial, and
records the denial in the server log. **It does not yet reach the user as a
message.** `saveConceptSet` in
`plugins/ui/apps/concept-sets/src/Terminology/Terminology.tsx:576` catches with a
bare `catch { }` and always renders the generic error text. A UI change is needed
for the message to appear. Change 3 is not part of the functional fix.

## Design decisions

**Grant to the existing role. Do not add a new role.** The alternative is to
mirror the cohort pattern and add a `concept set reader` role with a new scope.
That option is more consistent, but it changes the identity-provider seed
configuration and the JWT rewrite list, and every user must log in again. For a
patch release, the grant-only option is the correct trade.

**Grant write together with read.** Read alone lets a researcher save a new set,
but the update path then depends on ownership, and ownership depends on WebAPI
holding a user row at creation time. Read and write together removes that
dependency.

**Do not create permission rows.** The rows in `webapi.sec_permission` belong to
the WebAPI flyway migration. The script raises a `WARNING` and skips the grant
when a row is absent. A hand-made row can collide with a later migration.

## Not included

The original patch request also asked for a cherry-pick of #3154, the WebAPI role
sync through `openidDirect`. That change is already on `release/v0.18.0-beta`, so
no cherry-pick is needed.

## Validation

Cherry-picked from `khairul-syazwan/fix-conceptset-researcher-permissions`. Four
commits applied with no conflict. Every changed file is byte-identical to the
version on that branch.

`plugins/functions/d2e-webapi` Deno test suite, run in `denoland/deno:2.5.6`:

```
ok | 67 passed | 0 failed
```

The compose path needs no change. `docker-compose.yml` mounts
`./services/atlas-db-init` and runs every `*.sql` file in it.

On a stack that runs `develop` images, the following were confirmed:

- The script applies two grants on the first run, and is idempotent on later runs.
- A missing permission row raises a `WARNING` and skips the grant, without a
  non-zero exit.
- A researcher-only user receives `read:conceptset` and `write:conceptset`, and
  the concept-set save succeeds.

### Verified on a v0.18 stack

Tested on 2026-08-24 against an isolated stack that runs the `0.18.1-beta`
images, from this branch.

**The pre-flight gate passes.** The v0.18.1 WebAPI flyway migration seeds all
three permission rows, so no WebAPI image bump is needed:

```
 create:conceptset | Create concept sets
 read:conceptset   | Read concept sets
 write:conceptset  | Update concept sets
```

The v0.18.1 image also carries the same failing guard,
`isAnyPermitted(anyOf('read:conceptset','write:conceptset'))`, with no `isOwner`
fallback. The release line has the same defect.

**The grant script.** `2 applied, 0 skipped, role_id 3` on the first run. Three
grant rows on `concept set creator`. A second run reports `0 applied, 0 skipped`,
the count stays at 3, and the init container exits 0.

**The researcher chain.** A researcher-only account receives `read:conceptset`
and `write:conceptset` through `roles` claim, `sec_external_role_map`,
`sec_user_role`, and `sec_role_permission`.

**The facade, against the running route.** With the researcher-only token:

| Request | Result |
|---|---|
| `GET /conceptset/0/exists?name=...` | 200. This answered 500 before the fix. |
| `POST /conceptset/` | 200. Saved as the researcher. |
| `exists` with the saved name | 200, body `1`. The duplicate check is not bypassed. |
| `exists` after the grants are removed | **403** with `WEBAPI_ACCESS_DENIED`, not 500. |
| `exists` after the grants are restored | 200. |

The trex log holds one `getCountCSetWithSameName` denial only, from the
deliberate negative test.

### Note for the release

**WebAPI caches authorization.** After the grants change, a session that is
already authorized keeps its old permission set. The 403 case appeared only
after WebAPI restarted. Restart WebAPI when this patch is applied, or a
signed-in user does not receive the new grants.

### Second review round

Seven findings. Four were applied on both branches:

- The chart's coarse-permission wait ran before the `logto.users` wait, so it
  gated every atlas-db-init script. Moved after it.
- That wait fell through with no error, so a deployment that lost the race came
  up healthy while researchers still got 403. The init container now stops with a
  clear message.
- A WebAPI 401 was mapped to the permission denial, so an expired token told the
  user to ask an administrator. Only a 403 maps to the denial now.
- The route sent a hardcoded 403 and logged nothing. It now sends the status the
  error carries, and records the denial.

Re-verified after the change: Deno suite **68 passed, 0 failed**; and on the live
stack the 403 path, the new log record, and the restore all behave as above.

Recorded and not changed:

- **The compose path has no equivalent ordering guard.** `webapi-init` waits for
  `logto.users` only, so the same race can skip the grants with no retry. The
  chart now stops on that condition; compose does not. Left out on purpose,
  because it changes the path CI exercises. Follow-up needed.
- The concept-sets UI must read `WEBAPI_ACCESS_DENIED` for the message to appear.
  Follow-up needed.

### Not yet covered

Browser cases: edit and save again, the admin path, and the concept set list.
The API results cover the failure point that the issue reports.

The same change for `develop` is #3169.

## Behaviour change for the release notes

**Visibility.** Concept sets become visible across datasets for researchers.
`read:conceptset` is all or nothing. Role seeding cannot restore per-dataset
scoping. Per-dataset scoping needs per-entity access control or facade-side
filtering, which is a larger change and not suitable for a patch.

**Update rights.** `write:conceptset` lets a researcher edit any concept set,
not only their own. Read makes another researcher's set visible, and write makes
it editable. The facade runs no ownership check, so a researcher can overwrite a
concept set that another researcher owns and did not share.

This is deliberate. Read alone lets a researcher save a new set, but the update
path then depends on WebAPI holding an ownership row at creation time, which is
fragile. Before #2560 the terminology service enforced no ownership check on
concept-set update or delete, so a global `write:conceptset` is not a widening
against the release before that change. **State this in the release notes.**

## Rollback

Delete the two grant rows. No schema change and no data migration is involved.

```sql
DELETE FROM webapi.sec_role_permission rp
USING webapi.sec_role r, webapi.sec_permission p
WHERE rp.role_id = r.id
  AND rp.permission_id = p.id
  AND r.name = 'concept set creator'
  AND p.value IN ('read:conceptset', 'write:conceptset');
```

Remove the configmap key to stop the script from restoring the grants on the next
start.
