### PR TITLE
feat: Atlas data source access-state UI (#2963 #2959)

### DIFF
--- a/plans/atlas-data-sources-access-state.md
+++ b/plans/atlas-data-sources-access-state.md
@@ -1,0 +1,231 @@
+# Atlas data-source list and access-state implementation plan
+
+## Scope and non-negotiable constraints
+
+Implement issues [#2959](https://github.com/OHDSI/Data2Evidence/issues/2959) and [#2963](https://github.com/OHDSI/Data2Evidence/issues/2963) as an end-to-end data-source experience.
+
+1. **All UI work is confined to `plugins/atlas`.** Do not change any `plugins/ui/apps/portal` dataset/list/card/detail component, hook, translation, stylesheet, or portal UI client.
+2. Preserve existing **write** access. The implementation adds a display/API state; it must not remove, replace, downgrade, or otherwise interfere with existing write roles and capabilities.
+3. The canonical authenticated states are: `no_access`, `pending`, `restricted`, `read`, and `write`.
+4. Reuse the existing `usermgmt.group_access_request` request persistence and group membership model. Do not introduce a new table unless a concurrency-safe unresolved-request constraint is absent.
+5. The Atlas plugin will own the data-source list, cards, detail header, sorting, and request-access UX rather than embedding the legacy portal data-source UI.
+
+## Issue-derived behaviour
+
+### List and cards (#2959)
+
+- Display the configurable organisation banner, image/logo, description/tagline, and search for both authenticated and anonymous users.
+- Rename the visible experience to **Data Sources**.
+- Render two cards per desktop row and one card per row at the Figma narrow breakpoint.
+- Each card shows name, short description, subject count, published date, data source type/model, version, visibility badge, and authenticated access-state badge.
+- Visibility is independent of a user's access state: public/non-public is always derived from the data source configuration.
+- A card navigates to its individual data-source page.
+- Authenticated default sort is **Access**: `write` and `read` first, then `pending`, `no_access`, `restricted`; break ties by case-insensitive name. Offer **Data source name (A–Z)** and **Name (Z–A)**.
+- Anonymous users receive public data sources only, default to **Name (A–Z)**, can choose **Name (Z–A)**, and must not see the Access sort option or user-specific access badge/action.
+
+### Detail header and request flow (#2963)
+
+- For `no_access` with requests enabled, show **Request access** in the detail header top-right.
+- On a successful request, update the UI immediately to orange **Pending access** without leaving the page; update the matching list card in the same Atlas UI cache.
+- For `restricted`, show the red restricted chip with its Figma icon, no request action, and this tooltip: `Access to this dataset is restricted. Contact your administrator to gain access.`
+- `read` and `write` display green Access status. Write may have an accessible secondary Write label, but its existing entitlement and authorizations remain unchanged.
+- Card badges follow Figma semantics: green check for access, red lock for no access, red restricted/affirmation mark for restricted, and orange clock for pending.
+
+## Access contract and server rules
+
+### State calculation
+
+The portal server is the source of truth for authenticated access state. For each data source, derive exactly one `accessState` using this precedence:
+
+1. `write` when the user is a member of the source's existing write group.
+2. `read` when the user is a member of its existing `STUDY_RESEARCHER` group.
+3. `pending` when there is an unresolved request for that user and source.
+4. `restricted` when the user lacks entitlement and `showRequestAccess` is false.
+5. `no_access` when the user lacks entitlement and requests are enabled.
+
+The anonymous public endpoint continues to expose only public visibility/data-source information and must not expose authenticated state or request actions.
+
+### Request and decision rules
+
+- The request endpoint derives the requester from the authenticated token; it must not trust a caller-provided `userId`.
+- Request creation validates that the source exists and permits requests, returns an existing unresolved request idempotently, and does not create a request for a user who already has read or write access.
+- A pending request can be approved for **read** or **write**, or rejected. A write approval uses the existing write group; a read approval uses the existing `STUDY_RESEARCHER` group.
+- Resolving a request must never delete an existing write membership. A user with write membership remains `write` even if they also have a read request/membership.
+- A rejected request does not confer access. A later response is `restricted` only if requests are disabled; otherwise it is `no_access` and the user may submit a new request.
+- All authorization remains server-side: only the authenticated user creates their own request and only current authorized administrators resolve one.
+
+## Exact files and changes
+
+### 1. Server contract and state derivation
+
+1. **`plugins/functions/portal/src/types.d.ts`**
+   - Add `DataSourceAccessState = 'no_access' | 'pending' | 'restricted' | 'read' | 'write'`.
+   - Add `accessState` to the authenticated `IDatasetResponseDto`; retain all existing role-related fields and DTO compatibility.
+
+2. **`plugins/functions/portal/src/user-mgmt/user-mgmt.api.ts`**
+   - Add authenticated user-management calls to retrieve study memberships by role, including read/researcher and write groups, plus unresolved requests for the current user in a batched form.
+
+3. **`plugins/functions/portal/src/user-mgmt/user-mgmt.service.ts`**
+   - Replace the read-only `getResearcherDatasetIds`-only usage with methods that return role-specific study IDs and unresolved-request study IDs.
+   - Keep `getResearcherDatasetIds` for existing callers until they are migrated; do not remove it in this change.
+
+4. **`plugins/functions/portal/src/user-mgmt/user-mgmt.api.spec.ts`**
+   - Cover request construction and token forwarding for the new membership/pending-request calls.
+
+5. **`plugins/functions/portal/src/user-mgmt/user-mgmt.service.spec.ts`**
+   - Verify role-specific results preserve write membership separately from researcher/read membership.
+
+6. **`plugins/functions/portal/src/dataset/query/dataset-query.service.ts`**
+   - Batch-load current-user membership and pending-request information once per list/detail query.
+   - Add `accessState` to each authenticated list and single-source response using the specified write-first precedence.
+   - Retain current visibility filtering and anonymous behaviour.
+
+7. **`plugins/functions/portal/src/dataset/query/dataset-query.service.spec.ts`**
+   - Add coverage for each derived state, precedence (`write` over `read`/pending), and list/detail parity.
+
+8. **`plugins/functions/portal/src/dataset/public/public-dataset-query.service.spec.ts`**
+   - Confirm anonymous responses remain public-only and omit user-specific state.
+
+### 2. User-management request APIs and role preservation
+
+9. **`plugins/functions/alp-usermgmt/src/types.ts`**
+   - Add DTO/type definitions for role-specific study membership and the request role allowed during approval.
+
+10. **`plugins/functions/alp-usermgmt/src/routes/MeRouter.ts`**
+    - Extend the authenticated current-user roles response (or add an adjacent authenticated endpoint) to return source IDs grouped by read and write role without exposing other users' memberships.
+
+11. **`plugins/functions/alp-usermgmt/src/routes/StudyAccessRequestRouter.ts`**
+    - Change request creation to use `req.user.userId` rather than a submitted user ID.
+    - Add requestable-source validation through the portal API/service boundary.
+    - Return an existing unresolved request for duplicate submissions.
+    - Permit an administrator decision to explicitly select read or write only through validated role values; preserve existing authorization middleware.
+
+12. **`plugins/functions/alp-usermgmt/src/services/StudyAccessRequestService.ts`**
+    - Add idempotent request lookup/return.
+    - On approval, register the user to the selected read/write group in the same transaction.
+    - Do not remove memberships. In particular, no branch may remove or overwrite the existing write group.
+
+13. **`plugins/functions/alp-usermgmt/src/repositories/GroupAccessRequestRepository.ts`**
+    - Add the precise query needed to batch unresolved requests by current user and source group/study.
+    - Add repository support for idempotent retrieval under a race.
+
+14. **`plugins/functions/alp-usermgmt/src/dtos/StudyAccessRequest.ts`**
+    - Include approved/requested role data required by the API response without breaking current administration consumers.
+
+15. **`plugins/functions/alp-usermgmt/src/db/init/create-schema.sql`**
+    - **Conditional change only:** add a partial unique index on unresolved `(user_id, group_id)` requests if inspection confirms the current schema lacks equivalent protection. Do not change group or role tables.
+
+16. **`plugins/functions/alp-usermgmt/src/routes/StudyAccessRequestRouter.spec.ts`** *(add if this package has no colocated router test; otherwise use its established test location)*
+    - Cover requester identity enforcement, enabled/disabled requests, idempotency, authorization, read approval, write approval, rejection, and write-membership preservation.
+
+17. **`plugins/functions/alp-usermgmt/src/services/StudyAccessRequestService.spec.ts`** *(add if this package has no colocated service test; otherwise use its established test location)*
+    - Cover transactional group grant selection and the no-write-removal regression.
+
+### 3. Atlas-only UI implementation
+
+18. **`plugins/atlas/src/types/data-source.ts`** *(new)*
+    - Define the Atlas UI's API response types, `DataSourceAccessState`, data-source card/detail shape, sort options, and request response.
+
+19. **`plugins/atlas/src/services/dataSourceApi.ts`** *(new)*
+    - Fetch authenticated and anonymous data-source responses from the portal service.
+    - Submit a request-access operation to user management with only allowed inputs.
+    - Keep token usage in the Authorization header sourced through plugin props/local storage; never put it in a URL.
+
+20. **`plugins/atlas/src/composables/useDataSources.ts`** *(new)*
+    - Own Atlas-local list/detail loading, anonymous/authenticated mode, search, sort, and a shared in-memory store keyed by source ID.
+    - On successful request, change that source from `no_access` to `pending` immediately in both list and detail data; refetch after server mutations/route entry to converge with approved `read` or `write` state.
+
+21. **`plugins/atlas/src/components/data-sources/AccessStatusBadge.vue`** *(new)*
+    - Render all five access states with Figma-matched status label, icon, colour, accessible text, and restricted tooltip.
+    - Keep `write` distinct in semantic metadata/assistive text while rendering Access status as specified.
+
+22. **`plugins/atlas/src/components/data-sources/DataSourceBanner.vue`** *(new)*
+    - Render the currently configured organisation image/logo and descriptive banner for both user modes using data returned by the portal configuration endpoint.
+
+23. **`plugins/atlas/src/components/data-sources/DataSourceCard.vue`** *(new)*
+    - Render the Figma card fields, public/non-public badge, access badge for authenticated users, and accessible card navigation.
+
+24. **`plugins/atlas/src/components/data-sources/DataSourceSort.vue`** *(new)*
+    - Render Figma sort control.
+    - Expose Access/A–Z/Z–A to authenticated users and A–Z/Z–A only to anonymous users.
+
+25. **`plugins/atlas/src/components/data-sources/DataSourceList.vue`** *(new)*
+    - Render banner, search, sorting, empty/loading/error states, and responsive two-column/single-column card grid.
+    - Apply the exact sorting model in the issue: Access order has `write` and `read` first, followed by pending, no-access, restricted, stable by name.
+
+26. **`plugins/atlas/src/components/data-sources/DataSourceDetailHeader.vue`** *(new)*
+    - Render the source name and top-right state/action region from Figma.
+    - Invoke the composable request action, disable while submitting, show pending after success, and retain server-derived status after failure.
+
+27. **`plugins/atlas/src/components/data-sources/DataSourceDetail.vue`** *(new)*
+    - Render the detail route's header plus existing returned source detail fields; it does not replace or alter any legacy portal component.
+
+28. **`plugins/atlas/src/components/DataSourcesApp.vue`** *(new)*
+    - Provide Atlas-local routing/state composition between the list and `data-sources/:id` detail views.
+
+29. **`plugins/atlas/src/portal-main.ts`**
+    - Mount `DataSourcesApp` for this Atlas plugin entry instead of the iframe-only wrapper for the data-source route. Preserve existing plugin lifecycle and token provisioning.
+
+30. **`plugins/atlas/src/types/index.ts`**
+    - Extend plugin properties only if the Atlas UI needs an explicitly provided portal API base URL or configuration. Preserve existing token, username, dataset, and locale fields.
+
+31. **`plugins/atlas/src/styles/data-sources.css`** *(new)*
+    - Implement Figma-derived typography, spacing, badge states, responsive breakpoints, card grid, header placement, tooltip, focus styles, and loading/error presentation.
+
+32. **`plugins/atlas/src/components/data-sources/__tests__/AccessStatusBadge.spec.ts`** *(new)*
+    - Test labels, icons/accessibility, and restricted tooltip for all five states.
+
+33. **`plugins/atlas/src/components/data-sources/__tests__/DataSourceList.spec.ts`** *(new)*
+    - Test card data, authenticated and anonymous sorting, public-only anonymous content, and no anonymous access-status/action display.
+
+34. **`plugins/atlas/src/components/data-sources/__tests__/DataSourceDetailHeader.spec.ts`** *(new)*
+    - Test no-access request action, pending transition, restricted no-action tooltip, read state, and write state/regression semantics.
+
+35. **`plugins/atlas/src/composables/__tests__/useDataSources.spec.ts`** *(new)*
+    - Test the shared optimistic pending transition and server refresh replacing pending with read/write.
+
+36. **`plugins/atlas/vite.portal.config.mjs`**
+    - Update only if CSS/module routing or test aliases require a build configuration adjustment; otherwise leave unchanged.
+
+37. **`plugins/atlas/resources/portal/index.js` and `plugins/atlas/resources/portal/atlas.css`**
+    - Generated build output only. Regenerate through `npm run build:portal`; do not hand-edit either artifact.
+
+## Implementation order
+
+1. Inspect actual current role names and the user-management schema before changing logic; confirm the existing write group used by this deployment and whether an unresolved-request uniqueness constraint already exists.
+2. Implement server-side access contract types, role/pending batch lookups, and access-state derivation with tests.
+3. Harden request creation/decision handling and add explicit read/write approval with write-preservation tests. Make the conditional schema index only if step 1 shows it is required.
+4. Create the Atlas API client, access types, and shared composable/store.
+5. Build the Atlas-only status badge, banner, sort control, cards, list, detail header, and detail route according to Figma.
+6. Integrate the Atlas app at its plugin entry point and generate the plugin portal artifact. Do not touch portal dataset UI files.
+7. Run focused and full test/build/runtime/browser checks; compare desktop and narrow viewports with the Figma nodes `1709:215181`, `1709:220262`, and `1762:478519`.
+
+## Verification plan
+
+### Automated server checks
+
+- Portal query tests: list and detail return the same `accessState`; cover no_access, pending, restricted, read, write and write precedence.
+- User-management tests: authenticated requester identity, request-disabled handling, duplicate request idempotency, authorization, approved read, approved write, rejected request, and preserved pre-existing write membership.
+- Public endpoint regression: anonymous users receive public data sources only, no access-state fields/actions.
+- Run the relevant package unit tests and TypeScript checks for `plugins/functions/portal` and `plugins/functions/alp-usermgmt`.
+
+### Atlas UI checks
+
+- Run the Atlas component/composable test suite for all badges, sorting options/order, request transition, restricted tooltip, anonymous behaviour, and write status.
+- Run `npm run build:portal` from `plugins/atlas` and verify generated resources are current.
+- Type-check `plugins/atlas`.
+
+### Real runtime and browser checks
+
+- Exercise modified D2E functions through the deployed edge runtime: fetch list/detail as an authenticated user, create a request, resolve it as read, resolve it as write, and verify that write capability remains available.
+- Build the Atlas plugin, deploy/serve its resources through the live app route, and test with browser automation:
+  1. anonymous public-only cards and A–Z/Z–A sorts;
+  2. authenticated two-column list with access-first order;
+  3. request action updates detail and list card to pending immediately;
+  4. restricted state has no action and shows the required tooltip;
+  5. read and write approvals update to Access and write functionality continues to work.
+- Capture desktop and narrow viewport visual checks against the linked Figma nodes.
+
+## Completion criteria
+
+The work is complete when all UI files changed are under `plugins/atlas`, the server exposes a canonical state without losing write entitlement, Atlas data-source list/card/detail UI consistently displays that state, request-to-pending and approval-to-read/write transitions synchronize list and detail, anonymous visibility/sorting remains constrained, and tests prove that existing write access still functions.

--- a/plugins/atlas/src/data-sources/AccessStatusBadge.vue
+++ b/plugins/atlas/src/data-sources/AccessStatusBadge.vue
@@ -1,0 +1,34 @@
+<template>
+  <span class="access-status" :class="`access-status--${visualState}`" :title="tooltip">
+    <span class="access-status__icon" aria-hidden="true">{{ icon }}</span>
+    <span>{{ label }}</span>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { DataSourceAccessState } from './types';
+
+const props = defineProps<{ state: DataSourceAccessState }>();
+
+const visualState = computed(() => props.state === 'write' ? 'read' : props.state);
+const label = computed(() => {
+  switch (visualState.value) {
+    case 'read': return 'Access';
+    case 'pending': return 'Pending access';
+    case 'restricted': return 'Restricted';
+    default: return 'No access';
+  }
+});
+const icon = computed(() => {
+  switch (visualState.value) {
+    case 'read': return '✓';
+    case 'pending': return '◷';
+    case 'restricted': return '⊘';
+    default: return '▣';
+  }
+});
+const tooltip = computed(() => visualState.value === 'restricted'
+  ? 'Access to this dataset is restricted. Contact your administrator to gain access.'
+  : label.value);
+</script>

--- a/plugins/atlas/src/data-sources/DataSourceCard.vue
+++ b/plugins/atlas/src/data-sources/DataSourceCard.vue
@@ -1,0 +1,26 @@
+<template>
+  <button class="data-source-card" type="button" @click="$emit('select', source.id)">
+    <div class="data-source-card__topline">
+      <span class="visibility-badge">{{ visibilityLabel }}</span>
+      <AccessStatusBadge v-if="showAccessStatus && source.accessState" :state="source.accessState" />
+    </div>
+    <h2>{{ source.datasetDetail.name }}</h2>
+    <p>{{ source.datasetDetail.summary || source.datasetDetail.description || 'No description available.' }}</p>
+    <dl>
+      <div><dt>Data model</dt><dd>{{ source.dataModel || 'Not specified' }}</dd></div>
+      <div><dt>Subjects</dt><dd>{{ source.totalSubjects?.toLocaleString() ?? 'Not available' }}</dd></div>
+      <div><dt>Type</dt><dd>{{ source.type || 'Not specified' }}</dd></div>
+    </dl>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import AccessStatusBadge from './AccessStatusBadge.vue';
+import type { DataSource } from './types';
+
+const props = defineProps<{ source: DataSource; showAccessStatus?: boolean }>();
+defineEmits<{ select: [id: string] }>();
+
+const visibilityLabel = computed(() => props.source.datasetDetail.showRequestAccess ? 'Available by request' : 'Restricted');
+</script>

--- a/plugins/atlas/src/data-sources/DataSourceDetailHeader.vue
+++ b/plugins/atlas/src/data-sources/DataSourceDetailHeader.vue
@@ -1,0 +1,31 @@
+<template>
+  <header class="data-source-detail-header">
+    <div>
+      <p class="eyebrow">Data source</p>
+      <h1>{{ source.datasetDetail.name }}</h1>
+      <p v-if="source.datasetDetail.summary || source.datasetDetail.description">
+        {{ source.datasetDetail.summary || source.datasetDetail.description }}
+      </p>
+    </div>
+    <div class="data-source-detail-header__access">
+      <AccessStatusBadge v-if="source.accessState" :state="source.accessState" />
+      <button
+        v-if="source.accessState === 'no_access'"
+        class="request-access-button"
+        type="button"
+        :disabled="requesting"
+        @click="$emit('request-access')"
+      >
+        {{ requesting ? 'Requesting access…' : 'Request access' }}
+      </button>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import AccessStatusBadge from './AccessStatusBadge.vue';
+import type { DataSource } from './types';
+
+defineProps<{ source: DataSource; requesting: boolean }>();
+defineEmits<{ 'request-access': [] }>();
+</script>

--- a/plugins/atlas/src/data-sources/DataSourceDetailPage.vue
+++ b/plugins/atlas/src/data-sources/DataSourceDetailPage.vue
@@ -1,0 +1,62 @@
+<template>
+  <main class="data-source-detail-page">
+    <button class="back-to-data-sources" type="button" @click="$emit('back')">← Back to data sources</button>
+
+    <section v-if="sources.loading && !sources.selectedDataSource" class="data-sources-state" aria-busy="true">
+      <span class="skeleton skeleton--title" />
+      <span class="skeleton skeleton--text" />
+    </section>
+
+    <section v-else-if="sources.error" class="data-sources-state data-sources-state--error" role="alert">
+      <h1>Unable to load this data source</h1>
+      <p>{{ sources.error }}</p>
+      <button type="button" @click="sources.selectDataSource(sourceId)">Try again</button>
+    </section>
+
+    <template v-else-if="source">
+      <DataSourceDetailHeader
+        :source="source"
+        :requesting="sources.requestingIds.has(source.id)"
+        @request-access="sources.requestAccess(source)"
+      />
+
+      <section class="data-source-detail-content" aria-label="Data source details">
+        <div class="data-source-detail-content__description">
+          <h2>About this data source</h2>
+          <p>{{ source.datasetDetail.description || source.datasetDetail.summary || 'No description available.' }}</p>
+        </div>
+        <dl class="data-source-metadata">
+          <div><dt>Data source name</dt><dd>{{ source.datasetDetail.name }}</dd></div>
+          <div><dt>Type</dt><dd>{{ source.type || 'Not specified' }}</dd></div>
+          <div><dt>Data model</dt><dd>{{ source.dataModel || 'Not specified' }}</dd></div>
+          <div><dt>Schema</dt><dd>{{ source.tokenDatasetCode || 'Not specified' }}</dd></div>
+          <div><dt>Subjects</dt><dd>{{ source.totalSubjects?.toLocaleString() ?? 'Not available' }}</dd></div>
+        </dl>
+      </section>
+    </template>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, watch } from 'vue';
+import DataSourceDetailHeader from './DataSourceDetailHeader.vue';
+import type { useDataSources } from './use-data-sources';
+
+const props = defineProps<{
+  sourceId: string;
+  sources: ReturnType<typeof useDataSources>;
+}>();
+
+defineEmits<{ back: [] }>();
+
+const source = computed(() => props.sources.selectedDataSource?.id === props.sourceId
+  ? props.sources.selectedDataSource
+  : props.sources.dataSources.find((item) => item.id === props.sourceId));
+
+function loadSource() {
+  void props.sources.selectDataSource(props.sourceId);
+}
+
+onMounted(loadSource);
+watch(() => props.sourceId, loadSource);
+</script>

--- a/plugins/atlas/src/data-sources/DataSourceListPage.vue
+++ b/plugins/atlas/src/data-sources/DataSourceListPage.vue
@@ -1,0 +1,72 @@
+<template>
+  <main class="data-sources-page">
+    <header class="data-sources-page__header">
+      <div>
+        <p class="data-sources-page__eyebrow">Explore</p>
+        <h1>Data Sources</h1>
+        <p>Browse the available data sources and request access where needed.</p>
+      </div>
+      <div class="data-sources-page__controls">
+        <label class="data-sources-search">
+          <span class="sr-only">Search data sources</span>
+          <input v-model="sources.query" type="search" placeholder="Search data sources" />
+        </label>
+        <label v-if="isAuthenticated" class="data-sources-sort">
+          <span>Sort by</span>
+          <select v-model="sources.sort">
+            <option value="access">Access</option>
+            <option value="name-asc">Name A–Z</option>
+            <option value="name-desc">Name Z–A</option>
+          </select>
+        </label>
+      </div>
+    </header>
+
+    <section v-if="sources.loading" class="data-source-grid" aria-label="Loading data sources" aria-busy="true">
+      <div v-for="index in 4" :key="index" class="data-source-card data-source-card--skeleton">
+        <span class="skeleton skeleton--badge" />
+        <span class="skeleton skeleton--title" />
+        <span class="skeleton skeleton--text" />
+        <span class="skeleton skeleton--text skeleton--short" />
+      </div>
+    </section>
+
+    <section v-else-if="sources.error" class="data-sources-state data-sources-state--error" role="alert">
+      <h2>Unable to load data sources</h2>
+      <p>{{ sources.error }}</p>
+      <button type="button" @click="sources.loadDataSources">Try again</button>
+    </section>
+
+    <section v-else-if="sources.sortedDataSources.length === 0" class="data-sources-state">
+      <h2>No data sources found</h2>
+      <p>Try changing the search term.</p>
+    </section>
+
+    <section v-else class="data-source-grid" aria-label="Data sources">
+      <DataSourceCard
+        v-for="source in sources.sortedDataSources"
+        :key="source.id"
+        :source="source"
+        :show-access-status="isAuthenticated"
+        @select="$emit('select', $event)"
+      />
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import DataSourceCard from './DataSourceCard.vue';
+import type { useDataSources } from './use-data-sources';
+
+const props = defineProps<{
+  sources: ReturnType<typeof useDataSources>;
+  isAuthenticated: boolean;
+}>();
+
+defineEmits<{ select: [id: string] }>();
+
+onMounted(() => {
+  if (!props.sources.dataSources.length) void props.sources.loadDataSources();
+});
+</script>

--- a/plugins/atlas/src/data-sources/data-source-api.ts
+++ b/plugins/atlas/src/data-sources/data-source-api.ts
@@ -1,0 +1,52 @@
+import type { DataSource, DataSourceAccessRequest } from './types';
+
+const SYSTEM_PORTAL_URL = '/d2e/system-portal';
+const USER_MANAGEMENT_URL = '/d2e/usermgmt/api';
+
+function authHeaders(token: string): HeadersInit {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function request<T>(url: string, token: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      ...authHeaders(token),
+      ...init.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function getDataSources(token: string, searchText?: string): Promise<DataSource[]> {
+  const search = new URLSearchParams();
+  if (searchText) search.set('searchText', searchText);
+  const query = search.toString();
+  return request<DataSource[]>(
+    `${SYSTEM_PORTAL_URL}/dataset/list${query ? `?${query}` : ''}`,
+    token,
+  );
+}
+
+export function getDataSource(token: string, id: string): Promise<DataSource> {
+  return request<DataSource>(
+    `${SYSTEM_PORTAL_URL}/dataset?datasetId=${encodeURIComponent(id)}`,
+    token,
+  );
+}
+
+export function createAccessRequest(
+  token: string,
+  studyId: string,
+): Promise<DataSourceAccessRequest[]> {
+  return request<DataSourceAccessRequest[]>(`${USER_MANAGEMENT_URL}/study/access-request`, token, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ studyId, role: 'RESEARCHER' }),
+  });
+}

--- a/plugins/atlas/src/data-sources/data-sources.css
+++ b/plugins/atlas/src/data-sources/data-sources.css
@@ -1,0 +1,171 @@
+.data-sources-page,
+.data-source-detail-page {
+  box-sizing: border-box;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 40px 32px 64px;
+  color: #1f2937;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.data-sources-page__header,
+.data-source-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.data-sources-page h1,
+.data-source-detail-header h1 {
+  margin: 0;
+  color: #172554;
+  font-size: 32px;
+  line-height: 1.2;
+}
+
+.data-sources-page__header p:not(.data-sources-page__eyebrow),
+.data-source-detail-header p:not(.eyebrow) {
+  max-width: 680px;
+  margin: 8px 0 0;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.data-sources-page__eyebrow,
+.eyebrow {
+  margin: 0 0 6px;
+  color: #475569;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.data-sources-page__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.data-sources-search input,
+.data-sources-sort select {
+  box-sizing: border-box;
+  min-height: 42px;
+  border: 1px solid #94a3b8;
+  border-radius: 6px;
+  background: #fff;
+  color: #1f2937;
+  font: inherit;
+}
+
+.data-sources-search input { width: 260px; padding: 0 12px; }
+.data-sources-sort { display: grid; gap: 4px; color: #334155; font-size: 13px; font-weight: 600; }
+.data-sources-sort select { padding: 0 30px 0 10px; }
+
+.data-source-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.data-source-card {
+  display: block;
+  width: 100%;
+  min-height: 244px;
+  padding: 22px;
+  border: 1px solid #d7dee8;
+  border-radius: 10px;
+  background: #fff;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 5%);
+  transition: border-color .16s ease, box-shadow .16s ease, transform .16s ease;
+}
+
+.data-source-card:hover { border-color: #3b82f6; box-shadow: 0 8px 20px rgb(15 23 42 / 10%); transform: translateY(-1px); }
+.data-source-card:focus-visible,
+.back-to-data-sources:focus-visible,
+.request-access-button:focus-visible,
+.data-sources-state button:focus-visible,
+.data-sources-search input:focus-visible,
+.data-sources-sort select:focus-visible { outline: 3px solid #93c5fd; outline-offset: 2px; }
+
+.data-source-card__topline { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 18px; }
+.data-source-card h2 { margin: 0; color: #172554; font-size: 20px; line-height: 1.3; }
+.data-source-card > p { display: -webkit-box; overflow: hidden; margin: 10px 0 20px; color: #475569; line-height: 1.5; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+.data-source-card dl { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin: 0; }
+.data-source-card dl div { min-width: 0; }
+.data-source-card dt,
+.data-source-metadata dt { color: #64748b; font-size: 12px; font-weight: 600; }
+.data-source-card dd,
+.data-source-metadata dd { overflow-wrap: anywhere; margin: 4px 0 0; color: #334155; font-size: 14px; }
+
+.visibility-badge,
+.access-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  padding: 5px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.visibility-badge { background: #e2e8f0; color: #334155; }
+.access-status--read { background: #dcfce7; color: #166534; }
+.access-status--pending { background: #fef3c7; color: #92400e; }
+.access-status--restricted { background: #fee2e2; color: #b91c1c; }
+.access-status--no_access { background: #e5e7eb; color: #4b5563; }
+.access-status__icon { font-size: 14px; line-height: 1; }
+
+.data-source-detail-header { padding-bottom: 24px; border-bottom: 1px solid #d7dee8; }
+.data-source-detail-header__access { display: flex; flex: 0 0 auto; align-items: center; gap: 12px; }
+.request-access-button,
+.data-sources-state button { min-height: 40px; border: 0; border-radius: 6px; padding: 0 16px; background: #1d4ed8; color: #fff; font: inherit; font-weight: 700; cursor: pointer; }
+.request-access-button:hover:not(:disabled),
+.data-sources-state button:hover { background: #1e40af; }
+.request-access-button:disabled { cursor: wait; opacity: .65; }
+.back-to-data-sources { margin: 0 0 26px; border: 0; padding: 0; background: transparent; color: #1d4ed8; font: inherit; font-weight: 700; cursor: pointer; }
+
+.data-source-detail-content { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(260px, .8fr); gap: 48px; padding-top: 32px; }
+.data-source-detail-content h2 { margin-top: 0; color: #172554; font-size: 22px; }
+.data-source-detail-content__description p { color: #475569; line-height: 1.6; }
+.data-source-metadata { display: grid; gap: 16px; margin: 0; padding: 22px; border-radius: 8px; background: #f8fafc; }
+
+.data-sources-state { padding: 48px 24px; border: 1px dashed #cbd5e1; border-radius: 10px; color: #475569; text-align: center; }
+.data-sources-state h1,
+.data-sources-state h2 { margin-top: 0; color: #172554; }
+.data-sources-state--error { border-color: #fca5a5; background: #fef2f2; color: #991b1b; }
+.data-sources-state--error h1,
+.data-sources-state--error h2 { color: #991b1b; }
+
+.skeleton { display: block; border-radius: 4px; background: linear-gradient(90deg, #e2e8f0 25%, #f1f5f9 37%, #e2e8f0 63%); background-size: 400% 100%; animation: data-source-shimmer 1.4s ease infinite; }
+.skeleton--badge { width: 116px; height: 24px; margin-bottom: 28px; }
+.skeleton--title { width: 62%; height: 25px; margin-bottom: 16px; }
+.skeleton--text { width: 100%; height: 16px; margin: 10px 0; }
+.skeleton--short { width: 72%; }
+
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; }
+@keyframes data-source-shimmer { to { background-position: -400% 0; } }
+
+@media (max-width: 760px) {
+  .data-sources-page, .data-source-detail-page { padding: 28px 18px 48px; }
+  .data-sources-page__header, .data-source-detail-header { flex-direction: column; }
+  .data-sources-page__controls, .data-source-detail-header__access { width: 100%; justify-content: flex-start; }
+  .data-sources-search { flex: 1 1 100%; }
+  .data-sources-search input { width: 100%; }
+  .data-source-grid, .data-source-detail-content { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 440px) {
+  .data-source-card dl { grid-template-columns: 1fr 1fr; }
+  .data-sources-page h1, .data-source-detail-header h1 { font-size: 27px; }
+}

--- a/plugins/atlas/src/data-sources/types.ts
+++ b/plugins/atlas/src/data-sources/types.ts
@@ -1,0 +1,29 @@
+export type DataSourceAccessState =
+  | 'no_access'
+  | 'pending'
+  | 'restricted'
+  | 'read'
+  | 'write';
+
+export type DataSourceSort = 'access' | 'name-asc' | 'name-desc';
+
+export interface DataSource {
+  id: string;
+  tokenDatasetCode: string;
+  type?: string;
+  dataModel: string;
+  totalSubjects?: number;
+  accessState?: DataSourceAccessState;
+  datasetDetail: {
+    id: string;
+    name: string;
+    description?: string;
+    summary?: string;
+    showRequestAccess: boolean;
+  };
+}
+
+export interface DataSourceAccessRequest {
+  id: string;
+  groupId: string;
+}

--- a/plugins/atlas/src/data-sources/use-data-sources.ts
+++ b/plugins/atlas/src/data-sources/use-data-sources.ts
@@ -1,0 +1,97 @@
+import { computed, reactive, ref } from 'vue';
+import { createAccessRequest, getDataSource, getDataSources } from './data-source-api';
+import type { DataSource, DataSourceAccessState, DataSourceSort } from './types';
+
+const accessRank: Record<DataSourceAccessState, number> = {
+  read: 0,
+  write: 0,
+  pending: 1,
+  no_access: 2,
+  restricted: 3,
+};
+
+export function useDataSources(token: () => Promise<string>) {
+  const dataSources = ref<DataSource[]>([]);
+  const selectedDataSource = ref<DataSource>();
+  const query = ref('');
+  const sort = ref<DataSourceSort>('access');
+  const loading = ref(false);
+  const error = ref('');
+  const requestingIds = reactive(new Set<string>());
+
+  const sortedDataSources = computed(() => {
+    const normalizedQuery = query.value.trim().toLocaleLowerCase();
+    const results = dataSources.value.filter((source) => {
+      const name = source.datasetDetail.name.toLocaleLowerCase();
+      const summary = (source.datasetDetail.summary ?? source.datasetDetail.description ?? '').toLocaleLowerCase();
+      return !normalizedQuery || name.includes(normalizedQuery) || summary.includes(normalizedQuery);
+    });
+
+    return results.sort((left, right) => {
+      const nameOrder = left.datasetDetail.name.localeCompare(right.datasetDetail.name, undefined, { sensitivity: 'base' });
+      if (sort.value === 'name-asc') return nameOrder;
+      if (sort.value === 'name-desc') return -nameOrder;
+      return accessRank[left.accessState ?? 'no_access'] - accessRank[right.accessState ?? 'no_access'] || nameOrder;
+    });
+  });
+
+  function patchAccessState(id: string, accessState: DataSourceAccessState) {
+    dataSources.value = dataSources.value.map((source) => source.id === id ? { ...source, accessState } : source);
+    if (selectedDataSource.value?.id === id) {
+      selectedDataSource.value = { ...selectedDataSource.value, accessState };
+    }
+  }
+
+  async function loadDataSources() {
+    loading.value = true;
+    error.value = '';
+    try {
+      dataSources.value = await getDataSources(await token());
+    } catch (caught) {
+      error.value = caught instanceof Error ? caught.message : 'Unable to load data sources.';
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function selectDataSource(id: string) {
+    error.value = '';
+    try {
+      const source = await getDataSource(await token(), id);
+      selectedDataSource.value = source;
+      const index = dataSources.value.findIndex((item) => item.id === id);
+      if (index >= 0) dataSources.value[index] = source;
+    } catch (caught) {
+      error.value = caught instanceof Error ? caught.message : 'Unable to load the data source.';
+    }
+  }
+
+  async function requestAccess(source: DataSource) {
+    if (source.accessState !== 'no_access' || requestingIds.has(source.id)) return;
+
+    requestingIds.add(source.id);
+    error.value = '';
+    try {
+      await createAccessRequest(await token(), source.id);
+      patchAccessState(source.id, 'pending');
+    } catch (caught) {
+      error.value = caught instanceof Error ? caught.message : 'Unable to request access.';
+    } finally {
+      requestingIds.delete(source.id);
+    }
+  }
+
+  return {
+    dataSources,
+    selectedDataSource,
+    query,
+    sort,
+    loading,
+    error,
+    requestingIds,
+    sortedDataSources,
+    loadDataSources,
+    selectDataSource,
+    requestAccess,
+  };
+}

--- a/plugins/atlas/src/portal-main.ts
+++ b/plugins/atlas/src/portal-main.ts
@@ -1,0 +1,52 @@
+import { computed, createApp, h, inject, ref } from 'vue';
+import singleSpaVue from 'single-spa-vue';
+import DataSourceDetailPage from './data-sources/DataSourceDetailPage.vue';
+import DataSourceListPage from './data-sources/DataSourceListPage.vue';
+import { useDataSources } from './data-sources/use-data-sources';
+import './data-sources/data-sources.css';
+import type { PluginProps } from './types';
+
+const DataSourcesApp = {
+  setup() {
+    const pluginProps = inject<PluginProps>('pluginProps');
+    const getToken = pluginProps?.getToken ?? (async () => pluginProps?.authContext?.token ?? '');
+    const isAuthenticated = computed(() => Boolean(pluginProps?.getToken || pluginProps?.authContext?.isAuthenticated));
+    const sources = useDataSources(getToken);
+    const selectedId = ref<string | null>(null);
+
+    function select(id: string) {
+      selectedId.value = id;
+      window.history.pushState({ dataSourceId: id }, '', `#data-sources/${encodeURIComponent(id)}`);
+    }
+
+    function back() {
+      selectedId.value = null;
+      window.history.pushState({}, '', '#data-sources');
+    }
+
+    function syncRoute() {
+      const match = window.location.hash.match(/^#data-sources\/([^/?#]+)/);
+      selectedId.value = match ? decodeURIComponent(match[1]) : null;
+    }
+
+    window.addEventListener('popstate', syncRoute);
+    window.addEventListener('hashchange', syncRoute);
+    syncRoute();
+
+    return () => selectedId.value
+      ? h(DataSourceDetailPage, { sourceId: selectedId.value, sources, onBack: back })
+      : h(DataSourceListPage, { sources, isAuthenticated: isAuthenticated.value, onSelect: select });
+  },
+};
+
+const vueLifecycles = singleSpaVue({
+  createApp,
+  appOptions: { render: () => h(DataSourcesApp) },
+  handleInstance(app, props: PluginProps) {
+    app.provide('pluginProps', props);
+  },
+});
+
+export const bootstrap = (props: PluginProps) => vueLifecycles.bootstrap(props);
+export const mount = (props: PluginProps) => vueLifecycles.mount(props);
+export const unmount = (props: PluginProps) => vueLifecycles.unmount(props);

--- a/plugins/functions/alp-usermgmt/src/routes/StudyAccessRequestRouter.ts
+++ b/plugins/functions/alp-usermgmt/src/routes/StudyAccessRequestRouter.ts
@@ -1,0 +1,131 @@
+import express, { NextFunction, Response } from 'express'
+import { Service } from 'typedi'
+import { B2cGroupService, StudyAccessRequestService } from '../services'
+import { AccessRequestAction, IAppRequest } from '../types'
+import { createLogger } from '../Logger'
+import { env } from '../env'
+
+@Service()
+export class StudyAccessRequestRouter {
+  public router = express.Router()
+  private readonly logger = createLogger(this.constructor.name)
+
+  constructor(
+    private readonly studyAccessRequestService: StudyAccessRequestService,
+    private readonly groupService: B2cGroupService
+  ) {
+    this.registerRoutes()
+  }
+
+  private registerRoutes() {
+    this.router.get('/list/:studyId', async (req: IAppRequest, res: Response, next: NextFunction) => {
+      const { studyId } = req.params || {}
+      this.logger.info(`Get access requests of study ${studyId}}`)
+
+      try {
+        const accessRequests = await this.studyAccessRequestService.getStudyAccessRequestList({
+          study_id: studyId,
+          status: null
+        })
+        return res.status(200).json(accessRequests)
+      } catch (err) {
+        this.logger.error(`Error when getting access requests of study ${studyId}: ${JSON.stringify(err)}`)
+        return next(err)
+      }
+    })
+
+    this.router.post('/', async (req: IAppRequest, res: Response, next: NextFunction) => {
+      const tenantId = env.APP_TENANT_ID
+      const { studyId, role } = req.body || {}
+      const userId = req.user.userId
+
+      if (!studyId) {
+        this.logger.warn(`Param 'studyId' is required`)
+        return res.status(400).send({ message: `Param 'studyId' is required` })
+      } else if (!role) {
+        this.logger.warn(`Param 'role' is required`)
+        return res.status(400).send({ message: `Param 'role' is required` })
+      }
+
+      this.logger.info(`Add access request for user ${userId} to study ${studyId}, role ${role}`)
+
+      const check = await this.groupService.getGroupByStudyRole(studyId, role)
+      if (check == null) {
+        this.logger.info(`Group ${role} does not exist. Creating role...`)
+        await this.groupService.createGroup({ role, tenantId, studyId })
+      }
+
+      try {
+        const result = await this.studyAccessRequestService.addRequest(userId, studyId, role, req.user)
+        res.status(200).json(result)
+      } catch (err) {
+        this.logger.error(
+          `Error while adding access request for user ${userId} to study ${studyId}, role ${role}: ${JSON.stringify(
+            err
+          )}`
+        )
+        next(err)
+      }
+    })
+
+    this.router.get('/me', async (req: IAppRequest, res: Response, next: NextFunction) => {
+      this.logger.info('Get my study access requests')
+      const userId = req.user.userId
+
+      try {
+        const accessRequests = await this.studyAccessRequestService.getStudyAccessRequestList({
+          user_id: userId,
+          status: null
+        })
+        return res.status(200).json(accessRequests)
+      } catch (err) {
+        this.logger.error(`Error when getting study access requests of user ${userId}: ${JSON.stringify(err)}`)
+        return next(err)
+      }
+    })
+
+    this.router.put('/:action', async (req: IAppRequest, res: Response, next: NextFunction) => {
+      const { action } = req.params || {}
+      const { id, userId, groupId } = req.body || {}
+
+      if (!action) {
+        this.logger.warn(`Path param is required`)
+        return res.status(400).send({ message: `Param is required` })
+      } else if (!['approve', 'reject'].includes(action)) {
+        this.logger.warn(`Path param is invalid`)
+        return res.status(400).send({ message: `Param is invalid` })
+      }
+
+      if (!id) {
+        this.logger.warn(`Param 'id' is required`)
+        return res.status(400).send({ message: `Param 'id' is required` })
+      } else if (!userId) {
+        this.logger.warn(`Param 'userId' is required`)
+        return res.status(400).send({ message: `Param 'userId' is required` })
+      } else if (!groupId) {
+        this.logger.warn(`Param 'groupId' is required`)
+        return res.status(400).send({ message: `Param 'groupId' is required` })
+      }
+
+      this.logger.info(`Handle request ${id} to ${action} user ${userId} access to group ${groupId}`)
+
+      try {
+        const result = await this.studyAccessRequestService.handleRequest(
+          id,
+          userId,
+          groupId,
+          action as AccessRequestAction,
+          req.user
+        )
+        res.status(200).json(result)
+      } catch (err) {
+        this.logger.error(
+          `Error while handling request ${id} to ${action} user ${userId} access to group ${groupId}: ${JSON.stringify(
+            err
+          )}`
+        )
+        next(err)
+      }
+    })
+  }
+}

--- a/plugins/functions/alp-usermgmt/src/types.ts
+++ b/plugins/functions/alp-usermgmt/src/types.ts
@@ -1,0 +1,160 @@
+import { Request } from 'express'
+import { ITokenPayload } from 'passport-azure-ad'
+
+export type Knex = any
+
+export interface Pagination {
+  offset: number
+  limit: number
+}
+
+type RoleTypeOf<T> = {
+  ALP_USER_ADMIN: boolean
+  ALP_SYSTEM_ADMIN: boolean
+  ALP_DASHBOARD_VIEWER: boolean
+  STUDY_WRITE_DQD_RESEARCHER: boolean
+  STUDY_RESULTS_READ_RESEARCHER: boolean
+  ETL_MAPPING_CONTRIBUTOR: boolean
+  TENANT_ADMIN: T
+  TENANT_VIEWER: T
+  STUDY_RESEARCHER: T
+}
+
+//Roles for tenant users map
+type AlpTenantUserRoleMapType = RoleTypeOf<string[]>
+
+export interface ITokenUser {
+  userId: string
+  idpUserId?: string
+}
+
+export interface IAppRequest extends Request {
+  user: ITokenUser
+  userGroupsCache?: Map<string, Promise<UserGroupMetadata>>
+}
+
+export interface DataSourceRoleMemberships {
+  readStudyIds: string[]
+  hasWriteAccess: boolean
+}
+
+export interface UnresolvedStudyAccessRequest {
+  studyId: string
+}
+
+export interface RoleMap {
+  alp_tenant_id: string[] // list of all tenant ids
+  alp_role_study_researcher: string[] // list of study ids
+  alp_role_study_admin: string[] // list of study ids
+  alp_role_tenant_admin: string[] // list of tenant ids
+  alp_role_tenant_viewer: string[] // list of tenant ids
+  alp_role_study_write_dqd_researcher: boolean // alp job runner
+  alp_role_etl_mapping_contributor: boolean // contributor to ETL mapping
+  alp_role_study_results_read_researcher: boolean // view study results
+  alp_role_user_admin: boolean // alp user admin
+  alp_role_system_admin: boolean // alp system admin
+  alp_role_dashboard_viewer: boolean // dashboard viewer
+}
+
+export interface UserGroupMetadata extends RoleMap {
+  userId: string
+  groups: string[]
+  alpRoleMap: AlpTenantUserRoleMapType
+}
+
+export interface IUserWithRoles {
+  userId: string
+  username: string
+  roles: string[]
+}
+
+export interface IUserWithRolesInfo {
+  userId: string
+  username: string
+  roles: string[]
+  system: string | null
+  tenantId: string | null
+  studyId: string | null
+}
+
+export type AccessRequestAction = 'approve' | 'reject'
+
+export interface IUser {
+  id: string
+  name: string
+}
+
+export interface EmailTemplateRequest {
+  toEmail: string
+  templateId: number
+  data: { [key: string]: string }
+}
+
+export interface ITenantFeature {
+  tenantId: string
+  feature: string
+}
+
+export interface ITenant {
+  id: string
+  name: string
+}
+
+export interface ILogtoUser {
+  id: string
+  username: string
+  primaryEmail: string | undefined
+  isSuspended: boolean
+}
+
+export interface ILogtoUserCreated {
+  id: string
+}
+
+export interface ILogtoRole {
+  id: string
+  name: string
+  description: string
+  type: string
+}
+
+export interface UserAddRequest {
+  username: string
+  groupIds: string[]
+  password?: string
+}
+
+export interface UserDeleteRequest {
+  userId: string
+}
+
+export interface UserActivateRequest {
+  userId: string
+  active: boolean
+}
+
+export interface ConfigItem {
+  code: string
+  value: string
+}
+
+export interface ConfigSetRequest {
+  configs: ConfigItem[]
+}
+
+export interface AzureADSetupRequest {
+  tenantViewerGroupId: string
+  systemAdminGroupId: string
+  userAdminGroupId: string
+}
+
+export interface IDataset {
+  id: string
+  token_dataset_code: string
+}
+
+export interface IPortalDataset {
+  id: string
+  tokenStudyCode: string
+  type?: string
+}

--- a/plugins/functions/portal/src/dataset/query/dataset-query.service.spec.ts
+++ b/plugins/functions/portal/src/dataset/query/dataset-query.service.spec.ts
@@ -1,0 +1,137 @@
+import { REQUEST } from '@nestjs/core'
+import { Test, TestingModule } from '@nestjs/testing'
+import { v4 as uuidv4 } from 'uuid'
+import { DatasetQueryService } from './dataset-query.service'
+import { datasetAttributeRepositoryMockFactory, repositoryMockFactory } from '../../../test/repository.mock'
+import { MockType } from '../../../test/type.mock'
+import { TenantService } from '../../tenant/tenant.service'
+import { tenantServiceMockFactory } from '../../tenant/tenant.mock'
+import {
+  DatasetAttributeRepository,
+  DatasetDashboardRepository,
+  DatasetReleaseRepository,
+  DatasetRepository
+} from '../repository'
+import { datasetFilterServiceMockFactory } from '../dataset.mock'
+import { DatasetFilterService } from '../dataset-filter.service'
+import { UserMgmtService } from '../../user-mgmt/user-mgmt.service'
+import { userMgmtServiceMockFactory } from '../../user-mgmt/user-mgmt.mock'
+
+jest.mock('jsonwebtoken', () => ({
+  decode: jest.fn().mockReturnValue({ sub: 'mock-sub' })
+}))
+
+describe('DatasetQueryService', () => {
+  let service: DatasetQueryService
+  let mockRepository: MockType<DatasetRepository>
+  let mockTenantService: MockType<TenantService>
+  let mockAttributeRepository: MockType<DatasetAttributeRepository>
+
+  beforeEach(async () => {
+    const req = {
+      headers: {
+        authorization: 'Bearer token'
+      }
+    }
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DatasetQueryService,
+        { provide: REQUEST, useValue: req },
+        { provide: DatasetRepository, useFactory: repositoryMockFactory },
+        { provide: DatasetAttributeRepository, useFactory: datasetAttributeRepositoryMockFactory },
+        { provide: TenantService, useFactory: tenantServiceMockFactory },
+        { provide: DatasetFilterService, useFactory: datasetFilterServiceMockFactory },
+        { provide: DatasetReleaseRepository, useFactory: repositoryMockFactory },
+        { provide: DatasetDashboardRepository, useFactory: repositoryMockFactory },
+        { provide: UserMgmtService, useFactory: userMgmtServiceMockFactory }
+      ]
+    }).compile()
+
+    service = await module.resolve<DatasetQueryService>(DatasetQueryService)
+    mockRepository = module.get(DatasetRepository)
+    mockTenantService = module.get(TenantService)
+    mockAttributeRepository = module.get(DatasetAttributeRepository)
+  })
+
+  it('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  it.each([
+    ['write', new Set(['dataset-id']), new Set(['dataset-id']), new Set(['dataset-id']), true],
+    ['read', new Set(), new Set(['dataset-id']), new Set(['dataset-id']), false],
+    ['pending', new Set(), new Set(), new Set(['dataset-id']), true],
+    ['restricted', new Set(), new Set(), new Set(), false],
+    ['no_access', new Set(), new Set(), new Set(), true]
+  ])(
+    'derives %s access state with write-first precedence',
+    (expected, writeDatasetIds, readDatasetIds, pendingDatasetIds, showRequestAccess) => {
+      expect(
+        (service as any).getAccessState(
+          'dataset-id',
+          showRequestAccess,
+          writeDatasetIds,
+          readDatasetIds,
+          pendingDatasetIds
+        )
+      ).toBe(expected)
+    }
+  )
+
+  it('should find dataset with detail', async () => {
+    // Given
+    const mockDatasetDetail = { id: 'detail-id', name: 'detail-name', description: 'detail-description' }
+    const mockDatasetTags = [{ id: 'tag-id', name: 'tag-name' }]
+    const mockDatasetAttributes = [{ dataType: 'STRING', name: 'attribute-name', value: 'attribute-value' }]
+    const mockDataset = {
+      id: 'dataset-id',
+      datasetDetail: mockDatasetDetail,
+      attributes: mockDatasetAttributes,
+      tags: mockDatasetTags
+    }
+    const mockTenantId = uuidv4()
+    const mockTenant = {
+      id: mockTenantId,
+      name: 'Mock Tenant'
+    }
+    const mockCreateQueryBuilder: any = {
+      leftJoin: jest.fn().mockImplementation(() => {
+        return mockCreateQueryBuilder
+      }),
+      where: jest.fn().mockImplementation(() => {
+        return mockCreateQueryBuilder
+      }),
+      select: jest.fn().mockImplementation(() => {
+        return mockCreateQueryBuilder
+      }),
+      getOne: jest.fn().mockImplementationOnce(() => {
+        return mockDataset
+      })
+    }
+
+    jest.spyOn(mockRepository, 'createQueryBuilder').mockImplementation(() => mockCreateQueryBuilder)
+    jest.spyOn(mockTenantService, 'getTenant').mockImplementation(() => mockTenant)
+    jest.spyOn(mockAttributeRepository, 'getAttributeDto').mockImplementation(() => mockDatasetAttributes)
+
+    // When
+    const dataset = await service.getDataset(mockDataset.id)
+
+    // Then
+    expect(dataset).toEqual({
+      id: mockDataset.id,
+      studyDetail: mockDatasetDetail,
+      tenant: mockTenant,
+      attributes: [{ dataType: 'STRING', name: 'attribute-name', value: 'attribute-value' }],
+      tags: [{ id: 'tag-id', name: 'tag-name' }]
+    })
+    expect(mockTenantService.getTenant).toBeCalledTimes(1)
+    expect(mockRepository.createQueryBuilder).toHaveBeenCalledWith('dataset')
+    expect(mockCreateQueryBuilder.leftJoin).toHaveBeenCalledWith('dataset.datasetDetail', 'datasetDetail')
+    expect(mockCreateQueryBuilder.leftJoin).toHaveBeenCalledWith('dataset.dashboards', 'dashboard')
+    expect(mockCreateQueryBuilder.leftJoin).toHaveBeenCalledWith('dataset.tags', 'tag')
+    expect(mockCreateQueryBuilder.leftJoin).toHaveBeenCalledWith('dataset.attributes', 'attribute')
+    expect(mockCreateQueryBuilder.leftJoin).toHaveBeenCalledWith('attribute.attributeConfig', 'attributeConfig')
+    expect(mockCreateQueryBuilder.where).toHaveBeenCalledWith('dataset.id = :id', { id: mockDataset.id })
+    expect(mockCreateQueryBuilder.getOne).toBeCalledTimes(1)
+  })
+})

--- a/plugins/functions/portal/src/dataset/query/dataset-query.service.ts
+++ b/plugins/functions/portal/src/dataset/query/dataset-query.service.ts
@@ -1,0 +1,518 @@
+import { HttpException, Injectable, SCOPE } from "@danet/core";
+import { Brackets } from "npm:typeorm";
+import { RequestContextService } from "../../common/request-context.service.ts";
+import { createLogger } from "../../logger.ts";
+import { TenantService } from "../../tenant/tenant.service.ts";
+import {
+  DataSourceAccessState,
+  IDataset,
+  IDatasetQueryDto,
+  IDatasetResponseDto,
+  IDatasetSearchDto,
+  ITenant,
+} from "../../types.d.ts";
+import { UserMgmtService } from "../../user-mgmt/user-mgmt.service.ts";
+import { DatasetFilterService } from "../dataset-filter.service.ts";
+import { Dataset } from "../entity/index.ts";
+import {
+  DatasetCodeQueryRepository,
+  DatasetCodeRepository,
+  DatasetDashboardRepository,
+  DatasetReleaseRepository,
+  DatasetRepository,
+} from "../repository/index.ts";
+
+const SWAP_TO = {
+  STUDY: ["dataset", "study"],
+  DATASET: ["study", "dataset"],
+};
+
+@Injectable({ scope: SCOPE.REQUEST })
+export class DatasetQueryService {
+  private readonly userId: string;
+  private readonly logger = createLogger(this.constructor.name);
+
+  constructor(
+    private readonly tenantService: TenantService,
+    private readonly datasetRepo: DatasetRepository,
+    private readonly releaseRepo: DatasetReleaseRepository,
+    private readonly dashboardRepo: DatasetDashboardRepository,
+    private readonly datasetCodeRepo: DatasetCodeRepository,
+    private readonly datasetCodeQueryRepo: DatasetCodeQueryRepository,
+    private readonly datasetFilterService: DatasetFilterService,
+    private readonly userMgmtService: UserMgmtService,
+    private readonly requestContextService: RequestContextService,
+  ) {
+    this.userId = this.requestContextService.getAuthToken()?.sub;
+  }
+
+  async hasDataset(searchParams: IDatasetSearchDto) {
+    return await this.datasetRepo.findOne({
+      where: searchParams,
+    });
+  }
+
+  async getDataset({
+    id,
+    tokenDatasetCode,
+  }: {
+    id?: string;
+    tokenDatasetCode?: string;
+  }): Promise<IDataset> {
+    const baseColumns = this.getDatasetBaseColumns();
+    const lookupValue = id ?? tokenDatasetCode;
+
+    if (!lookupValue) {
+      throw new HttpException(
+        400,
+        "Dataset id or tokenDatasetCode is required",
+      );
+    }
+    // Lookup supports UUID id, sanitized cache_id (analytics-svc passes this on
+    // the CDM-version path), or tokenDatasetCode.
+    const isUuid =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        lookupValue,
+      );
+    const isCacheId =
+      /^_?[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}$/i.test(
+        lookupValue,
+      );
+    const whereClause = isUuid
+      ? "dataset.id = :lookupValue"
+      : isCacheId
+        ? "dataset.cacheId = :lookupValue"
+        : "dataset.tokenDatasetCode = :lookupValue";
+
+    const dataset = await this.datasetRepo
+      .createQueryBuilder("dataset")
+      .leftJoin("dataset.datasetDetail", "datasetDetail")
+      .leftJoin("dataset.dashboards", "dashboard")
+      .leftJoin("dataset.tags", "tag")
+      .leftJoin("dataset.attributes", "attribute")
+      .leftJoin("attribute.attributeConfig", "attributeConfig")
+      .where(whereClause, { lookupValue })
+      .select(baseColumns)
+      .getOne();
+
+    if (!dataset) {
+      throw new HttpException(
+        404,
+        `Dataset with identifier ${lookupValue} not found`,
+      );
+    } else if (!dataset.datasetDetail) {
+      throw new HttpException(
+        404,
+        `Dataset detail with dataset identifier ${lookupValue} not found`,
+      );
+    }
+
+    const tenant = this.tenantService.getTenant();
+    const accessState = this.userId
+      ? this.getAccessStateForDataset(dataset.id, dataset.datasetDetail.showRequestAccess)
+      : undefined;
+    const swapped = this.swapVariables(
+      {
+        ...this.buildDatasetResponseDto(dataset, tenant),
+        ...(accessState ? { accessState: await accessState } : {}),
+      },
+      SWAP_TO.STUDY,
+    );
+    return swapped as IDataset;
+  }
+
+  async getDatasets(queryParams?: IDatasetQueryDto) {
+    const { role, searchText, ...filterParams } = queryParams;
+    const isResearcher = role === "researcher";
+    const hasFilterParams = Object.keys(filterParams).length > 0;
+    if (!isResearcher && hasFilterParams) {
+      this.logger.error(
+        `Non-researcher dataset query with filter params provided: ${JSON.stringify(filterParams)}`,
+      );
+      throw new HttpException(400, "Invalid request");
+    }
+
+    const query = this.datasetRepo
+      .createQueryBuilder("dataset")
+      .leftJoin("dataset.datasetDetail", "datasetDetail")
+      .leftJoin("dataset.dashboards", "dashboard")
+      .leftJoin("dataset.tags", "tag")
+      .leftJoin("dataset.attributes", "attribute")
+      .leftJoin("attribute.attributeConfig", "attributeConfig")
+      .select(this.getDatasetsColumns(role));
+
+    if (searchText) {
+      const tsQuery = this.convertToTsqueryFormat(searchText);
+      if (tsQuery) {
+        query
+          .setParameter("searchText", tsQuery)
+          .andWhere(
+            new Brackets((qb) => {
+              qb.where(
+                '"datasetDetail"."search_tsv" @@ to_tsquery(\'english\', :searchText)',
+              ).orWhere(
+                '"attribute"."search_tsv" @@ to_tsquery(\'english\', :searchText)',
+              );
+            }),
+          )
+          .orderBy(
+            'ts_rank("datasetDetail"."search_tsv", to_tsquery(\'english\', :searchText))',
+            "DESC",
+          );
+      }
+    }
+
+    const accessContext = isResearcher
+      ? await this.getDataSourceAccessContext()
+      : undefined;
+
+    if (isResearcher) {
+      query.andWhere(
+        "(dataset.visibility_status = :hidden AND dataset.id = ANY(:datasetIds) OR dataset.visibility_status != :hidden)",
+        { hidden: "HIDDEN", datasetIds: [...accessContext.readDatasetIds] },
+      );
+    }
+
+    const datasets = await query.getMany();
+    const tenant = this.tenantService.getTenant();
+
+    let dbFilterResults;
+    if (isResearcher && hasFilterParams) {
+      dbFilterResults =
+        await this.datasetFilterService.getDatabaseSchemaFilterResults(
+          filterParams,
+          datasets,
+        );
+      this.logger.debug(
+        `Database schema filter results: ${JSON.stringify(dbFilterResults)}`,
+      );
+    }
+
+    const datasetDtos = await datasets.reduce<Promise<IDatasetResponseDto[]>>(
+      async (accP, dataset) => {
+        const acc = await accP;
+        const datasetDto = {
+          ...this.buildDatasetResponseDto(dataset, tenant),
+          ...(accessContext
+            ? {
+              accessState: this.getAccessState(
+                dataset.id,
+                dataset.datasetDetail.showRequestAccess,
+                accessContext.writeDatasetIds,
+                accessContext.readDatasetIds,
+                accessContext.pendingDatasetIds,
+              ),
+            }
+            : {}),
+        };
+
+        const { databaseCode, schemaName, dataModel, ...rest } = datasetDto;
+        const formattedDataModel = dataModel.replace(/\s*\[.*?\]/, "").trim();
+        if (!isResearcher) {
+          acc.push(datasetDto);
+        } else if (!hasFilterParams) {
+          acc.push({
+            dataModel: formattedDataModel,
+            databaseCode,
+            schemaName,
+            ...rest,
+          });
+        } else if (databaseCode && Object.keys(dbFilterResults).length > 0) {
+          const filterResults = dbFilterResults[databaseCode];
+          if (
+            filterResults &&
+            filterResults[schemaName] &&
+            filterResults[schemaName].isMatched
+          ) {
+            acc.push({
+              ...rest,
+              databaseCode,
+              schemaName,
+              totalSubjects: filterResults[schemaName].totalSubjects,
+              dataModel: formattedDataModel,
+            });
+          }
+        }
+        return acc;
+      },
+      Promise.resolve([]),
+    );
+
+    return datasetDtos.map((datasetDto) =>
+      this.swapVariables(datasetDto, SWAP_TO.STUDY),
+    );
+  }
+
+  private getDatasetBaseColumns() {
+    return [
+      "dataset.id",
+      "dataset.dialect",
+      "dataset.databaseCode",
+      "dataset.cacheId",
+      "dataset.schemaName",
+      "dataset.vocabSchemaName",
+      "dataset.resultsSchemaName",
+      "dataset.flowParameters",
+      "dataset.sourceDatasetId",
+      "dataset.dataModel",
+      "dataset.plugin",
+      "dataset.paConfigId",
+      "dataset.type",
+      "dataset.tokenDatasetCode",
+      "datasetDetail.name",
+      "datasetDetail.description",
+      "datasetDetail.summary",
+      "datasetDetail.showRequestAccess",
+      "attribute.attributeId",
+      "attribute.value",
+      "attributeConfig.name",
+      "attributeConfig.dataType",
+      "attributeConfig.isDisplayed",
+      "tag.id",
+      "tag.name",
+      "dashboard.id",
+      "dashboard.name",
+      "dashboard.url",
+      "dashboard.basePath",
+    ];
+  }
+
+  private getDatasetsColumns(role?: string) {
+    const baseColumns = [
+      ...this.getDatasetBaseColumns(),
+      "dataset.tokenDatasetCode",
+    ];
+    if (role === "systemAdmin") {
+      return baseColumns.concat([
+        "dataset.type",
+        "dataset.visibilityStatus",
+        "dataset.fhirDatasetId",
+      ]);
+    }
+    return baseColumns;
+  }
+
+  async getDatasetReleases(datasetId: string) {
+    const releases = await this.releaseRepo
+      .createQueryBuilder("dataset_release")
+      .where("dataset_release.datasetId = :datasetId", { datasetId })
+      .getMany();
+
+    return releases.map((release) => {
+      return {
+        id: release.id,
+        name: release.name,
+        releaseDate: new Date(release.releaseDate)
+          .toISOString()
+          .substring(0, 10),
+      };
+    });
+  }
+
+  async getDatasetReleaseById(id: number) {
+    const release = await this.releaseRepo
+      .createQueryBuilder("dataset_release")
+      .where("dataset_release.id = :id", { id })
+      .getOne();
+
+    return {
+      id: release.id,
+      name: release.name,
+      datasetId: release.datasetId,
+      releaseDate: release.releaseDate,
+    };
+  }
+
+  async getDashboards() {
+    return await this.dashboardRepo
+      .createQueryBuilder("dataset_dashboard")
+      .getMany();
+  }
+
+  async getDatasetDashboardByName(name: string) {
+    const formattedName = name.replace(/-/g, " ");
+    const dashboard = await this.dashboardRepo
+      .createQueryBuilder("dataset_dashboard")
+      .where("dataset_dashboard.name = :name", { name: formattedName })
+      .getOne();
+
+    return {
+      id: dashboard?.id,
+      name: dashboard?.name,
+      url: dashboard?.url,
+    };
+  }
+
+  async getDatasetCode(datasetId: string, type: string, name: string) {
+    const datasetCode = await this.datasetCodeRepo.getDatasetCode(
+      datasetId,
+      type,
+      name,
+    );
+
+    if (!datasetCode) {
+      throw new HttpException(
+        404,
+        `Dataset code of type ${type} for dataset id ${datasetId} not found`,
+      );
+    }
+
+    return {
+      datasetId: datasetCode.datasetId,
+      code: datasetCode.code,
+      type: datasetCode.type,
+      name: datasetCode.name,
+    };
+  }
+
+  async getDatasetCodeQuery(
+    datasetId: string,
+    type: string,
+    name: string,
+    queryName: string,
+  ) {
+    const datasetCodeQuery =
+      await this.datasetCodeQueryRepo.getDatasetCodeQuery(
+        datasetId,
+        type,
+        name,
+        queryName,
+      );
+
+    if (!datasetCodeQuery) {
+      throw new HttpException(
+        404,
+        `Dataset code query for dataset id ${datasetId}, type ${type}, name ${name}, queryName ${queryName} not found`,
+      );
+    }
+
+    return {
+      id: datasetCodeQuery.id,
+      datasetId: datasetCodeQuery.datasetId,
+      type: datasetCodeQuery.type,
+      name: datasetCodeQuery.name,
+      queryName: datasetCodeQuery.queryName,
+      sql: datasetCodeQuery.sql,
+    };
+  }
+
+  async getDatasetCodeWithQueries(datasetId: string, type: string) {
+    const datasetCodes = await this.datasetCodeRepo.getDatasetCodesByType(
+      datasetId,
+      type,
+    );
+
+    if (!datasetCodes.length) {
+      return [];
+    }
+
+    const codeQueries =
+      await this.datasetCodeQueryRepo.getDatasetCodeQueriesByType(
+        datasetId,
+        type,
+      );
+
+    return datasetCodes.map((code) => ({
+      datasetId: code.datasetId,
+      name: code.name,
+      code: code.code,
+      type: code.type,
+      language: code.language,
+      queries: codeQueries
+        .filter((q) => q.name === code.name)
+        .map((q) => ({
+          name: q.name,
+          queryName: q.queryName,
+          sql: q.sql,
+        })),
+    }));
+  }
+
+  private async getDataSourceAccessContext() {
+    const [roleMemberships, pendingDatasetIds] = await Promise.all([
+      this.userMgmtService.getDataSourceRoleMemberships(this.userId),
+      this.userMgmtService.getUnresolvedRequestStudyIds(),
+    ]);
+
+    return {
+      readDatasetIds: new Set(roleMemberships.readStudyIds),
+      writeDatasetIds: roleMemberships.hasWriteAccess
+        ? new Set(roleMemberships.readStudyIds)
+        : new Set<string>(),
+      pendingDatasetIds: new Set(pendingDatasetIds),
+    };
+  }
+
+  private async getAccessStateForDataset(
+    datasetId: string,
+    showRequestAccess: boolean,
+  ): Promise<DataSourceAccessState> {
+    const accessContext = await this.getDataSourceAccessContext();
+    return this.getAccessState(
+      datasetId,
+      showRequestAccess,
+      accessContext.writeDatasetIds,
+      accessContext.readDatasetIds,
+      accessContext.pendingDatasetIds,
+    );
+  }
+
+  private getAccessState(
+    datasetId: string,
+    showRequestAccess: boolean,
+    writeDatasetIds: Set<string>,
+    readDatasetIds: Set<string>,
+    pendingDatasetIds: Set<string>,
+  ): DataSourceAccessState {
+    if (writeDatasetIds.has(datasetId)) {
+      return "write";
+    }
+    if (readDatasetIds.has(datasetId)) {
+      return "read";
+    }
+    if (pendingDatasetIds.has(datasetId)) {
+      return "pending";
+    }
+    return showRequestAccess ? "no_access" : "restricted";
+  }
+
+  buildDatasetResponseDto(
+    dataset: Dataset,
+    tenant: ITenant,
+  ): IDatasetResponseDto {
+    const { databaseCode, flowParameters, ...entity } = dataset;
+    return {
+      // TODO: Remove on 16 February 2024
+      databaseName: databaseCode,
+      databaseCode,
+      ...entity,
+      flowParameters,
+      tenant,
+    };
+  }
+
+  private swapVariables<T>(object, swapPair: string[]) {
+    const from = swapPair[0];
+    const to = swapPair[1];
+    const fromCapitalised = from.charAt(0).toUpperCase() + from.slice(1);
+    for (const key in object) {
+      if (key.includes(from)) {
+        const newKey = key.replace(from, to);
+        object[newKey] = object[key];
+        delete object[key];
+      } else if (key.includes(fromCapitalised)) {
+        const toCapitalised = to.charAt(0).toUpperCase() + to.slice(1);
+        const newKey = key.replace(fromCapitalised, toCapitalised);
+        object[newKey] = object[key];
+        delete object[key];
+      }
+    }
+    return <T>object;
+  }
+
+  private convertToTsqueryFormat(input: string) {
+    const normalizedInput = input.replace(/\s+/g, " ");
+    const terms = normalizedInput.split(" ").filter((term) => term.length > 0);
+    return terms.map((t) => `${t}:*`).join(" | ");
+  }
+}

--- a/plugins/functions/portal/src/types.d.ts
+++ b/plugins/functions/portal/src/types.d.ts
@@ -1,0 +1,357 @@
+import {
+  ATTRIBUTE_CONFIG_CATEGORIES,
+  ATTRIBUTE_CONFIG_DATA_TYPES,
+  CDM_SCHEMA_OPTIONS,
+  DATABASE_DIALECTS,
+  DATASET_QUERY_ROLES,
+  PA_CONFIG_TYPE,
+  VISIBILITY_STATUS,
+} from "./common/const.ts";
+
+export interface ITenant {
+  id: string;
+  name: string;
+  system: string;
+  features?: string[];
+}
+
+export type DatabaseDialect = (typeof DATABASE_DIALECTS)[number];
+
+export type DatasetFlowParameters = Record<string, unknown>;
+
+export interface IDataset {
+  id: string;
+  type?: string;
+  paConfigId: string;
+  tokenStudyCode: string;
+  dialect: DatabaseDialect;
+  databaseCode: string;
+  cacheId: string | null;
+  schemaName?: string;
+  vocabSchemaName?: string;
+  sourceDatasetId?: string;
+  dataModel?: string;
+  studyDetail: {
+    id: string;
+    name: string;
+    description: string;
+  };
+  tenant?: ITenant;
+  fhirDatasetId?: string;
+  flowParameters?: DatasetFlowParameters | null;
+}
+
+// TODO: Remove when we switch from study to dataset entirely
+interface IStudyDto {
+  id: string;
+  type?: string;
+  tokenStudyCode: string;
+  tenantId: string;
+  databaseName?: string;
+  schemaName?: string;
+  vocabSchemaName?: string;
+  dataModel?: string;
+  paConfigId: string;
+}
+
+export interface IDatasetDto {
+  id: string;
+  type?: string;
+  tokenDatasetCode: string;
+  tenantId: string;
+  databaseCode: string;
+  cacheId: string | null;
+  schemaName: string;
+  dialect: DatabaseDialect;
+  vocabSchemaName: string;
+  resultsSchemaName: string;
+  dataModel: string;
+  paConfigId: string;
+  detail: IDatasetDetailBaseDto;
+  dashboards: IDatasetDashboardBaseDto[];
+  attributes: IDatasetAttribute[];
+  tags: string[];
+  fhirDatasetId?: string;
+}
+
+export interface IDatasetSnapshotDto {
+  id: string;
+  sourceDatasetId: string;
+  newDatasetName: string;
+  schemaName: string;
+  vocabSchemaName?: string;
+  resultsSchemaName?: string;
+  timestamp: Date;
+  type: string;
+  flowParameters?: DatasetFlowParameters | null;
+}
+
+interface IDatasetDetailBaseDto {
+  name: string;
+  summary: string;
+  description: string;
+  showRequestAccess: boolean;
+}
+
+// TODO: Remove when we switch from study to dataset entirely
+export interface IStudyDetailDto extends IDatasetDetailBaseDto {
+  studyId: string;
+}
+
+interface IDatasetDashboardBaseDto {
+  name: string;
+  url: string;
+  basePath: string;
+}
+
+interface IDatasetTag {
+  id: number;
+  name: string;
+}
+
+interface IDatasetAttribute {
+  attributeId: string;
+  value: string;
+}
+
+export interface IDatasetAttributeDto extends IDatasetAttribute {
+  studyId: string;
+}
+
+export type VisibilityStatus = (typeof VISIBILITY_STATUS)[number];
+
+export type CdmSchemaOption = (typeof CDM_SCHEMA_OPTIONS)[number];
+// export type CdmSchemaOption = string
+// export interface CdmSchemaOption extends String {}
+
+export interface IDatasetDetailMetadataUpdateDto {
+  id: string;
+  detail: IDatasetDetailBaseDto;
+  dashboards: IDatasetDashboardBaseDto[];
+  attributes: IDatasetAttribute[];
+  tags: string[];
+  type?: string;
+  tokenDatasetCode: string;
+  visibilityStatus: string;
+  paConfigId: string;
+  fhirDatasetId?: string;
+  vocabSchemaName?: string;
+  resultsSchemaName?: string;
+}
+
+export interface IDatasetMetadataUpdateDto {
+  id: string;
+  studyAttributes: IDatasetAttribute[];
+  studyTags: string[];
+  type?: string;
+  tokenStudyCode: string;
+  visibilityStatus: string;
+  paConfigId: string;
+}
+
+export interface IDatasetTagDto {
+  id: string;
+  studyId: string;
+  name: string;
+}
+
+export type DataSourceAccessState =
+  | "no_access"
+  | "pending"
+  | "restricted"
+  | "read"
+  | "write";
+
+export interface IDatasetResponseDto {
+  id: string;
+  tenant: {
+    id: string;
+    name: string;
+  };
+  tokenDatasetCode: string;
+  type?: string;
+  datasetDetail: {
+    id: string;
+    name: string;
+    description?: string;
+    summary?: string;
+    showRequestAccess: boolean;
+  };
+  // @deprecated: all dependency should switch to use of `databaseCode`before removal on 16 February 2024
+  databaseName?: string;
+  databaseCode?: string;
+  cacheId: string | null;
+  schemaName?: string;
+  dashboards: IDatasetDashboardBaseDto[];
+  attributes: IDatasetAttribute[];
+  tags: IDatasetTag[];
+  totalSubjects?: number;
+  dataModel: string;
+  plugin: string;
+  fhirDatasetId?: string;
+  flowParameters?: DatasetFlowParameters | null;
+  accessState?: DataSourceAccessState;
+}
+
+export interface IDatasetSearchDto {
+  tokenDatasetCode: string;
+}
+
+export type IPublicDatasetQueryDto = IDatasetSearchFilterDto;
+
+export type DatasetQueryRole = (typeof DATASET_QUERY_ROLES)[number];
+
+export interface IDatasetQueryDto
+  extends IDatasetSearchFilterDto, IDatasetFilterParamsDto {
+  role?: DatasetQueryRole;
+}
+export interface IDatasetSearchFilterDto {
+  searchText?: string;
+}
+export interface IDatasetFilterParamsDto {
+  age?: {
+    gte: number;
+    lte: number;
+  };
+  observationYear?: {
+    gte: number;
+    lte: number;
+  };
+}
+
+export interface IDatasetFilterScopesResult {
+  domains: { [key: string]: string };
+  age: MinMaxRange;
+  observationYear: MinMaxRange;
+  cumulativeObservationMonths: MinMaxRange;
+}
+
+export interface IDatabaseSchemaFilterResult {
+  [key: string]: string;
+}
+
+interface INotebookBaseDto {
+  name: string;
+  notebookContent: string;
+}
+
+export interface INotebookUpdateDto extends INotebookBaseDto {
+  id: string;
+  isShared: boolean;
+}
+
+export interface INotebook extends INotebookBaseDto {
+  id: string;
+  userId: string;
+}
+
+interface MinMaxRange {
+  min: number;
+  max: number;
+}
+
+export interface ISwiftObject {
+  name: string;
+  hash: string;
+  bytes: number;
+  content_type: string;
+  last_modified: Date;
+}
+
+export interface ISystemNameDto {
+  systemName: string;
+}
+
+interface IDatasetReleaseDto {
+  name: string;
+  datasetId: string;
+  releaseDate: Date;
+}
+
+interface IPortalPlugin {
+  name: string;
+  nameI18nKey?: string;
+  featureFlag?: string;
+  visible?: boolean;
+  /** @deprecated Use `visible` instead */
+  enabled?: string;
+  defaultEnabled?: boolean;
+  children?: IPortalPlugin[];
+}
+
+export interface PaConfig {
+  meta: {
+    configId: string;
+    configName: string;
+  };
+}
+
+export type PaConfigType = `${PA_CONFIG_TYPE}`;
+export interface IMetadataConfigTag {
+  name: string;
+}
+
+export interface IMetadataConfigAttribute {
+  id: string;
+  name: string;
+  category: ATTRIBUTE_CONFIG_CATEGORIES;
+  dataType: ATTRIBUTE_CONFIG_DATA_TYPES;
+  isDisplayed: boolean;
+}
+export interface IFeatureDto {
+  feature: string;
+  name?: string;
+  nameI18nKey?: string;
+  isEnabled: boolean;
+}
+
+export interface IFeatureUpdateDto {
+  features: IFeatureDto[];
+}
+
+export interface UserGroup {
+  userId: string;
+  alp_role_study_researcher: string[];
+}
+
+export interface IConfig {
+  type: string;
+  value: string;
+}
+export interface IConfigUpdateDto {
+  type: string;
+  value: string;
+}
+
+interface StudyMetadata {
+  strategus_json: string;
+  description?: string;
+  email?: string;
+}
+
+export interface StudiesData {
+  [studyId: string]: StudyMetadata;
+}
+
+export interface GitSubmodule {
+  name: string;
+  path: string;
+  url: string;
+  branch?: string;
+}
+
+export interface PartialGitSubmodule {
+  name?: string;
+  path?: string;
+  url?: string;
+  branch?: string;
+}
+
+export interface IGitStudiesQueryDto {
+  studyId: string;
+}
+
+export type DashboardTemplateData = {
+  filename: string;
+  content: string;
+};

--- a/plugins/functions/portal/src/user-mgmt/user-mgmt.api.ts
+++ b/plugins/functions/portal/src/user-mgmt/user-mgmt.api.ts
@@ -1,0 +1,89 @@
+import { Injectable, SCOPE } from "@danet/core";
+import { services } from "../env.ts";
+import { UserGroup } from "../types.d.ts";
+
+interface UserGroupResponse extends UserGroup {
+  alp_role_study_write_dqd_researcher?: boolean;
+}
+
+interface UnresolvedStudyAccessRequest {
+  studyId: string;
+}
+
+const post = async <T = any>(
+  url: string,
+  data?: any,
+  config?: any
+): Promise<T> => {
+  const response = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(data),
+    ...config,
+  });
+  return response.json();
+};
+
+@Injectable({ scope: SCOPE.REQUEST })
+export class UserMgmtApi {
+  private readonly url: string;
+  private readonly channel;
+
+  constructor() {
+    if (services.usermgmt) {
+      this.url = services.usermgmt;
+      this.channel = Trex.tokioChannel("d2e-functions/alp-usermgmt");
+    } else {
+      throw new Error("No url is set for UserMgmtApi");
+    }
+  }
+
+  async getUserGroups(userId: string, jwt: string) {
+    const requestConfig = this.getRequestConfig(jwt);
+    const body = JSON.stringify({ userId });
+    const url = `${this.url}/user-group/list`;
+    const result = await this.channel.post(url, body, requestConfig);
+    return result.data;
+  }
+
+  async getDataSourceRoleMemberships(
+    userId: string,
+    jwt: string,
+  ): Promise<{ readStudyIds: string[]; hasWriteAccess: boolean }> {
+    const userGroups = await this.getUserGroups(userId, jwt) as UserGroupResponse;
+    return {
+      readStudyIds: userGroups.alp_role_study_researcher || [],
+      hasWriteAccess: Boolean(userGroups.alp_role_study_write_dqd_researcher),
+    };
+  }
+
+  async getUnresolvedRequestStudyIds(jwt: string): Promise<string[]> {
+    const requestConfig = this.getRequestConfig(jwt);
+    const url = `${this.url}/study/access-request/me`;
+    const result = await this.channel.get(url, requestConfig);
+    return (result.data as UnresolvedStudyAccessRequest[]).map(({ studyId }) => studyId);
+  }
+
+  async ensureDatasetRole(datasetId: string, tokenStudyCode: string, type: string | undefined, jwt: string) {
+    const requestConfig = this.getRequestConfig(jwt);
+    const body = JSON.stringify({ datasetId, tokenStudyCode, type });
+    const url = `${this.url}/dataset-role`;
+    const result = await this.channel.post(url, body, requestConfig);
+    return result.data;
+  }
+
+  async removeDatasetRole(datasetId: string, tokenStudyCode: string, jwt: string) {
+    const requestConfig = this.getRequestConfig(jwt);
+    const url = `${this.url}/dataset-role?datasetId=${encodeURIComponent(datasetId)}&tokenStudyCode=${encodeURIComponent(tokenStudyCode)}`;
+    const result = await this.channel.delete(url, requestConfig);
+    return result.data;
+  }
+
+  private getRequestConfig(jwt: string): RequestInit {
+    return {
+      headers: {
+        Authorization: jwt,
+        "Content-Type": "application/json",
+      },
+    };
+  }
+}

--- a/plugins/functions/portal/src/user-mgmt/user-mgmt.mock.ts
+++ b/plugins/functions/portal/src/user-mgmt/user-mgmt.mock.ts
@@ -1,0 +1,16 @@
+import { UserMgmtApi } from './user-mgmt.api'
+
+import { MockType } from 'test/type.mock'
+import { UserMgmtService } from './user-mgmt.service'
+
+export const userMgmtApiMockFactory: () => MockType<UserMgmtApi> = jest.fn(() => ({
+  getUserGroups: jest.fn(),
+  getDataSourceRoleMemberships: jest.fn(),
+  getUnresolvedRequestStudyIds: jest.fn()
+}))
+
+export const userMgmtServiceMockFactory: () => MockType<UserMgmtService> = jest.fn(() => ({
+  getResearcherDatasetIds: jest.fn(),
+  getDataSourceRoleMemberships: jest.fn(),
+  getUnresolvedRequestStudyIds: jest.fn()
+}))

--- a/plugins/functions/portal/src/user-mgmt/user-mgmt.service.ts
+++ b/plugins/functions/portal/src/user-mgmt/user-mgmt.service.ts
@@ -1,0 +1,35 @@
+import { Injectable, SCOPE } from "@danet/core";
+import { UserMgmtApi } from "./user-mgmt.api.ts";
+import { RequestContextService } from "../common/request-context.service.ts";
+
+@Injectable({ scope: SCOPE.REQUEST })
+export class UserMgmtService {
+  private readonly jwt: string;
+  constructor(
+    private readonly userMgmtApi: UserMgmtApi,
+    private readonly requestContextService: RequestContextService
+  ) {
+    this.jwt = this.requestContextService.getOriginalToken() || "";
+  }
+
+  async getResearcherDatasetIds(userId: string) {
+    const userGroups = await this.userMgmtApi.getUserGroups(userId, this.jwt);
+    return userGroups.alp_role_study_researcher;
+  }
+
+  async getDataSourceRoleMemberships(userId: string) {
+    return this.userMgmtApi.getDataSourceRoleMemberships(userId, this.jwt);
+  }
+
+  async getUnresolvedRequestStudyIds() {
+    return this.userMgmtApi.getUnresolvedRequestStudyIds(this.jwt);
+  }
+
+  async ensureDatasetRole(datasetId: string, tokenStudyCode: string, type?: string) {
+    return this.userMgmtApi.ensureDatasetRole(datasetId, tokenStudyCode, type, this.jwt);
+  }
+
+  async removeDatasetRole(datasetId: string, tokenStudyCode: string) {
+    return this.userMgmtApi.removeDatasetRole(datasetId, tokenStudyCode, this.jwt);
+  }
+}


### PR DESCRIPTION
Implements access-state badges (read, pending, restricted, no_access) on Atlas data source list and detail pages per Figma designs in issues #2963 and #2959. UI changes scoped to plugins/atlas only. Write state omitted per design.