### PR TITLE
[Adhoc] Fix bigquery data characterization flow run(rc)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -933,6 +933,7 @@ services:
       TASK_API_ENFORCE_HTTPS: ${TASK_API_ENFORCE_HTTPS:-true}
       LOW_NUMBER_SUPPRESSION_THRESHOLD: ${LOW_NUMBER_SUPPRESSION_THRESHOLD:-10}
       ROUNDING_TARGET: ${ROUNDING_TARGET:-10}
+      D2E_BIGQUERY_JDBC_URL: ${D2E_BIGQUERY_JDBC_URL:-}
 
   # Needed only for future alterations of schema when version upgrades
   # alp-logto-db-post-alterations-init:

--- a/plugins/flows/_shared_flow_utils/dao/daobase.py
+++ b/plugins/flows/_shared_flow_utils/dao/daobase.py
@@ -33,7 +33,8 @@ def build_bigquery_r_connection_string(
         "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;"
         f"ProjectId={project};OAuthType=0;"
         f"OAuthServiceAcctEmail={client_email};"
-        f"OAuthPvtKeyPath={key_path}"
+        f"OAuthPvtKeyPath={key_path};"
+        "EnableSession=1"
     )
     return (
         "connectionDetails <- DatabaseConnector::createConnectionDetails("

--- a/plugins/flows/_shared_flow_utils/tests/test_r_connection_string.py
+++ b/plugins/flows/_shared_flow_utils/tests/test_r_connection_string.py
@@ -13,6 +13,7 @@ def test_bigquery_r_connection_string_shape():
         "connectionString = 'jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;"
         "ProjectId=my-gcp-project;OAuthType=0;"
         "OAuthServiceAcctEmail=svc@my-gcp-project.iam.gserviceaccount.com;"
-        "OAuthPvtKeyPath=/tmp/google-sa.json'" in result
+        "OAuthPvtKeyPath=/tmp/google-sa.json;"
+        "EnableSession=1'" in result
     )
     assert "user = ''" in result and "password = ''" in result


### PR DESCRIPTION
1. Adds D2E_BIGQUERY_JDBC_URL env which is required in entrypoint.sh for `dataflow-gen-worker`.
2. Add `EnableSession=1` to bigquery jdbc connection so that transaction control statements are valid.


### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)