### PR TITLE
ci: promote trex -devx tag to canonical develop-devx

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1635,6 +1635,23 @@ jobs:
             echo "Neither $SRC nor $DST present; nothing to publish."
           fi
 
+      # build_trex_image pushes a second variant as <RUN_TAG>-devx off the same
+      # Dockerfile. The matrix above iterates image *names*, so it cannot reach a
+      # tag suffix — the canonical -devx alias was therefore never published for
+      # any branch. docker-compose-local.yml asks for <DOCKER_TAG_NAME>-devx,
+      # which for the compose default (develop) surfaces far from here as
+      # "manifest unknown" on a pull.
+      #
+      # Develop only, and forward only: never publishes a commit-specific tag.
+      # No build_disable fallback arm — that is a build_images matrix input only,
+      # so <RUN_TAG>-devx is always present when this step runs.
+      - name: Re-tag develop devx image as canonical
+        if: matrix.image == 'd2e-trex' && needs.setup.outputs.is_develop_push == 'true'
+        run: |
+          SRC=${REG_URL}/d2e-trex:${RUN_TAG}-devx          # develop-<sha>-devx (read only)
+          DST=${REG_URL}/d2e-trex:develop-devx             # the alias being moved
+          docker buildx imagetools create -t "$DST" "$SRC"
+
       # Multi-arch-aware cleanup: the per-arch child manifests of a manifest
       # list are stored as untagged package versions in GHCR, so a blind
       # delete-only-untagged sweep (actions/delete-package-versions) removes


### PR DESCRIPTION
The promote matrix iterates image names, so the -devx tag suffix was never aliased and d2e-trex:develop-devx never existed.

### Merge Checklist

Please cross check this list if additions / modifications needs to be done on top of your core changes and tick them off. Reviewer can as well glance through and help the developer if something is missed out.

- [ ] Automated Tests (Jasmine integration tests, Unit tests, and/or Performance tests)
- [ ] Updated Manual tests / Demo Config
- [ ] Documentation (Application guide, Admin guide, Markdown, Readme and/or Wiki)
- [ ] Verified that local development environment is working with latest changes (integrated with latest `develop` branch)
- [ ] following best practices in [code review doc](../code_review.md)