### PR TITLE
feat(vue-mri): open the analysis wizard from an exploration card (#3121)

### DIFF
--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
@@ -95,67 +95,11 @@
     </div>
   </div>
 
-  <Teleport to="#app">
-    <DashboardSelectionModal
-      :is-open="dashboardFlow.showDashboardSelectionModal"
-      :dashboards="dashboardFlow.dashboardCodes"
-      :wizard-definitions="dashboardFlow.wizardDefinitions"
-      :loading="dashboardFlow.dashboardMetadataLoading"
-      :error="dashboardFlow.dashboardSelectionError"
-      @close="dashboardFlow.closeDashboardSelectionModal"
-      @select="dashboardFlow.handleDashboardSelected"
-    />
-  </Teleport>
-
-  <Teleport to="#app">
-    <CompleteRequiredFiltersModal
-      :is-open="dashboardFlow.showRequiredFiltersModal"
-      :all-fields="dashboardFlow.allWizardFields"
-      :sections="dashboardFlow.selectedWizardDefinition?.sections"
-      :form-note="dashboardFlow.selectedWizardDefinition?.formNote"
-      :initial-values="dashboardFlow.initialFormValues"
-      :initial-display-values="dashboardFlow.initialDisplayValues"
-      :loading="dashboardFlow.applyingRequiredFilters"
-      :error="dashboardFlow.requiredFiltersError"
-      @cancel="dashboardFlow.handleRequiredFiltersCancel"
-      @submit="dashboardFlow.handleRequiredFiltersSubmit"
-    />
-  </Teleport>
-
-  <Teleport to="#app">
-    <ConfigureTable1Dialog
-      :is-open="dashboardFlow.showTable1ConfigModal"
-      :dataset-id="getSelectedDataset?.id || ''"
-      :initial-concept-sets="dashboardFlow.confirmedTable1ConceptSets"
-      @cancel="dashboardFlow.handleTable1ConfigCancel"
-      @close="dashboardFlow.closeDashboardFlow"
-      @confirm="dashboardFlow.handleTable1ConfigConfirm"
-    />
-  </Teleport>
-
-  <Teleport to="#app">
-    <ShinyDashboardModal
-      v-if="dashboardFlow.showDashboardModal"
-      :is-open="dashboardFlow.showDashboardModal"
-      :dataset-id="getSelectedDataset.id"
-      :cohort-id="(dashboardFlow.savedCohortId ?? getActiveCohortMaterializedId)?.toString() || ''"
-      :wizard-config="dashboardFlow.dashboardContext.wizardConfig"
-      :conditions="dashboardFlow.dashboardContext.conditions"
-      :mriquery="dashboardFlow.dashboardContext.mriquery"
-      @close="dashboardFlow.closeDashboardModal"
-    />
-  </Teleport>
-
-  <Teleport to="#app">
-    <SaveCohortModal
-      :is-open="dashboardFlow.showSaveCohortModal"
-      :mode="dashboardFlow.saveCohortModalMode"
-      :wizard-config="dashboardFlow.dashboardContext.wizardConfig"
-      @success="dashboardFlow.handleSaveCohortSuccess"
-      @cancel="dashboardFlow.handleCancelSaveCohort"
-      @close="dashboardFlow.closeDashboardFlow"
-    />
-  </Teleport>
+  <DashboardFlowModals
+    :flow="dashboardFlow"
+    :dataset-id="getSelectedDataset?.id || ''"
+    :cohort-id="(dashboardFlow.savedCohortId ?? getActiveCohortMaterializedId)?.toString() || ''"
+  />
 
   <Teleport to="#app">
     <VDialog
@@ -209,11 +153,7 @@ import { formatNumber } from '../utils/NumberUtils'
 import icon from '../lib/ui/app-icon.vue'
 import appIcon from '../lib/ui/app-icon.vue'
 import DownloadMenu from './DownloadMenu.vue'
-import ShinyDashboardModal from './ShinyViewer/ShinyDashboardModal.vue'
-import SaveCohortModal from './ShinyViewer/SaveCohortModal.vue'
-import DashboardSelectionModal from './ShinyViewer/DashboardSelectionModal.vue'
-import CompleteRequiredFiltersModal from './ShinyViewer/CompleteRequiredFiltersModal.vue'
-import ConfigureTable1Dialog from './ShinyViewer/ConfigureTable1Dialog.vue'
+import DashboardFlowModals from './DashboardFlowModals.vue'
 import Button from './Button.vue'
 import { useDashboardFlow } from '../composables/useDashboardFlow'
 import { usePortalContext } from '../composables/usePortalContext'
@@ -575,11 +515,7 @@ export default {
     DisabledHoverPopover,
     appIcon,
     DownloadMenu,
-    ShinyDashboardModal,
-    SaveCohortModal,
-    DashboardSelectionModal,
-    CompleteRequiredFiltersModal,
-    ConfigureTable1Dialog,
+    DashboardFlowModals,
     Button,
     VButton,
     VDialog,

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/DashboardFlowModals.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/DashboardFlowModals.vue
@@ -1,0 +1,92 @@
+<template>
+  <Teleport to="#app">
+    <DashboardSelectionModal
+      :is-open="flow.showDashboardSelectionModal"
+      :dashboards="flow.dashboardCodes"
+      :wizard-definitions="flow.wizardDefinitions"
+      :loading="flow.dashboardMetadataLoading"
+      :error="flow.dashboardSelectionError"
+      @close="flow.closeDashboardSelectionModal"
+      @select="flow.handleDashboardSelected"
+    />
+  </Teleport>
+
+  <Teleport to="#app">
+    <CompleteRequiredFiltersModal
+      :is-open="flow.showRequiredFiltersModal"
+      :all-fields="flow.allWizardFields"
+      :sections="flow.selectedWizardDefinition?.sections"
+      :form-note="flow.selectedWizardDefinition?.formNote"
+      :initial-values="flow.initialFormValues"
+      :initial-display-values="flow.initialDisplayValues"
+      :loading="flow.applyingRequiredFilters"
+      :error="flow.requiredFiltersError"
+      @cancel="flow.handleRequiredFiltersCancel"
+      @submit="flow.handleRequiredFiltersSubmit"
+    />
+  </Teleport>
+
+  <Teleport to="#app">
+    <ConfigureTable1Dialog
+      :is-open="flow.showTable1ConfigModal"
+      :dataset-id="datasetId"
+      :initial-concept-sets="flow.confirmedTable1ConceptSets"
+      @cancel="flow.handleTable1ConfigCancel"
+      @close="flow.closeDashboardFlow"
+      @confirm="flow.handleTable1ConfigConfirm"
+    />
+  </Teleport>
+
+  <Teleport to="#app">
+    <ShinyDashboardModal
+      v-if="flow.showDashboardModal"
+      :is-open="flow.showDashboardModal"
+      :dataset-id="datasetId"
+      :cohort-id="cohortId"
+      :wizard-config="flow.dashboardContext.wizardConfig"
+      :conditions="flow.dashboardContext.conditions"
+      :mriquery="flow.dashboardContext.mriquery"
+      @close="flow.closeDashboardModal"
+    />
+  </Teleport>
+
+  <Teleport to="#app">
+    <SaveCohortModal
+      :is-open="flow.showSaveCohortModal"
+      :mode="flow.saveCohortModalMode"
+      :wizard-config="flow.dashboardContext.wizardConfig"
+      @success="flow.handleSaveCohortSuccess"
+      @cancel="flow.handleCancelSaveCohort"
+      @close="flow.closeDashboardFlow"
+    />
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+// The five modals the dashboard-wizard flow needs, moved verbatim out of
+// ChartToolbar.vue so ExplorationsPage.vue can mount the same flow without
+// duplicating the bindings.
+//
+// `flow` arrives as a prop, and Vue's component props are shallow-reactive:
+// a plain object nested inside a prop does not get the deep-reactive,
+// ref-auto-unwrapping treatment that `data()` gives it in ChartToolbar (an
+// Options API component). Wrapping it in `reactive()` here restores that
+// unwrapping for the template bindings above, without changing the prop's
+// own declared type.
+import { reactive } from 'vue'
+import type { useDashboardFlow } from '../composables/useDashboardFlow'
+import ShinyDashboardModal from './ShinyViewer/ShinyDashboardModal.vue'
+import SaveCohortModal from './ShinyViewer/SaveCohortModal.vue'
+import DashboardSelectionModal from './ShinyViewer/DashboardSelectionModal.vue'
+import CompleteRequiredFiltersModal from './ShinyViewer/CompleteRequiredFiltersModal.vue'
+import ConfigureTable1Dialog from './ShinyViewer/ConfigureTable1Dialog.vue'
+
+interface Props {
+  flow: ReturnType<typeof useDashboardFlow>
+  datasetId: string
+  cohortId: string
+}
+
+const props = defineProps<Props>()
+const flow = reactive(props.flow)
+</script>

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ExplorationsPage.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ExplorationsPage.vue
@@ -172,9 +172,28 @@
             </template>
           </v-tooltip>
 
-          <!-- Placeholders, on purpose: data quality is #3119 (not ours) and
-               analyze is #3121. They render so the bar matches the frame,
-               and do nothing yet. -->
+          <v-tooltip
+            location="top"
+            content-class="explorations-tooltip"
+            :text="canAnalyze ? getText('MRI_PA_EXPLORATIONS_ANALYZE') : getText('MRI_PA_OPEN_DASHBOARD_TOOLTIP_DISABLED')"
+          >
+            <template #activator="{ props: tooltipProps }">
+              <span v-bind="tooltipProps">
+                <D2eIconButton
+                  category="no-stroke"
+                  :disabled="!canAnalyze"
+                  :aria-label="getText('MRI_PA_EXPLORATIONS_ANALYZE')"
+                  :data-testid="`explorations-analyze-btn-${card.id}`"
+                  @click="openAnalyze(card)"
+                >
+                  <ExplorationAnalyzeIcon />
+                </D2eIconButton>
+              </span>
+            </template>
+          </v-tooltip>
+
+          <!-- Placeholder, on purpose: data quality is #3119, not ours. It
+               renders so the bar matches the frame, and does nothing yet. -->
           <v-tooltip
             v-for="placeholder in ACTION_PLACEHOLDERS"
             :key="placeholder.testid"
@@ -228,6 +247,23 @@
 
     </div>
 
+    <!--
+      Mounted only while the flow is live. These modals `<Teleport to="#app">`,
+      and #app is an ancestor of this page, so leaving them mounted meant that
+      unmounting the page — which is what clicking a card does — tore down a
+      teleport whose target was itself being removed. Vue threw
+      "Cannot destructure property 'bum' of 'ne' as it is null" during unmount,
+      the update aborted, and the card click silently stopped navigating to the
+      cohort builder. `analyzeInProgress` keeps the page mounted for the
+      duration of the flow, so the two never overlap.
+    -->
+    <DashboardFlowModals
+      v-if="explorations.analyzeInProgress || dashboardFlowModalOpen"
+      :flow="dashboardFlow"
+      :dataset-id="store.getters.getSelectedDataset?.id ?? portalContext.datasetId"
+      :cohort-id="(dashboardFlow.savedCohortId ?? store.getters.getActiveCohortMaterializedId)?.toString() || ''"
+    />
+
     <AddCohort
       v-if="materializeTarget"
       v-model="materializeOpen"
@@ -261,12 +297,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { useStore } from 'vuex'
 import { D2eButton, D2eExplorationCard, D2eIconButton, D2eMenu, D2eSelect, D2eTextField } from '@d2e/ui'
 import { useExplorationsStore } from '../stores/explorations'
 import { useNotificationStore } from '../stores/notifications'
 import { usePortalContext } from '../composables/usePortalContext'
+import { useDashboardFlow } from '../composables/useDashboardFlow'
 import { filterAndSort, type ExplorationSortKey } from './helpers/explorationList'
 import { applyFilters, authorOptions, emptyFilters, type ExplorationFilters } from './helpers/explorationFilters'
 import { chartQueryFor } from './helpers/explorationSqlQuery'
@@ -283,6 +320,7 @@ import RenameExplorationDialog from './RenameExplorationDialog.vue'
 import DeleteExplorationDialog from './DeleteExplorationDialog.vue'
 import ExplorationFiltersPanel from './ExplorationFiltersPanel.vue'
 import FilterCardSummary from './FilterCardSummary.vue'
+import DashboardFlowModals from './DashboardFlowModals.vue'
 
 const emit = defineEmits<{
   (e: 'open-exploration', bmkId: string, chartType: string | null): void
@@ -293,6 +331,11 @@ const store = useStore()
 const portalContext = usePortalContext()
 const explorations = useExplorationsStore()
 const notifications = useNotificationStore()
+// Wrapped in `reactive()` so its nested refs unwrap the same way ChartToolbar's
+// copy does through its (deeply reactive) `data()` — without this, reading
+// e.g. `dashboardFlow.showDashboardModal` here or in the template would return
+// the Ref instance itself rather than its value.
+const dashboardFlow = reactive(useDashboardFlow(store.dispatch, store.getters))
 
 // The card's own checkbox and quick-action buttons sit inside the card root, so
 // their clicks bubble up to it. Opening the exploration from those would fight
@@ -306,15 +349,14 @@ const IGNORED_CLICK_TARGETS = [
   '.d2e-exploration-card__lead-row .v-btn',
 ].join(', ')
 
-// #3119 data quality and #3121 analyze are not wired yet. They render so the
-// action bar matches the frame. #3120 filter summary is wired below.
+// #3119 data quality is not wired yet. It renders so the action bar matches
+// the frame. #3120 filter summary and #3121 analyze are wired below.
 const ACTION_PLACEHOLDERS = [
   {
     icon: ExplorationDataQualityIcon,
     labelKey: 'MRI_PA_EXPLORATIONS_DATA_QUALITY',
     testid: 'explorations-dq-btn',
   },
-  { icon: ExplorationAnalyzeIcon, labelKey: 'MRI_PA_EXPLORATIONS_ANALYZE', testid: 'explorations-analyze-btn' },
 ]
 const EMPTY_VALUE = '-'
 
@@ -341,6 +383,12 @@ const loadError = computed(() => store.getters.getBookmarksLoadError)
 const datasetName = computed(() => store.getters.getSelectedDataset?.id || portalContext.datasetId)
 const datasetItems = computed(() => [{ label: datasetName.value, value: datasetName.value }])
 const canMaterialize = computed<boolean>(() => Boolean(store.getters.getCanDatasetMaterializeCohorts))
+
+// Matches ChartToolbar.vue's isWizardFeatureEnabled / canOpenDashboard.
+const isWizardEnabled = computed(
+  () => portalContext.features?.some(f => f.feature === 'wizards' && f.isEnabled === true) ?? false,
+)
+const canAnalyze = computed(() => Boolean(store.getters.getCanDatasetMaterializeCohorts) && isWizardEnabled.value)
 
 const getText = (key: string): string => {
   const resolver = store.getters.getText
@@ -604,6 +652,62 @@ const openFilterSummary = async (card: {
     summaryBusy.value = false
   }
 }
+
+/**
+ * Open the dashboard-wizard flow for a card.
+ *
+ * Unlike Filter summary, this genuinely needs the active bookmark set —
+ * `dashboardFlow.dashboardContext` returns nulls without one — so it calls
+ * `loadbookmarkToState` (which commits SET_ACTIVE_BOOKMARK), not the private
+ * action Filter summary uses to avoid that. `explorations.analyzeInProgress`
+ * (set below) stops PatientAnalytics' getActiveBookmark watcher from reading
+ * that as a reason to auto-switch to the cohort builder mid-click.
+ */
+const openAnalyze = async (card: { source: BookmarkDisplay }): Promise<void> => {
+  // Only a bookmark id: a cohort-definition or Atlas id comes from a different
+  // table and can collide with one, the same reason `openFilterSummary` above
+  // only reads `source.bookmark?.id`.
+  const bmkId = card.source.bookmark?.id
+  if (!bmkId) return
+  explorations.analyzeInProgress = true
+  try {
+    await store.dispatch('loadbookmarkToState', { bmkId, chartType: card.source.bookmark?.chartType })
+    dashboardFlow.openDashboardModal()
+  } catch (error) {
+    explorations.analyzeInProgress = false
+    // Mirrors PatientAnalytics.loadExploration's own catch: the saved filter
+    // does not fit the active config.
+    notifications.setAlertMessage({
+      message: getText('MRI_PA_BMK_COMPATIBLE_ERROR'),
+      messageType: 'error',
+      title: getText('MRI_PA_NOTIFICATION_ERROR'),
+    })
+    console.error('[ExplorationsPage] Analyze could not load the exploration', error)
+  }
+}
+
+// True while any of the five wizard-flow modals is open. Watched below so
+// closing (finishing or cancelling) can clean up the shared Vuex state the
+// flow mutated — otherwise the cohort builder opens next carrying filters
+// the user never chose there.
+const dashboardFlowModalOpen = computed(
+  () =>
+    dashboardFlow.showDashboardSelectionModal ||
+    dashboardFlow.showRequiredFiltersModal ||
+    dashboardFlow.showTable1ConfigModal ||
+    dashboardFlow.showDashboardModal ||
+    dashboardFlow.showSaveCohortModal,
+)
+
+watch(dashboardFlowModalOpen, (isOpen, wasOpen) => {
+  if (isOpen || !wasOpen) return
+  // Resetting mid-flow (e.g. between the selection modal closing and the next
+  // one opening) breaks the wizard; ChartToolbar.vue guards its own reset the
+  // same way.
+  if (dashboardFlow.isProcessingDashboardFlow()) return
+  dashboardFlow.resetDashboardFlowState()
+  explorations.analyzeInProgress = false
+})
 
 // Mirrors Bookmarks.addCohort: a D2E record materialises its bookmark, an Atlas
 // record materialises its cohort definition.

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ExplorationsPage.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ExplorationsPage.vue
@@ -305,6 +305,11 @@ import { useNotificationStore } from '../stores/notifications'
 import { usePortalContext } from '../composables/usePortalContext'
 import { useDashboardFlow } from '../composables/useDashboardFlow'
 import * as types from '../store/mutation-types'
+import {
+  analyzeBookmarkId,
+  isDashboardFlowOpen,
+  shouldResetDashboardFlow,
+} from './helpers/explorationAnalyze'
 import { filterAndSort, type ExplorationSortKey } from './helpers/explorationList'
 import { applyFilters, authorOptions, emptyFilters, type ExplorationFilters } from './helpers/explorationFilters'
 import { chartQueryFor } from './helpers/explorationSqlQuery'
@@ -670,7 +675,7 @@ const openAnalyze = async (card: { source: BookmarkDisplay }): Promise<void> => 
   // Only a bookmark id: a cohort-definition or Atlas id comes from a different
   // table and can collide with one, the same reason `openFilterSummary` above
   // only reads `source.bookmark?.id`.
-  const bmkId = card.source.bookmark?.id
+  const bmkId = analyzeBookmarkId(card)
   if (!bmkId) return
   // `loadbookmarkToState` is a multi-second network and parse. Two overlapping
   // opens would interleave over the same shared bookmark state and both call
@@ -717,21 +722,14 @@ const openAnalyze = async (card: { source: BookmarkDisplay }): Promise<void> => 
 // closing (finishing or cancelling) can clean up the shared Vuex state the
 // flow mutated — otherwise the cohort builder opens next carrying filters
 // the user never chose there.
-const dashboardFlowModalOpen = computed(
-  () =>
-    dashboardFlow.showDashboardSelectionModal ||
-    dashboardFlow.showRequiredFiltersModal ||
-    dashboardFlow.showTable1ConfigModal ||
-    dashboardFlow.showDashboardModal ||
-    dashboardFlow.showSaveCohortModal,
-)
+const dashboardFlowModalOpen = computed(() => isDashboardFlowOpen(dashboardFlow))
 
 watch(dashboardFlowModalOpen, async (isOpen, wasOpen) => {
-  if (isOpen || !wasOpen) return
   // Resetting mid-flow (e.g. between the selection modal closing and the next
   // one opening) breaks the wizard; ChartToolbar.vue guards its own reset the
   // same way.
-  if (dashboardFlow.isProcessingDashboardFlow()) return
+  const isProcessing = dashboardFlow.isProcessingDashboardFlow()
+  if (!shouldResetDashboardFlow({ isOpen, wasOpen: Boolean(wasOpen), isProcessing })) return
   dashboardFlow.resetDashboardFlowState()
 
   // The flow mutates Vuex the cohort builder shares: it sets the active

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ExplorationsPage.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ExplorationsPage.vue
@@ -258,9 +258,9 @@
       duration of the flow, so the two never overlap.
     -->
     <DashboardFlowModals
-      v-if="explorations.analyzeInProgress || dashboardFlowModalOpen"
+      v-if="dashboardFlowModalOpen"
       :flow="dashboardFlow"
-      :dataset-id="store.getters.getSelectedDataset?.id ?? portalContext.datasetId"
+      :dataset-id="store.getters.getSelectedDataset?.id || ''"
       :cohort-id="(dashboardFlow.savedCohortId ?? store.getters.getActiveCohortMaterializedId)?.toString() || ''"
     />
 
@@ -304,6 +304,7 @@ import { useExplorationsStore } from '../stores/explorations'
 import { useNotificationStore } from '../stores/notifications'
 import { usePortalContext } from '../composables/usePortalContext'
 import { useDashboardFlow } from '../composables/useDashboardFlow'
+import * as types from '../store/mutation-types'
 import { filterAndSort, type ExplorationSortKey } from './helpers/explorationList'
 import { applyFilters, authorOptions, emptyFilters, type ExplorationFilters } from './helpers/explorationFilters'
 import { chartQueryFor } from './helpers/explorationSqlQuery'
@@ -371,6 +372,8 @@ const summaryBusy = ref(false)
 const filterSummaryName = ref('')
 /** Its bookmark id, so reopening the same one is a no-op. */
 const filterSummaryBmkId = ref<string | null>(null)
+/** True across the Analyze bookmark load, to reject overlapping opens. */
+const analyzeLoading = ref(false)
 /**
  * A snapshot of the live filter state the panel is about to overwrite, so
  * closing can put it back exactly — including edits that were never saved.
@@ -669,20 +672,44 @@ const openAnalyze = async (card: { source: BookmarkDisplay }): Promise<void> => 
   // only reads `source.bookmark?.id`.
   const bmkId = card.source.bookmark?.id
   if (!bmkId) return
+  // `loadbookmarkToState` is a multi-second network and parse. Two overlapping
+  // opens would interleave over the same shared bookmark state and both call
+  // `openDashboardModal`, the second resetting the modal the first opened.
+  if (analyzeLoading.value) return
+  analyzeLoading.value = true
+
+  // Suppressed only across the dispatch. That is the whole window the watcher
+  // cares about — it fires on the unset-to-set transition, which happens
+  // inside `loadbookmarkToState`, and the bookmark stays set afterwards, so no
+  // later transition occurs. Keeping the flag raised for the whole flow made
+  // it possible to strand it true, after which the watcher never switched
+  // again and the deep-link path stopped working.
   explorations.analyzeInProgress = true
   try {
     await store.dispatch('loadbookmarkToState', { bmkId, chartType: card.source.bookmark?.chartType })
-    dashboardFlow.openDashboardModal()
   } catch (error) {
-    explorations.analyzeInProgress = false
-    // Mirrors PatientAnalytics.loadExploration's own catch: the saved filter
-    // does not fit the active config.
+    // `loadbookmarkToState` commits SET_ACTIVE_BOOKMARK before the IFR
+    // conversion can reject, so the bookmark is left active on a failure and
+    // PatientAnalytics would show its nav tab for a half-restored cohort.
+    store.commit(types.SET_ACTIVE_BOOKMARK, null)
     notifications.setAlertMessage({
       message: getText('MRI_PA_BMK_COMPATIBLE_ERROR'),
       messageType: 'error',
       title: getText('MRI_PA_NOTIFICATION_ERROR'),
     })
     console.error('[ExplorationsPage] Analyze could not load the exploration', error)
+    return
+  } finally {
+    explorations.analyzeInProgress = false
+    analyzeLoading.value = false
+  }
+
+  try {
+    // Awaited: `openDashboardModal` is async, and an unawaited rejection would
+    // escape this handler entirely.
+    await dashboardFlow.openDashboardModal()
+  } catch (error) {
+    console.error('[ExplorationsPage] Analyze could not open the wizard', error)
   }
 }
 
@@ -699,14 +726,28 @@ const dashboardFlowModalOpen = computed(
     dashboardFlow.showSaveCohortModal,
 )
 
-watch(dashboardFlowModalOpen, (isOpen, wasOpen) => {
+watch(dashboardFlowModalOpen, async (isOpen, wasOpen) => {
   if (isOpen || !wasOpen) return
   // Resetting mid-flow (e.g. between the selection modal closing and the next
   // one opening) breaks the wizard; ChartToolbar.vue guards its own reset the
   // same way.
   if (dashboardFlow.isProcessingDashboardFlow()) return
   dashboardFlow.resetDashboardFlowState()
-  explorations.analyzeInProgress = false
+
+  // The flow mutates Vuex the cohort builder shares: it sets the active
+  // bookmark and can dispatch addFilterCard for fields the wizard needed.
+  // `resetDashboardFlowState` drops its record of those cards without
+  // reverting them, so without this the builder opens carrying a filter the
+  // user never added and `useUnsavedChanges` reports a dirty state — which
+  // also blocks closing the browser tab. Required by `pr9/01-analyze-action`
+  // section 2c.
+  store.commit(types.SET_ACTIVE_BOOKMARK, null)
+  try {
+    await store.dispatch('queryReset')
+    await store.dispatch('resetChart')
+  } catch (error) {
+    console.error('[ExplorationsPage] could not reset the shared filter state', error)
+  }
 })
 
 // Mirrors Bookmarks.addCohort: a D2E record materialises its bookmark, an Atlas

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
@@ -185,6 +185,7 @@ import { useAtlasStore } from '../stores/atlas'
 import { useUnsavedChanges } from '../composables/useUnsavedChanges'
 import { usePortalContext } from '../composables/usePortalContext'
 import { useNotificationStore } from '../stores/notifications'
+import { useExplorationsStore } from '../stores/explorations'
 
 const PANE_SIZE = {
   FULL: 100,
@@ -203,6 +204,7 @@ export default {
       unsavedChanges: useUnsavedChanges(),
       portalContext: usePortalContext(),
       notifications: useNotificationStore(),
+      explorations: useExplorationsStore(),
     }
   },
   data() {
@@ -240,6 +242,10 @@ export default {
       }
     },
     getActiveBookmark(newVal, oldVal) {
+      // The Analyze card action also sets the active bookmark (dashboardContext
+      // needs it), but it must not trigger this auto-switch: it would unmount
+      // ExplorationsPage, and the wizard modals mounted inside it, mid-click.
+      if (this.explorations.analyzeInProgress) return
       // Auto-switch to cohort view when a bookmark is loaded (e.g., from deep link)
       // Only trigger when going from no bookmark to having one
       if (newVal && !oldVal && this.displayCohorts) {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/helpers/__tests__/explorationAnalyze.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/helpers/__tests__/explorationAnalyze.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeBookmarkId,
+  isDashboardFlowOpen,
+  shouldResetDashboardFlow,
+} from '../explorationAnalyze'
+
+describe('analyzeBookmarkId', () => {
+  it('returns the bookmark id from the card view model', () => {
+    expect(analyzeBookmarkId({ source: { bookmark: { id: 'bmk-1' } } })).toBe('bmk-1')
+  })
+
+  it('refuses a cohort-definition or Atlas record, which have no bookmark id', () => {
+    // Those ids come from other tables and can collide with a bookmark id;
+    // getBookmarkById would throw or address a different exploration.
+    expect(analyzeBookmarkId({ source: { cohortDefinition: { id: 'cd-1' } } })).toBeNull()
+    expect(analyzeBookmarkId({ source: { atlasCohortDefinition: { id: 'atlas-1' } } })).toBeNull()
+  })
+
+  it('reads source, not the flat view model, which has no bookmark', () => {
+    // The grid maps each record into { id, source, name, bmkId, ... }.
+    expect(analyzeBookmarkId({ bookmark: { id: 'bmk-1' } })).toBeNull()
+  })
+
+  it('is null for an empty id, a missing source and a missing card', () => {
+    expect(analyzeBookmarkId({ source: { bookmark: { id: '' } } })).toBeNull()
+    expect(analyzeBookmarkId({ source: {} })).toBeNull()
+    expect(analyzeBookmarkId({})).toBeNull()
+    expect(analyzeBookmarkId(null)).toBeNull()
+    expect(analyzeBookmarkId(undefined)).toBeNull()
+  })
+
+  it('is null for a non-string id rather than passing it through', () => {
+    expect(analyzeBookmarkId({ source: { bookmark: { id: 42 } } })).toBeNull()
+  })
+})
+
+describe('isDashboardFlowOpen', () => {
+  const none = {
+    showDashboardSelectionModal: false,
+    showRequiredFiltersModal: false,
+    showTable1ConfigModal: false,
+    showDashboardModal: false,
+    showSaveCohortModal: false,
+  }
+
+  it('is false when every modal is closed', () => {
+    expect(isDashboardFlowOpen(none)).toBe(false)
+  })
+
+  it('is true for each modal on its own', () => {
+    for (const key of Object.keys(none) as (keyof typeof none)[]) {
+      expect(isDashboardFlowOpen({ ...none, [key]: true })).toBe(true)
+    }
+  })
+
+  it('is false for absent flags, so a half-built flow object cannot mount the modals', () => {
+    expect(isDashboardFlowOpen({})).toBe(false)
+    expect(isDashboardFlowOpen(null)).toBe(false)
+    expect(isDashboardFlowOpen(undefined)).toBe(false)
+  })
+
+  it('depends on nothing but the flags, so it cannot be left stuck on', () => {
+    // The regression this guards: the mount condition used to OR in a sticky
+    // "analyze in progress" flag. Flow paths that end with no modal open left
+    // it set, the modals stayed mounted, and unmounting the page then tore
+    // down a teleport whose target was being removed — silently aborting the
+    // switch to the cohort builder until a reload.
+    expect(isDashboardFlowOpen(none)).toBe(false)
+  })
+})
+
+describe('shouldResetDashboardFlow', () => {
+  it('resets on the true-to-false edge when the flow is idle', () => {
+    expect(shouldResetDashboardFlow({ isOpen: false, wasOpen: true, isProcessing: false })).toBe(true)
+  })
+
+  it('does not reset while a modal is open', () => {
+    expect(shouldResetDashboardFlow({ isOpen: true, wasOpen: false, isProcessing: false })).toBe(false)
+    expect(shouldResetDashboardFlow({ isOpen: true, wasOpen: true, isProcessing: false })).toBe(false)
+  })
+
+  it('does not reset on the first evaluation, when nothing was open before', () => {
+    expect(shouldResetDashboardFlow({ isOpen: false, wasOpen: false, isProcessing: false })).toBe(false)
+  })
+
+  it('does not reset in the gap between two modals', () => {
+    // The flow closes one modal and opens the next across an await; resetting
+    // in that window breaks the wizard.
+    expect(shouldResetDashboardFlow({ isOpen: false, wasOpen: true, isProcessing: true })).toBe(false)
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/helpers/explorationAnalyze.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/helpers/explorationAnalyze.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure decisions behind the exploration card's Analyze action.
+ *
+ * These live outside `ExplorationsPage.vue` so they can be tested without
+ * mounting anything, which the repository's testing policy asks for. The
+ * defects they encode were all found by review rather than by tests, so each
+ * one has a case in `__tests__/explorationAnalyze.test.ts`.
+ */
+
+/** The five wizard-flow modals, as the composable exposes them. */
+export interface DashboardFlowFlags {
+  showDashboardSelectionModal?: boolean
+  showRequiredFiltersModal?: boolean
+  showTable1ConfigModal?: boolean
+  showDashboardModal?: boolean
+  showSaveCohortModal?: boolean
+}
+
+/**
+ * The bookmark id to analyse, or `null` when the card cannot be analysed.
+ *
+ * Only `bookmark.id` is accepted. A cohort-definition or Atlas id comes from a
+ * different table and the two can collide — the grid namespaces its own card
+ * ids for exactly that reason — and `getBookmarkById` dereferences the result
+ * of a `.find()` with no guard, so passing one either throws or silently
+ * addresses a different exploration.
+ */
+export function analyzeBookmarkId(card: unknown): string | null {
+  const id = (card as { source?: { bookmark?: { id?: unknown } } })?.source?.bookmark?.id
+  return typeof id === 'string' && id.length > 0 ? id : null
+}
+
+/**
+ * Whether any wizard modal is on screen.
+ *
+ * This is the mount condition for `DashboardFlowModals`. It is derived only
+ * from the modal flags, which are refs, so it cannot be left stuck on. An
+ * earlier version OR-ed in a sticky "analyze in progress" flag; several flow
+ * paths end with every modal closed and that flag still set, after which the
+ * modals stayed mounted and unmounting the page tore down a teleport whose
+ * target was itself being removed.
+ */
+export function isDashboardFlowOpen(flags: DashboardFlowFlags | null | undefined): boolean {
+  if (!flags) return false
+  return Boolean(
+    flags.showDashboardSelectionModal ||
+      flags.showRequiredFiltersModal ||
+      flags.showTable1ConfigModal ||
+      flags.showDashboardModal ||
+      flags.showSaveCohortModal
+  )
+}
+
+/**
+ * Whether closing has finished the flow, so the shared Vuex state it mutated
+ * should be put back.
+ *
+ * Only on the true-to-false edge, and never while the composable reports it is
+ * still working: the flow closes one modal before opening the next across an
+ * await, and resetting in that gap breaks it.
+ */
+export function shouldResetDashboardFlow(args: {
+  isOpen: boolean
+  wasOpen: boolean
+  isProcessing: boolean
+}): boolean {
+  return !args.isOpen && args.wasOpen && !args.isProcessing
+}

--- a/plugins/ui/apps/vue-mri-ui-lib/src/stores/explorations.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/stores/explorations.ts
@@ -5,6 +5,12 @@ import { defineStore } from 'pinia'
 export const useExplorationsStore = defineStore('explorations', {
   state: () => ({
     selectedBookmarkIds: [] as string[],
+    // True while the Analyze action's own loadbookmarkToState dispatch is
+    // filling the active bookmark. PatientAnalytics.vue's getActiveBookmark
+    // watcher auto-switches to the cohort builder whenever a bookmark goes
+    // from unset to set; Analyze needs the active bookmark set (dashboardContext
+    // reads it) without that switch firing and unmounting this page mid-click.
+    analyzeInProgress: false,
   }),
   getters: {
     isSelected: state => (id: string) => state.selectedBookmarkIds.includes(id),


### PR DESCRIPTION
Closes #3121.

Seventh in the Data Exploration redesign stack. **Based on `khairul-syazwan/d2e-filter-summary` (#3271), not `develop`** — review that one first.

## What this adds

An **Analyze** action on the exploration card that opens the existing dashboard-wizard flow. This is wiring: the flow already works in the cohort builder and no dialog's content changes.

The five wizard modals move out of `ChartToolbar.vue` into `DashboardFlowModals.vue` verbatim, so the builder and the exploration page mount one copy instead of the block being duplicated. The Analyze placeholder PR 4 shipped is wired rather than replaced, so it keeps the exported Figma glyph. Availability copies `ChartToolbar`'s own `canOpenDashboard`.

## The design decision

Analyze needs the active bookmark — `dashboardContext` returns nulls without one — so unlike the filter summary it cannot avoid committing `SET_ACTIVE_BOOKMARK`. `PatientAnalytics` watches that to auto-switch to the cohort builder, which would unmount this page mid-click.

**Chosen: the wizard opens over the exploration page, and the switch is suppressed** for the duration of the load. Rationale: #3120 established that a card action does not relocate the user, and two card actions behaving differently is worse than either alone. **If the product owner would rather Analyze land in the cohort builder, say so** — it is a small change, only moving where `DashboardFlowModals` is mounted.

## Three things the interfaces do not advertise

**`useDashboardFlow` returns raw refs.** `ChartToolbar` gets nested-ref unwrapping for free by holding it in an Options-API `data()`, but props are `shallowReactive`, so the same object read through a prop yields the `Ref` rather than its value. Both new consumers wrap it in `reactive()`. Without this every `:disabled` and tooltip binding silently misbehaves.

**`isProcessingDashboardFlow` is a plain `let` boolean, not a ref.** A computed over it never re-evaluates, so it cannot drive a reactive mount condition — and it can itself remain `true` after a failed flow.

**The modals `<Teleport to="#app">`, and `#app` is an ancestor of this page.** Leaving them mounted meant unmounting the page tore down a teleport whose target was itself being removed. Vue threw `Cannot destructure property 'bum' of 'ne' as it is null` during unmount, the update aborted, and **clicking a card silently stopped opening the cohort builder**. They are mounted only while a modal is actually open.

That last one is worth dwelling on: it reproduced with **983 tests green and three clean builds**, and produced no console output, because `app.config.errorHandler` is `() => null` in both `lifecycles.ts` and `main.ts` and production strips Vue warnings. It was found only by clicking a card in the running app and then temporarily unmasking the handler. **Worth fixing that error handler separately.**

## Review findings, all fixed

A review of the first cut found three HIGH defects:

- **The mount condition depended on a sticky flag that could strand `true`**, re-creating the teleport crash above — permanently, silently, until reload. Several real paths end the flow with every modal closed and the flag still set: `openDashboardModal` returning early with no active bookmark, `handleOpenDashboard` bailing on an unready config, and the `catch` in `handleRequiredFiltersSubmit`. The condition is now the modal flags alone, which are refs and cannot strand, and the flag is raised only across the load and cleared in a `finally`.
- **The flow's Vuex mutations were never undone.** `resetDashboardFlowState` discards its record of the filter cards the wizard added without reverting them, so the builder opened carrying a filter the user never added, `useUnsavedChanges` reported dirty, and the browser tab could not be closed. Closing now clears the active bookmark and resets query and chart.
- **`openDashboardModal()` was not awaited**, so a rejection escaped the handler that clears state.

Plus: a failed load no longer leaves the bookmark active and offering a half-restored cohort; overlapping opens are rejected; and the dataset id expression matches `ChartToolbar`'s.

## Validation evidence — agent reported

**No end-to-end suite was run; do not read this as full E2E coverage.**

- `npx vitest run --coverage` on Node 20 — the command CI runs — **983 passed, 0 failed**.
- All three app builds pass. No library file changed.
- **Lint not run.** `plugins/ui/node_modules` hoists eslint 7.32, which cannot read the app's flat config.

**Browser, hot-deployed against a local runtime:**

- Analyze opens *Get started on your analysis with wizard* **over the exploration page**, no view switch.
- The dialog lists the configured wizard, and selecting it reaches **Complete Required Filters pre-populated from the exploration's own saved filters** — Age Range `>40`, Gender `FEMALE`.
- After closing the flow, the modals unmount, **clicking a card still opens the cohort builder**, and no unsaved-changes dialog appears.
- No runtime errors.

**Not exercised: Apply Filters onward**, which renders a Shiny dashboard the local stack cannot serve. Exercising any of this at all required local database setup — the `wizards` feature flag and injecting the shipped wizard definitions into the dataset's PA config, which carried no `wizardsConfig` key.

## Reviewer notes

- **No unit test covers the new logic.** The id derivation, the mount computed and the reset watcher are pure state logic and testable without mounting. Worth adding; called out rather than quietly skipped.
- `ShinyDashboardModal`'s `dataset-id` was `getSelectedDataset.id` and is now the shared `?.id || ''` prop, turning a loud failure into an empty string. Deliberate, so both mount sites agree.
- `ChartToolbar` retains dead `showDashboardModal` / `handleOpenDashboard` members. They were dead before this change; not touched here.
