### PR TITLE
fix(cohorts): keep wizard dropdowns inside the modal (v0.18.0-beta)

### DIFF
--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ConceptSetTypeaheadField.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ConceptSetTypeaheadField.vue
@@ -264,6 +264,7 @@ function handleKeyDown(event: KeyboardEvent) {
   if (!isOpen.value) {
     if (event.key === 'ArrowDown' && options.value.length > 0) {
       isOpen.value = true
+      updateDropdownPosition()
       highlightedIndex.value = 0
       event.preventDefault()
     }

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ConceptSetTypeaheadField.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ShinyViewer/ConceptSetTypeaheadField.vue
@@ -207,13 +207,24 @@ function updateDropdownPosition() {
   if (!input) return
 
   const rect = input.getBoundingClientRect()
+  // The dropdown is teleported to body, so the modal's overflow cannot clip it.
+  // Position within the visible form rather than the entire browser viewport.
+  const boundary = input.closest('.required-filters-modal')?.getBoundingClientRect()
+  const top = Math.max(0, boundary?.top ?? 0)
+  const bottom = Math.min(window.innerHeight, boundary?.bottom ?? window.innerHeight)
+  const left = Math.max(0, boundary?.left ?? 0)
+  const right = Math.min(window.innerWidth, boundary?.right ?? window.innerWidth)
+  if (rect.top < top || rect.bottom > bottom || rect.left < left || rect.right > right) {
+    dropdownStyle.value = { display: 'none' }
+    return
+  }
+
   const MAX_HEIGHT = 200 // keep in sync with .concept-typeahead-dropdown max-height
   const GAP = 8
-  const spaceBelow = window.innerHeight - rect.bottom
-  const spaceAbove = rect.top
+  const spaceBelow = bottom - rect.bottom
+  const spaceAbove = rect.top - top
 
-  // Flip above the field when there isn't room below (e.g. fields low in the
-  // modal), so the dropdown never spills past the viewport / behind the footer.
+  // Flip above the field when there isn't room below within the form.
   const openUp = spaceBelow < Math.min(MAX_HEIGHT, 160) && spaceAbove > spaceBelow
 
   const style: Record<string, string> = {


### PR DESCRIPTION
Backport of #3311 to `release/v0.18.0-beta`; the patches are identical.

Fix wizard dropdowns overflowing the Cohort Builder modal by positioning them within its bounding box, hiding them when their input scrolls out of view, and refreshing their position on keyboard reopening.

| Before | After (release build) |
| --- | --- |
| ![Before](https://raw.githubusercontent.com/OHDSI/Data2Evidence/afb491e0a180ef30bd77955b7ad50114b764e284/docs/qa/issue-69/before-overflow.png) | ![After](https://raw.githubusercontent.com/OHDSI/Data2Evidence/afb491e0a180ef30bd77955b7ad50114b764e284/docs/qa/issue-69/release-after-scroll.png) |
