### PR TITLE
Bump PatientLevelPrediction to 6.6.0 in flow-hades renv.lock

### DIFF
--- a/plugins/flows/hades/renv.lock
+++ b/plugins/flows/hades/renv.lock
@@ -1922,11 +1922,11 @@
     },
     "PatientLevelPrediction": {
       "Package": "PatientLevelPrediction",
-      "Version": "6.5.0",
+      "Version": "6.6.0",
       "Source": "GitHub",
       "Type": "Package",
       "Title": "Develop Clinical Prediction Models Using the Common Data Model",
-      "Date": "2025-07-25",
+      "Date": "2026-03-09",
       "Authors@R": "c( person(\"Egill\", \"Fridgeirsson\", email = \"e.fridgeirsson@erasmusmc.nl\", role = c(\"aut\", \"cre\")), person(\"Jenna\", \"Reps\", email = \"jreps@its.jnj.com\", role = c(\"aut\")), person(\"Martijn\", \"Schuemie\", role = c(\"aut\")), person(\"Marc\", \"Suchard\", role = c(\"aut\")), person(\"Patrick\", \"Ryan\", role = c(\"aut\")), person(\"Peter\", \"Rijnbeek\", role = c(\"aut\")), person(\"Observational Health Data Science and Informatics\", role = c(\"cph\")))",
       "Description": "A user friendly way to create patient level prediction models using the Observational Medical Outcomes Partnership Common Data Model. Given a cohort of interest and an outcome of interest, the package can use data in the Common Data Model to build a large set of features. These features can then be used to fit a predictive model with a number of machine learning algorithms. This is further described in Reps (2017) <doi:10.1093/jamia/ocy032>.",
       "License": "Apache License 2.0",
@@ -1966,11 +1966,12 @@
         "mgcv",
         "OhdsiShinyAppBuilder (>= 1.0.0)",
         "parallel",
+        "pkgload",
         "polspline",
         "readr",
         "ResourceSelection",
-        "ResultModelManager (>= 0.2.0)",
-        "reticulate (>= 1.30)",
+        "ResultModelManager (>= 0.6.0)",
+        "reticulate (>= 1.41)",
         "rmarkdown",
         "RSQLite",
         "scoring",
@@ -1980,7 +1981,7 @@
         "withr",
         "xgboost (> 1.3.2.1)"
       ],
-      "RoxygenNote": "7.3.2",
+      "RoxygenNote": "7.3.3",
       "Encoding": "UTF-8",
       "Config/testthat/edition": "3",
       "Roxygen": "list(markdown = TRUE)",
@@ -1990,7 +1991,7 @@
       "RemoteHost": "api.github.com",
       "RemoteUsername": "ohdsi",
       "RemoteRepo": "PatientLevelPrediction",
-      "RemoteRef": "v6.5.0"
+      "RemoteRef": "v6.6.0"
     },
     "PheValuator": {
       "Package": "PheValuator",


### PR DESCRIPTION
## What

Bumps `PatientLevelPrediction` from **6.5.0** to **6.6.0** in `plugins/flows/hades/renv.lock`.

The entry was regenerated from PLP 6.6.0's actual `DESCRIPTION` rather than hand-editing two
fields, since the lock stores a full DESCRIPTION snapshot — so `Date`, `RoxygenNote` and
`Suggests` are updated too, not just `Version`/`RemoteRef`.

## Why

The trex-notebook Strategus spec builders were written against PLP **6.6.0**: they emit
`hyperparameterSettings` and expose `setRidgeRegression`, **neither of which exists in 6.5.0**.
A notebook-generated PLP spec is therefore rejected by the currently pinned version.

Note the direction — unlike the CohortMethod drift (notebook *behind* the pin at 5.4.0 vs
5.5.2), here the notebook is *ahead*, so aligning means moving the flow forward.

Companion branch: `SantanM/internal-3235_notebook-prefect-alignment` in `trex-notebook`.

## ⚠️ Accepted risk: PLP 6.6.0 results migration is not DuckDB-compatible

**The analysis works; writing results to the database does not.** In a full Strategus run
against `demo_cdm` on the trex DuckDB endpoint:

```
✔ CohortGeneratorModule — 3 cohorts generated
✔ PLP Analysis_1 / Analysis_2 — "Run finished successfully", runPlp 39 secs, models saved
✖ createPlpResultTables → migrateDataModel
    Migration_1-store_version.sql                    ✔
    Migration_2-add_hyperparameter_settings.sql      ✖  near "IF": syntax error
```

The migration emits untranslated T-SQL that DuckDB has no equivalent for:

```sql
IF NOT EXISTS (SELECT 1 FROM main.hyperparameter_settings) BEGIN ... END;
IF COL_LENGTH('main.model_designs', 'hyperparameter_setting_id') IS NULL BEGIN
  ALTER TABLE main.model_designs ADD hyperparameter_setting_id int; END;
```

This is a **new** failure surface: 6.5.0 has no such migration. It is not an outdated
`ResultModelManager` — see verification below. Until upstream translates this SQL, PLP runs on
DuckDB-backed datasets should disable results upload, or the migration needs a
SqlRender-translated variant.

## Verification performed before the bump

Dependency safety — checked, not assumed:

- PLP 6.6.0's **`Imports` block is byte-identical** to 6.5.0's. Every bound is satisfied by the
  lock: `Cyclops 3.6.0` (needs ≥3.0.0), `DatabaseConnector 6.3.2` (≥6.0.0),
  `FeatureExtraction 3.11.0` (≥3.0.0), `ParallelLogger 3.5.0` (≥2.0.0), `SqlRender 1.19.2`
  (≥1.1.3), R 4.4.3 (≥4.0.0).
- **`Suggests` did tighten** — `ResultModelManager ≥0.2.0 → ≥0.6.0`, `reticulate ≥1.30 → ≥1.41`,
  plus `pkgload`. All three are already locked at or above those floors (RMM **0.6.0**,
  reticulate 1.41.0, pkgload 1.4.0).
- **No package in the lock constrains PLP from above** — all five reverse dependencies
  (`DeepPatientLevelPrediction ≥6.5.0`, `EnsemblePatientLevelPrediction ≥6.0.0`,
  `PheValuator ≥6.0.4`, `Hades`, `Strategus`) use lower bounds only.
- Installed 6.6.0 into an isolated library against the locked dependencies: it loads,
  Strategus 1.4.0 loads alongside it, and the run above proceeded to model training.
- `v6.6.0` tag resolves on GitHub; lock remains valid JSON at 280 packages.

## Notes for reviewers

- **A flow-hades image rebuild is required** for this to take effect. The lock is the pin only.
- The published docs site is built from `main` and is **ahead of the v6.6.0 tag** (it lists
  `createOutcomeLimitedSplitSettings`, which the tag does not export). Verify against the
  installed package, not the site.
- Two notebook-side divergences remain and are **not** addressed by this bump:
  `runCovariateSummary` should be folded into `executeSettings`, and the notebook's
  `createDefaultCovariateSettings` enables a different analysis set than FeatureExtraction
  3.11.0 (6 extra, 10 missing). Both are FeatureExtraction/builder concerns, not PLP.

Draft: opened for review of the accepted risk before merge.
