### PR TITLE
perf(vue-mri): cut the eager bundle 77% in the portal and 40% in Atlas

### DIFF
--- a/plugins/atlas/package.json
+++ b/plugins/atlas/package.json
@@ -52,23 +52,7 @@
           "source": "/atlas-login",
           "target": "/resources/login"
         }
-      ],
-      "uiplugins": {
-        "researcher": [
-          {
-            "name": "Atlas",
-            "nameI18nKey": "UI_PLUGIN_ATLAS",
-            "route": "atlas",
-            "pluginPath": "/atlas-portal/index.js",
-            "type": "app",
-            "autoMount": false,
-            "enabled": true,
-            "requiredRoles": [
-              "RESEARCHER"
-            ]
-          }
-        ]
-      }
+      ]
     }
   }
 }

--- a/plugins/ui/apps/portal/src/singleSpa/__tests__/preloadScheduler.test.ts
+++ b/plugins/ui/apps/portal/src/singleSpa/__tests__/preloadScheduler.test.ts
@@ -1,4 +1,4 @@
-import { preloadNow, preloadWhenIdle, resetPreloadQueue } from "../preloadScheduler";
+import { cancelPreload, preloadNow, preloadWhenIdle, resetPreloadQueue } from "../preloadScheduler";
 
 // Force the setTimeout fallback so the tests drive the scheduler with fake
 // timers rather than depending on a jsdom requestIdleCallback.
@@ -102,5 +102,63 @@ describe("preloadScheduler", () => {
     await flush();
     await advance(IDLE_FALLBACK_MS);
     expect(next.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not download a plugin whose preload was cancelled", async () => {
+    // A plugin can unmount before its turn comes up — a dataset switch
+    // remounts the whole researcher container. Downloading it then would
+    // compete with whatever the user moved on to.
+    const going = deferred();
+    const staying = deferred();
+
+    preloadWhenIdle("going", going.load);
+    preloadWhenIdle("staying", staying.load);
+    cancelPreload("going");
+
+    await advance(IDLE_FALLBACK_MS);
+
+    expect(going.load).not.toHaveBeenCalled();
+    expect(staying.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues one entry per plugin, so a re-register cannot double up", async () => {
+    // `generateAppId` derives the id from the path alone, so a plugin that is
+    // unregistered and registered again reuses it. Two entries would put two
+    // background downloads on the wire.
+    const plugin = deferred();
+
+    preloadWhenIdle("plugin", plugin.load);
+    preloadWhenIdle("plugin", plugin.load);
+
+    await advance(IDLE_FALLBACK_MS);
+    expect(plugin.load).toHaveBeenCalledTimes(1);
+
+    plugin.resolve();
+    await flush();
+    await advance(IDLE_FALLBACK_MS * 2);
+    expect(plugin.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds background preloads until every foreground preload settles", async () => {
+    // Two plugins can both match the current location when their base paths
+    // nest. With a boolean flag the first to settle resumed the drain while
+    // the second was still on the wire.
+    const firstActive = deferred();
+    const secondActive = deferred();
+    const queued = deferred();
+
+    preloadNow("active-a", firstActive.load);
+    preloadNow("active-b", secondActive.load);
+    preloadWhenIdle("queued", queued.load);
+
+    firstActive.resolve();
+    await flush();
+    await advance(IDLE_FALLBACK_MS * 2);
+    expect(queued.load).not.toHaveBeenCalled();
+
+    secondActive.resolve();
+    await flush();
+    await advance(IDLE_FALLBACK_MS);
+    expect(queued.load).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/ui/apps/portal/src/singleSpa/__tests__/preloadScheduler.test.ts
+++ b/plugins/ui/apps/portal/src/singleSpa/__tests__/preloadScheduler.test.ts
@@ -1,0 +1,106 @@
+import { preloadNow, preloadWhenIdle, resetPreloadQueue } from "../preloadScheduler";
+
+// Force the setTimeout fallback so the tests drive the scheduler with fake
+// timers rather than depending on a jsdom requestIdleCallback.
+const IDLE_FALLBACK_MS = 500;
+
+const flush = async () => {
+  // Let already-resolved promise callbacks run between timer advances.
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const advance = async (ms: number) => {
+  jest.advanceTimersByTime(ms);
+  await flush();
+};
+
+/** A load function whose promise this test resolves by hand. */
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = () => res();
+    reject = rej;
+  });
+  const load = jest.fn(() => promise);
+  return { load, resolve, reject };
+}
+
+describe("preloadScheduler", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetPreloadQueue();
+    delete (window as any).requestIdleCallback;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("loads the active plugin straight away", () => {
+    const active = deferred();
+    preloadNow("active", active.load);
+    expect(active.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start a queued preload immediately", async () => {
+    const queued = deferred();
+    preloadWhenIdle("queued", queued.load);
+
+    expect(queued.load).not.toHaveBeenCalled();
+
+    await advance(IDLE_FALLBACK_MS);
+    expect(queued.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds background preloads until the active one settles", async () => {
+    const active = deferred();
+    const queued = deferred();
+
+    preloadNow("active", active.load);
+    preloadWhenIdle("queued", queued.load);
+
+    // The active bundle is still in flight, so nothing else may compete.
+    await advance(IDLE_FALLBACK_MS * 4);
+    expect(queued.load).not.toHaveBeenCalled();
+
+    active.resolve();
+    await flush();
+    await advance(IDLE_FALLBACK_MS);
+    expect(queued.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains the queue one bundle at a time", async () => {
+    const first = deferred();
+    const second = deferred();
+
+    preloadWhenIdle("first", first.load);
+    preloadWhenIdle("second", second.load);
+
+    await advance(IDLE_FALLBACK_MS);
+    expect(first.load).toHaveBeenCalledTimes(1);
+    expect(second.load).not.toHaveBeenCalled();
+
+    first.resolve();
+    await flush();
+    await advance(IDLE_FALLBACK_MS);
+    expect(second.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps draining after a preload fails", async () => {
+    const failing = deferred();
+    const next = deferred();
+
+    preloadWhenIdle("failing", failing.load);
+    preloadWhenIdle("next", next.load);
+
+    await advance(IDLE_FALLBACK_MS);
+    expect(failing.load).toHaveBeenCalledTimes(1);
+
+    failing.reject(new Error("network"));
+    await flush();
+    await advance(IDLE_FALLBACK_MS);
+    expect(next.load).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/ui/apps/portal/src/singleSpa/preloadScheduler.ts
+++ b/plugins/ui/apps/portal/src/singleSpa/preloadScheduler.ts
@@ -1,0 +1,103 @@
+/**
+ * Schedules plugin bundle preloads so the active plugin is not starved.
+ *
+ * The researcher container pre-renders a container for every `type: "app"`
+ * plugin, so `registerSingleSpaApp` runs for all of them on the same tick. An
+ * unconditional eager preload therefore put six bundles on the wire together.
+ *
+ * On a constrained link that starves the plugin the user actually asked for.
+ * Measured at 4 Mbit/s with six bundles in flight, vue-mri's 1,036 KB entry
+ * took 8,935 ms, an effective 116 KB/s out of the 500 KB/s the link allows.
+ *
+ * The plugin whose route is already active still preloads immediately, which
+ * is what closes the LOADING_SOURCE_CODE race that the eager preload was added
+ * for. Every other plugin is queued and drained one at a time while the browser
+ * is idle, so at most one background download competes with the foreground one.
+ *
+ * Deferring is only an optimisation. If the user opens a plugin before its
+ * queued preload has run, single-spa calls the app's load function on
+ * activation and the module cache dedupes the two callers.
+ */
+
+type PreloadTask = { id: string; load: () => Promise<unknown> };
+
+const queue: PreloadTask[] = [];
+let draining = false;
+// True while the active plugin's bundle is downloading. Background preloads
+// wait for it, so the plugin the user opened gets the whole link.
+let foregroundInFlight = false;
+
+const IDLE_TIMEOUT_MS = 5000;
+const FALLBACK_DELAY_MS = 500;
+
+function whenIdle(run: () => void): void {
+  const idle = (window as any).requestIdleCallback;
+  if (typeof idle === "function") {
+    idle(() => run(), { timeout: IDLE_TIMEOUT_MS });
+    return;
+  }
+  window.setTimeout(run, FALLBACK_DELAY_MS);
+}
+
+function drain(): void {
+  if (foregroundInFlight) {
+    // A foreground preload started while we were waiting for idle. Stand down;
+    // preloadNow restarts the drain once it settles.
+    draining = false;
+    return;
+  }
+
+  const next = queue.shift();
+  if (!next) {
+    draining = false;
+    return;
+  }
+
+  console.debug(`[preloadScheduler] ${next.id} - background preload`);
+  // Chain the next task on settle, not on success, so one failing bundle does
+  // not strand the rest of the queue.
+  next
+    .load()
+    .catch(() => undefined)
+    .then(() => whenIdle(drain));
+}
+
+/**
+ * Preload immediately. Use for the plugin whose route is already active.
+ *
+ * Background preloads start only once this one settles, so the active plugin
+ * gets the whole link rather than sharing it.
+ */
+export function preloadNow(id: string, load: () => Promise<unknown>): void {
+  console.debug(`[preloadScheduler] ${id} - foreground preload`);
+  foregroundInFlight = true;
+  // Fire and forget. A failure here is surfaced later by single-spa when it
+  // calls the load function through its own lifecycle.
+  load()
+    .catch((error) => {
+      console.debug(`[preloadScheduler] ${id} - preload failed (will retry on activation):`, error);
+    })
+    .then(() => {
+      foregroundInFlight = false;
+      startDraining();
+    });
+}
+
+/** Queue a preload to run in the background, one bundle at a time. */
+export function preloadWhenIdle(id: string, load: () => Promise<unknown>): void {
+  queue.push({ id, load });
+  startDraining();
+}
+
+function startDraining(): void {
+  if (draining || foregroundInFlight) return;
+  draining = true;
+  whenIdle(drain);
+}
+
+/** Test seam: drop anything still queued. */
+export function resetPreloadQueue(): void {
+  queue.length = 0;
+  draining = false;
+  foregroundInFlight = false;
+}

--- a/plugins/ui/apps/portal/src/singleSpa/preloadScheduler.ts
+++ b/plugins/ui/apps/portal/src/singleSpa/preloadScheduler.ts
@@ -23,9 +23,14 @@ type PreloadTask = { id: string; load: () => Promise<unknown> };
 
 const queue: PreloadTask[] = [];
 let draining = false;
-// True while the active plugin's bundle is downloading. Background preloads
-// wait for it, so the plugin the user opened gets the whole link.
-let foregroundInFlight = false;
+// How many foreground preloads are downloading. Background preloads wait for
+// all of them, so the plugin the user opened gets the whole link.
+//
+// A counter rather than a boolean: two registered plugins can both match the
+// current location if their base paths nest, and with a boolean the first to
+// settle would resume background draining while the second was still on the
+// wire.
+let foregroundInFlight = 0;
 
 const IDLE_TIMEOUT_MS = 5000;
 const FALLBACK_DELAY_MS = 500;
@@ -40,7 +45,7 @@ function whenIdle(run: () => void): void {
 }
 
 function drain(): void {
-  if (foregroundInFlight) {
+  if (foregroundInFlight > 0) {
     // A foreground preload started while we were waiting for idle. Stand down;
     // preloadNow restarts the drain once it settles.
     draining = false;
@@ -70,7 +75,7 @@ function drain(): void {
  */
 export function preloadNow(id: string, load: () => Promise<unknown>): void {
   console.debug(`[preloadScheduler] ${id} - foreground preload`);
-  foregroundInFlight = true;
+  foregroundInFlight += 1;
   // Fire and forget. A failure here is surfaced later by single-spa when it
   // calls the load function through its own lifecycle.
   load()
@@ -78,19 +83,44 @@ export function preloadNow(id: string, load: () => Promise<unknown>): void {
       console.debug(`[preloadScheduler] ${id} - preload failed (will retry on activation):`, error);
     })
     .then(() => {
-      foregroundInFlight = false;
+      foregroundInFlight -= 1;
       startDraining();
     });
 }
 
 /** Queue a preload to run in the background, one bundle at a time. */
 export function preloadWhenIdle(id: string, load: () => Promise<unknown>): void {
+  // One entry per plugin. A plugin can be registered again after an unload —
+  // `generateAppId` derives the id from the path alone, so the second
+  // registration reuses it — and two entries for one id would put two
+  // background downloads on the wire, which is the thing this file exists to
+  // prevent.
+  if (queue.some((task) => task.id === id)) {
+    console.debug(`[preloadScheduler] ${id} - already queued`);
+    return;
+  }
   queue.push({ id, load });
   startDraining();
 }
 
+/**
+ * Drop a plugin's queued preload. Call this when a plugin is unregistered.
+ *
+ * Without it a plugin that unmounts before its turn comes up still gets
+ * downloaded, competing with whatever the user moved on to. A dataset switch
+ * remounts the whole researcher container, so this is a normal event, not an
+ * edge case. A preload already in flight is left alone: the bytes are spent,
+ * and the module cache makes them harmless.
+ */
+export function cancelPreload(id: string): void {
+  const index = queue.findIndex((task) => task.id === id);
+  if (index === -1) return;
+  queue.splice(index, 1);
+  console.debug(`[preloadScheduler] ${id} - queued preload cancelled`);
+}
+
 function startDraining(): void {
-  if (draining || foregroundInFlight) return;
+  if (draining || foregroundInFlight > 0) return;
   draining = true;
   whenIdle(drain);
 }
@@ -99,5 +129,5 @@ function startDraining(): void {
 export function resetPreloadQueue(): void {
   queue.length = 0;
   draining = false;
-  foregroundInFlight = false;
+  foregroundInFlight = 0;
 }

--- a/plugins/ui/apps/portal/src/singleSpa/singleSpaRegistry.ts
+++ b/plugins/ui/apps/portal/src/singleSpa/singleSpaRegistry.ts
@@ -10,7 +10,7 @@ import {
 import { RegisteredApp, SingleSpaPluginConfig } from "./types";
 import { createActivityFunction, generateContainerId, matchesBasePath } from "./utils";
 import { resolveModuleUrl } from "./overrideUtils";
-import { preloadNow, preloadWhenIdle } from "./preloadScheduler";
+import { cancelPreload, preloadNow, preloadWhenIdle } from "./preloadScheduler";
 
 const registeredApps: Map<string, RegisteredApp> = new Map();
 const moduleCache: Map<string, Promise<any>> = new Map();
@@ -109,6 +109,12 @@ export async function unloadSingleSpaApp(appId: string): Promise<void> {
 
   const status = getAppStatus(appId);
   console.debug(`[singleSpaRegistry] ${appId} - unregistering, current status: ${status}`);
+
+  // Before anything else: if this plugin's background preload has not run yet,
+  // drop it. Nobody is waiting for the bundle now, and downloading it would
+  // compete with whatever the user moved on to. Safe even in the deferred
+  // branch below, because a re-register queues the preload again.
+  cancelPreload(appId);
 
   try {
     if (status === MOUNTED || status === NOT_MOUNTED || status === NOT_LOADED) {

--- a/plugins/ui/apps/portal/src/singleSpa/singleSpaRegistry.ts
+++ b/plugins/ui/apps/portal/src/singleSpa/singleSpaRegistry.ts
@@ -8,8 +8,9 @@ import {
   NOT_MOUNTED,
 } from "single-spa";
 import { RegisteredApp, SingleSpaPluginConfig } from "./types";
-import { createActivityFunction, generateContainerId } from "./utils";
+import { createActivityFunction, generateContainerId, matchesBasePath } from "./utils";
 import { resolveModuleUrl } from "./overrideUtils";
+import { preloadNow, preloadWhenIdle } from "./preloadScheduler";
 
 const registeredApps: Map<string, RegisteredApp> = new Map();
 const moduleCache: Map<string, Promise<any>> = new Map();
@@ -60,15 +61,21 @@ export async function registerSingleSpaApp(config: SingleSpaPluginConfig): Promi
     isActive: false,
   });
 
-  // Eagerly kick off the bundle download so the module is cached in
-  // moduleCache by the time activeWhen first fires. Fire-and-forget — if
-  // the load fails, single-spa will surface the error when it calls
-  // app() through its normal lifecycle path. This eliminates the
-  // LOADING_SOURCE_CODE race window where a portal switch can catch a
-  // heavy bundle (e.g. vue-mri) mid-download.
-  loadModule().catch(error => {
-    console.debug(`[singleSpaRegistry] ${config.id} - preload failed (will retry on activation):`, error);
-  });
+  // Kick off the bundle download so the module is cached in moduleCache by the
+  // time activeWhen first fires. This eliminates the LOADING_SOURCE_CODE race
+  // window where a portal switch can catch a heavy bundle (e.g. vue-mri)
+  // mid-download.
+  //
+  // The researcher container registers every plugin on the same tick, so
+  // preloading all of them at once put six bundles on the wire together and
+  // starved whichever one the user had actually opened. Only the plugin on the
+  // current route preloads straight away; the rest queue and download one at a
+  // time in the background. See preloadScheduler.ts.
+  if (matchesBasePath(config.basePath, window.location)) {
+    preloadNow(config.id, loadModule);
+  } else {
+    preloadWhenIdle(config.id, loadModule);
+  }
 }
 
 export function updateCustomProps(appId: string, customProps: Record<string, any>): void {

--- a/plugins/ui/apps/portal/src/singleSpa/utils.ts
+++ b/plugins/ui/apps/portal/src/singleSpa/utils.ts
@@ -9,13 +9,24 @@ export function isSingleSpaApp(module: any): module is AppLifecycles {
   );
 }
 
+/**
+ * True when the browser is on this plugin's route.
+ *
+ * Deliberately ignores autoMount. An autoMount plugin is always "active" for
+ * single-spa, but for preload ordering we want to know whether the user is
+ * actually looking at it.
+ */
+export function matchesBasePath(basePath: string, location: Location): boolean {
+  return location.pathname === basePath || location.pathname.startsWith(basePath + "/");
+}
+
 export function createActivityFunction(basePath: string, autoMount?: boolean): (location: Location) => boolean {
   return (location: Location) => {
     if (autoMount) {
       return true;
     }
 
-    return location.pathname === basePath || location.pathname.startsWith(basePath + "/");
+    return matchesBasePath(basePath, location);
   };
 }
 

--- a/plugins/ui/apps/vue-mri-ui-lib/build/__tests__/postcss-woff2-only.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/build/__tests__/postcss-woff2-only.test.ts
@@ -79,6 +79,6 @@ describe('postcssWoff2Only', () => {
     const css = `.thing { src: url('a.ttf'); }`
     const out = await run(css)
 
-    expect(out).toContain("a.ttf")
+    expect(out).toContain('a.ttf')
   })
 })

--- a/plugins/ui/apps/vue-mri-ui-lib/build/__tests__/postcss-woff2-only.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/build/__tests__/postcss-woff2-only.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import postcss from 'postcss'
+import { postcssWoff2Only } from '../postcss-woff2-only'
+
+const run = async (css: string): Promise<string> => {
+  const result = await postcss([postcssWoff2Only()]).process(css, { from: undefined })
+  return result.css
+}
+
+describe('postcssWoff2Only', () => {
+  it('collapses the @mdi/font bulletproof syntax down to woff2', async () => {
+    // @mdi/font names the EOT file in a src of its own, then names it a second
+    // time together with woff2, woff and ttf. Both src declarations must go.
+    const css = `@font-face {
+  font-family: "Material Design Icons";
+  src: url("../fonts/mdi.eot?v=7.4.47");
+  src: url("../fonts/mdi.eot?#iefix&v=7.4.47") format("embedded-opentype"), url("../fonts/mdi.woff2?v=7.4.47") format("woff2"), url("../fonts/mdi.woff?v=7.4.47") format("woff"), url("../fonts/mdi.ttf?v=7.4.47") format("truetype");
+  font-weight: normal;
+}`
+    const out = await run(css)
+
+    expect(out).toContain('mdi.woff2')
+    expect(out).not.toContain('.eot')
+    expect(out).not.toContain('format("woff")')
+    expect(out).not.toContain('truetype')
+    expect(out.match(/src:/g)).toHaveLength(1)
+    // Unrelated declarations survive.
+    expect(out).toContain('font-weight: normal')
+  })
+
+  it('keeps local() sources, because they avoid a download', async () => {
+    const css = `@font-face {
+  font-family: 'app-more-icons';
+  src: local('app-more-icons'), url('../assets/fonts/app-more-icons.woff2') format('woff2'), url('../assets/fonts/app-more-icons.woff') format('woff');
+}`
+    const out = await run(css)
+
+    expect(out).toContain("local('app-more-icons')")
+    expect(out).toContain('app-more-icons.woff2')
+    expect(out).not.toContain('app-more-icons.woff)')
+    expect(out).not.toContain("format('woff')")
+  })
+
+  it('leaves a rule alone when it offers no woff2', async () => {
+    // app-FFH-icons ships woff and ttf only. Stripping those would break it.
+    const css = `@font-face {
+  font-family: 'app-FFH-icons';
+  src: local('app-FFH-icons'), url('../assets/fonts/app-FFH-icons.woff') format('woff'), url('../assets/fonts/app-FFH-icons.ttf') format('truetype');
+}`
+    const out = await run(css)
+
+    expect(out).toContain('app-FFH-icons.woff')
+    expect(out).toContain('app-FFH-icons.ttf')
+  })
+
+  it('does not split on commas inside url() or format()', async () => {
+    const css = `@font-face {
+  font-family: 'inline';
+  src: url("data:font/woff2;base64,AAAA,BBBB") format("woff2"), url("fallback.ttf") format("truetype");
+}`
+    const out = await run(css)
+
+    expect(out).toContain('data:font/woff2;base64,AAAA,BBBB')
+    expect(out).not.toContain('fallback.ttf')
+  })
+
+  it('recognises a woff2 url even when format() is absent', async () => {
+    const css = `@font-face {
+  font-family: 'no-format';
+  src: url('../assets/fonts/thing.woff2'), url('../assets/fonts/thing.ttf');
+}`
+    const out = await run(css)
+
+    expect(out).toContain('thing.woff2')
+    expect(out).not.toContain('thing.ttf')
+  })
+
+  it('ignores src declarations outside @font-face', async () => {
+    const css = `.thing { src: url('a.ttf'); }`
+    const out = await run(css)
+
+    expect(out).toContain("a.ttf")
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/build/postcss-woff2-only.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/build/postcss-woff2-only.ts
@@ -1,0 +1,85 @@
+import type { Plugin } from 'postcss'
+
+/**
+ * Keep only the WOFF2 source in each `@font-face` rule.
+ *
+ * Why this is necessary
+ * --------------------
+ * The build runs in Vite library mode. In library mode Vite ignores
+ * `build.assetsInlineLimit` and inlines every asset as a base64 data URI,
+ * whatever its size. Each font format named in a `@font-face` rule therefore
+ * becomes part of `lifecycles.js`.
+ *
+ * `@mdi/font` uses the "bulletproof" `@font-face` syntax. That syntax names the
+ * EOT file two times, then names WOFF2, WOFF and TTF. The result was 4.69 MiB of
+ * icon font binary, which base64 expands to 6.25 MiB of the bundle, for a font
+ * where browsers only ever read the 403 KiB WOFF2.
+ *
+ * Every browser that D2E supports reads WOFF2. WOFF2 shipped in Chrome 36,
+ * Firefox 39, Safari 10 and Edge 14. Only IE11 needs the other formats, and this
+ * application is Vue 3 on single-spa, which does not run on IE11.
+ *
+ * Behaviour
+ * ---------
+ * A rule is rewritten only when it already offers a WOFF2 source. `local()`
+ * sources are kept, because they avoid a download altogether. A rule with no
+ * WOFF2 source is left alone, so fonts that ship no WOFF2 file keep working.
+ */
+
+/** Split a comma separated `src` value, ignoring commas inside `()` or quotes. */
+function splitSources(value: string): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let quote: string | null = null
+  let current = ''
+
+  for (const char of value) {
+    if (quote) {
+      if (char === quote) quote = null
+    } else if (char === '"' || char === "'") {
+      quote = char
+    } else if (char === '(') {
+      depth += 1
+    } else if (char === ')') {
+      depth -= 1
+    } else if (char === ',' && depth === 0) {
+      parts.push(current.trim())
+      current = ''
+      continue
+    }
+    current += char
+  }
+
+  if (current.trim()) parts.push(current.trim())
+  return parts
+}
+
+const isWoff2 = (source: string): boolean =>
+  /format\(\s*['"]?woff2['"]?\s*\)/i.test(source) || /\.woff2(\?|#|['")]|$)/i.test(source)
+
+const isLocal = (source: string): boolean => /^local\(/i.test(source)
+
+export function postcssWoff2Only(): Plugin {
+  return {
+    postcssPlugin: 'woff2-only-font-src',
+    AtRule: {
+      'font-face': (rule) => {
+        const declarations = rule.nodes?.filter(
+          (node): node is typeof node & { prop: string; value: string } =>
+            node.type === 'decl' && node.prop.toLowerCase() === 'src'
+        )
+        if (!declarations || declarations.length === 0) return
+
+        const sources = declarations.flatMap((declaration) => splitSources(declaration.value))
+        const woff2 = sources.filter(isWoff2)
+        if (woff2.length === 0) return
+
+        const kept = [...sources.filter(isLocal), ...woff2]
+        declarations[0].value = kept.join(', ')
+        declarations.slice(1).forEach((declaration) => declaration.remove())
+      },
+    },
+  }
+}
+
+postcssWoff2Only.postcss = true

--- a/plugins/ui/apps/vue-mri-ui-lib/build/postcss-woff2-only.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/build/postcss-woff2-only.ts
@@ -63,20 +63,20 @@ export function postcssWoff2Only(): Plugin {
   return {
     postcssPlugin: 'woff2-only-font-src',
     AtRule: {
-      'font-face': (rule) => {
+      'font-face': rule => {
         const declarations = rule.nodes?.filter(
           (node): node is typeof node & { prop: string; value: string } =>
             node.type === 'decl' && node.prop.toLowerCase() === 'src'
         )
         if (!declarations || declarations.length === 0) return
 
-        const sources = declarations.flatMap((declaration) => splitSources(declaration.value))
+        const sources = declarations.flatMap(declaration => splitSources(declaration.value))
         const woff2 = sources.filter(isWoff2)
         if (woff2.length === 0) return
 
         const kept = [...sources.filter(isLocal), ...woff2]
         declarations[0].value = kept.join(', ')
-        declarations.slice(1).forEach((declaration) => declaration.remove())
+        declarations.slice(1).forEach(declaration => declaration.remove())
       },
     },
   }

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
@@ -175,13 +175,17 @@ function getBookmarkKey(bookmark) {
 }
 import VButton from './vuetify/VButton.vue'
 import VDialog from './vuetify/VDialog.vue'
-import InclusionReport from '../query-filter/components/InclusionReport/index.vue'
+import { defineAsyncComponent } from 'vue'
 import type { RuleFilterCardDetails } from '../query-filter/types/InclusionReportTypes'
 import {
   getAttributeName,
   getAdvanceTimeFilterFormatted,
   getInclusionReportFilterCardDetails,
 } from '../utils/filterCardUtils'
+
+// Loaded on demand so plotly.js stays out of the single-spa entry's static
+// dependency graph. See docs: the chart chunk was blocking mount.
+const InclusionReport = defineAsyncComponent(() => import('../query-filter/components/InclusionReport/index.vue'))
 
 export default {
   name: 'chartToolbar',

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/ChartToolbar.vue
@@ -175,7 +175,7 @@ function getBookmarkKey(bookmark) {
 }
 import VButton from './vuetify/VButton.vue'
 import VDialog from './vuetify/VDialog.vue'
-import { defineAsyncComponent } from 'vue'
+import { lazyComponent } from '../utils/lazyComponent'
 import type { RuleFilterCardDetails } from '../query-filter/types/InclusionReportTypes'
 import {
   getAttributeName,
@@ -185,7 +185,7 @@ import {
 
 // Loaded on demand so plotly.js stays out of the single-spa entry's static
 // dependency graph. See docs: the chart chunk was blocking mount.
-const InclusionReport = defineAsyncComponent(() => import('../query-filter/components/InclusionReport/index.vue'))
+const InclusionReport = lazyComponent('InclusionReport', () => import('../query-filter/components/InclusionReport/index.vue'))
 
 export default {
   name: 'chartToolbar',

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/CohortComparisonDialog.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/CohortComparisonDialog.vue
@@ -41,12 +41,15 @@ import messageBox from './MessageBox.vue'
 import appButton from '../lib/ui/app-button.vue'
 import ChartButton from './ChartButton.vue'
 import Constants from '../utils/Constants'
-import { defineAsyncComponent } from 'vue'
+import { lazyComponent } from '../utils/lazyComponent'
 import { useNotificationStore } from '../stores/notifications'
 
 // Loaded on demand so plotly.js stays out of the single-spa entry's static
 // dependency graph. See docs: the chart chunk was blocking mount.
-const CohortComparisonContainer = defineAsyncComponent(() => import('./CohortComparisonContainer.vue'))
+const CohortComparisonContainer = lazyComponent(
+  'CohortComparisonContainer',
+  () => import('./CohortComparisonContainer.vue')
+)
 
 // const CancelToken = axios.CancelToken;
 // let cancel;

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/CohortComparisonDialog.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/CohortComparisonDialog.vue
@@ -41,8 +41,12 @@ import messageBox from './MessageBox.vue'
 import appButton from '../lib/ui/app-button.vue'
 import ChartButton from './ChartButton.vue'
 import Constants from '../utils/Constants'
-import CohortComparisonContainer from './CohortComparisonContainer.vue'
+import { defineAsyncComponent } from 'vue'
 import { useNotificationStore } from '../stores/notifications'
+
+// Loaded on demand so plotly.js stays out of the single-spa entry's static
+// dependency graph. See docs: the chart chunk was blocking mount.
+const CohortComparisonContainer = defineAsyncComponent(() => import('./CohortComparisonContainer.vue'))
 
 // const CancelToken = axios.CancelToken;
 // let cancel;

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/LazyLoadError.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/LazyLoadError.vue
@@ -1,0 +1,64 @@
+<template>
+  <!-- role="alert": this replaces content the user asked to see, and there is
+       no other signal that it failed. -->
+  <div class="lazy-load-error" role="alert" data-testid="lazy-load-error">
+    <p class="lazy-load-error__message">{{ getText('MRI_PA_CHART_LOAD_ERROR') }}</p>
+    <button type="button" class="lazy-load-error__retry" @click="reload">
+      {{ getText('MRI_PA_COLL_BUT_RETRY') }}
+    </button>
+  </div>
+</template>
+
+<script lang="ts">
+import { mapGetters } from 'vuex'
+
+/**
+ * Shown when a lazily loaded component's chunk cannot be fetched.
+ *
+ * The charts load on demand so the chart libraries stay out of the entry
+ * bundle, which means each one is a network dependency at runtime. The most
+ * likely cause of a failure is a stale document asking for a chunk hash that a
+ * new deployment has replaced, and a full reload is the only fix for that — the
+ * retry hook in `lazyComponent` has already given up by the time this renders.
+ */
+export default {
+  name: 'lazyLoadError',
+  computed: {
+    ...mapGetters(['getText']),
+  },
+  methods: {
+    reload(): void {
+      window.location.reload()
+    },
+  },
+}
+</script>
+
+<style scoped lang="scss">
+.lazy-load-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 100%;
+  padding: 24px;
+  text-align: center;
+}
+
+.lazy-load-error__message {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--d2e-color-text-secondary, #5b6771);
+}
+
+.lazy-load-error__retry {
+  padding: 6px 16px;
+  font-size: 0.875rem;
+  color: var(--d2e-color-white, #ffffff);
+  cursor: pointer;
+  background: var(--d2e-color-primary, #003d5b);
+  border: none;
+  border-radius: 6px;
+}
+</style>

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
@@ -168,7 +168,7 @@ import appButton from '../lib/ui/app-button.vue'
 import appIcon from '../lib/ui/app-icon.vue'
 import appLink from '../lib/ui/app-link.vue'
 import ExplorationsPage from './ExplorationsPage.vue'
-import ChartController from './ChartController.vue'
+import { defineAsyncComponent } from 'vue'
 import ChartToolbar from './ChartToolbar.vue'
 import FilterCardSummary from './FilterCardSummary.vue'
 import filters from './Filters.vue'
@@ -186,6 +186,10 @@ import { useUnsavedChanges } from '../composables/useUnsavedChanges'
 import { usePortalContext } from '../composables/usePortalContext'
 import { useNotificationStore } from '../stores/notifications'
 import { useExplorationsStore } from '../stores/explorations'
+
+// Loaded on demand so plotly.js stays out of the single-spa entry's static
+// dependency graph. See docs: the chart chunk was blocking mount.
+const ChartController = defineAsyncComponent(() => import('./ChartController.vue'))
 
 const PANE_SIZE = {
   FULL: 100,

--- a/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/components/PatientAnalytics.vue
@@ -168,7 +168,7 @@ import appButton from '../lib/ui/app-button.vue'
 import appIcon from '../lib/ui/app-icon.vue'
 import appLink from '../lib/ui/app-link.vue'
 import ExplorationsPage from './ExplorationsPage.vue'
-import { defineAsyncComponent } from 'vue'
+import { lazyComponent } from '../utils/lazyComponent'
 import ChartToolbar from './ChartToolbar.vue'
 import FilterCardSummary from './FilterCardSummary.vue'
 import filters from './Filters.vue'
@@ -189,7 +189,7 @@ import { useExplorationsStore } from '../stores/explorations'
 
 // Loaded on demand so plotly.js stays out of the single-spa entry's static
 // dependency graph. See docs: the chart chunk was blocking mount.
-const ChartController = defineAsyncComponent(() => import('./ChartController.vue'))
+const ChartController = lazyComponent('ChartController', () => import('./ChartController.vue'))
 
 const PANE_SIZE = {
   FULL: 100,

--- a/plugins/ui/apps/vue-mri-ui-lib/src/lib/i18n.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/lib/i18n.ts
@@ -22,6 +22,7 @@ export const i18n = {
     MRI_PA_COLL_BUT_OK: 'OK',
     MRI_PA_COLL_BUT_CANCEL: 'Cancel',
     MRI_PA_COLL_BUT_RETRY: 'Retry',
+    MRI_PA_CHART_LOAD_ERROR: 'This chart could not be loaded. Reload the page and try again.',
     MRI_PA_COLL_BUT_SAVE: 'Save',
     MRI_PA_COHORT_SAVED: 'Cohort saved',
     MRI_PA_BOOKMARK_SAVED: 'Bookmark saved successfully',

--- a/plugins/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
@@ -9,13 +9,14 @@ export default {
 <script setup lang="ts">
 import bsCard from '@/lib/ui/bs-card.vue'
 import appTab from '@/lib/ui/app-tab.vue'
-import { ref, computed, defineAsyncComponent } from 'vue'
+import { ref, computed } from 'vue'
+import { lazyComponent } from '@/utils/lazyComponent'
 import Samples from './Samples.vue'
 import { d2eWebapiService } from '@/query-filter/services/D2eWebapiService'
 
 // Loaded on demand so plotly.js stays out of the single-spa entry's static
 // dependency graph. See docs: the chart chunk was blocking mount.
-const InclusionReport = defineAsyncComponent(() => import('./InclusionReport/index.vue'))
+const InclusionReport = lazyComponent('InclusionReport', () => import('./InclusionReport/index.vue'))
 
 const props = defineProps<{
   cohortDefinitionId: string

--- a/plugins/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/query-filter/components/ExecuteSidePanel.vue
@@ -9,10 +9,13 @@ export default {
 <script setup lang="ts">
 import bsCard from '@/lib/ui/bs-card.vue'
 import appTab from '@/lib/ui/app-tab.vue'
-import { ref, computed } from 'vue'
-import InclusionReport from './InclusionReport/index.vue'
+import { ref, computed, defineAsyncComponent } from 'vue'
 import Samples from './Samples.vue'
 import { d2eWebapiService } from '@/query-filter/services/D2eWebapiService'
+
+// Loaded on demand so plotly.js stays out of the single-spa entry's static
+// dependency graph. See docs: the chart chunk was blocking mount.
+const InclusionReport = defineAsyncComponent(() => import('./InclusionReport/index.vue'))
 
 const props = defineProps<{
   cohortDefinitionId: string

--- a/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/__tests__/query.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/__tests__/query.test.ts
@@ -2,6 +2,10 @@ import { vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 vi.mock('axios')
+// drilldown loads plotly with a dynamic import, so the chart chunk stays out of
+// the single-spa entry. vi.mock intercepts the dynamic specifier too.
+const plotlyUpdate = vi.fn()
+vi.mock('@/lib/CustomPlotly', () => ({ default: { update: plotlyUpdate } }))
 vi.mock('@/store', () => ({
   default: {
     getters: {},
@@ -86,7 +90,7 @@ describe('store - query', () => {
 
   describe('actions', () => {
     describe('drilldown', () => {
-      it('dispatches datetime constraints when selected values come from chart-formatted datetime strings', () => {
+      it('dispatches datetime constraints when selected values come from chart-formatted datetime strings', async () => {
         const dispatch = vi.fn()
         const context = {
           rootGetters: {
@@ -102,7 +106,7 @@ describe('store - query', () => {
           dispatch,
         }
 
-        queryModule.actions.drilldown(context as any, {
+        await queryModule.actions.drilldown(context as any, {
           aSelectedData: [
             {
               id: 'patient.attributes.start_datetime',
@@ -121,7 +125,7 @@ describe('store - query', () => {
         )
       })
 
-      it('keeps selected calendar day for time drilldown values', () => {
+      it('keeps selected calendar day for time drilldown values', async () => {
         const dispatch = vi.fn()
         const context = {
           rootGetters: {
@@ -137,7 +141,7 @@ describe('store - query', () => {
           dispatch,
         }
 
-        queryModule.actions.drilldown(context as any, {
+        await queryModule.actions.drilldown(context as any, {
           aSelectedData: [
             {
               id: 'patient.attributes.admission_date',
@@ -164,6 +168,29 @@ describe('store - query', () => {
         expect(payload.toDateValue).toBeInstanceOf(Date)
         expect(DateUtils.displayDateFormat(payload.fromDateValue)).toBe('1976-02-21')
         expect(DateUtils.displayDateFormat(payload.toDateValue)).toBe('1976-03-20')
+      })
+
+      it('clears the plotly selection through the lazily imported chart module', async () => {
+        plotlyUpdate.mockClear()
+        const dispatch = vi.fn()
+        const dispatchEvent = vi.fn()
+        const plotlyElement = { dispatchEvent }
+        const context = {
+          rootGetters: {
+            getMriFrontendConfig: {
+              getAttributeByPath: () => ({ getType: () => 'text' }),
+            },
+          },
+          getters: { getPlotlyElement: plotlyElement },
+          dispatch,
+        }
+
+        await queryModule.actions.drilldown(context as any, {
+          aSelectedData: [{ id: 'patient.attributes.gender', value: 'Female' }],
+        })
+
+        expect(dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'plotly_deselect' }))
+        expect(plotlyUpdate).toHaveBeenCalledWith(plotlyElement, {}, { selections: [] })
       })
     })
 

--- a/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/query.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/store/modules/query.ts
@@ -19,7 +19,6 @@ import DateUtils from '../../utils/DateUtils'
 import QueryString from '../../utils/QueryString'
 import { VariantValidator } from '../../utils/VariantValidator'
 import * as types from '../mutation-types'
-import Plotly from '../../lib/CustomPlotly'
 import moment from 'moment'
 
 const parseDrilldownDateValue = (value: unknown): Date | null => {
@@ -1087,7 +1086,7 @@ const actions = {
   setCurrentPatientCount({ commit }, { currentPatientCount }) {
     commit(types.SET_CURRENT_PATIENT_COUNT, { currentPatientCount })
   },
-  drilldown({ rootGetters, getters, dispatch }, { aSelectedData }) {
+  async drilldown({ rootGetters, getters, dispatch }, { aSelectedData }) {
     try {
       const collectedConstraints = {}
       let collectedDateConstraints = {}
@@ -1211,6 +1210,10 @@ const actions = {
       const plotlyElement = getters.getPlotlyElement
       if (plotlyElement) {
         getters.getPlotlyElement.dispatchEvent?.(new CustomEvent('plotly_deselect'))
+        // Loaded on demand. A static import here would pull plotly.js into the
+        // store, and the store is built by lifecycles.ts, so the whole chart
+        // chunk would become a static dependency of the single-spa entry.
+        const { default: Plotly } = await import('../../lib/CustomPlotly')
         Plotly.update(plotlyElement, {}, { selections: [] })
       }
     } catch (e) {

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/lazyComponent.test.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/__tests__/lazyComponent.test.ts
@@ -1,0 +1,79 @@
+import { vi, describe, expect, it, beforeEach, afterEach } from 'vitest'
+
+/**
+ * The charts load on demand so the chart libraries stay out of the entry
+ * bundle. That makes each one a network dependency, and this app sets
+ * `app.config.errorHandler = () => null` in every non-debug build — so a
+ * rejected chunk fetch is discarded and the pane just renders empty.
+ *
+ * These tests pin the `onError` policy that stops that: retry once, then fail
+ * loudly enough to reach the console and visibly enough to reach the user.
+ *
+ * `defineAsyncComponent` is mocked so the options object can be inspected
+ * directly. That keeps this a test of the retry policy rather than of
+ * rendering.
+ */
+const capturedOptions: Record<string, any>[] = []
+
+vi.mock('vue', () => ({
+  defineAsyncComponent: (options: Record<string, any>) => {
+    capturedOptions.push(options)
+    return { name: 'stub' }
+  },
+}))
+vi.mock('../../components/LazyLoadError.vue', () => ({ default: { name: 'lazyLoadError' } }))
+
+import { lazyComponent } from '../lazyComponent'
+import LazyLoadError from '../../components/LazyLoadError.vue'
+
+const optionsFor = (loader = async () => ({})) => {
+  capturedOptions.length = 0
+  lazyComponent('TestChart', loader as never)
+  return capturedOptions[0]
+}
+
+describe('lazyComponent', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows an error component rather than nothing when the chunk cannot load', () => {
+    expect(optionsFor().errorComponent).toBe(LazyLoadError)
+  })
+
+  it('retries once, because the common causes are transient', () => {
+    const retry = vi.fn()
+    const fail = vi.fn()
+
+    optionsFor().onError(new Error('network'), retry, fail, 1)
+
+    expect(retry).toHaveBeenCalledTimes(1)
+    expect(fail).not.toHaveBeenCalled()
+  })
+
+  it('gives up on the second failure instead of retrying forever', () => {
+    const retry = vi.fn()
+    const fail = vi.fn()
+
+    optionsFor().onError(new Error('network'), retry, fail, 2)
+
+    expect(fail).toHaveBeenCalledTimes(1)
+    expect(retry).not.toHaveBeenCalled()
+  })
+
+  it('logs through console.error, which the suppressed Vue handler cannot swallow', () => {
+    const error = new Error('network')
+
+    optionsFor().onError(error, vi.fn(), vi.fn(), 2)
+
+    expect(console.error).toHaveBeenCalledWith('[lazyComponent] TestChart failed to load', error)
+  })
+
+  it('sets a timeout, so a stalled fetch does not hang on the loading state', () => {
+    expect(optionsFor().timeout).toBeGreaterThan(0)
+  })
+})

--- a/plugins/ui/apps/vue-mri-ui-lib/src/utils/lazyComponent.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/src/utils/lazyComponent.ts
@@ -1,0 +1,41 @@
+import { defineAsyncComponent, type AsyncComponentLoader, type Component } from 'vue'
+import LazyLoadError from '../components/LazyLoadError.vue'
+
+/**
+ * Declare a component that loads on demand, and fail visibly if it cannot.
+ *
+ * The chart-bearing components load lazily so plotly.js, echarts and d3 stay
+ * out of the single-spa entry's static dependency graph. That turns each one
+ * into a network dependency at runtime, which a static import never was.
+ *
+ * A bare `defineAsyncComponent(loader)` handles that badly here. This app sets
+ * `app.config.errorHandler = () => null` in every non-debug build, in both
+ * `main.ts` and `lifecycles.ts`, so a rejected chunk fetch is discarded: the
+ * pane renders empty, nothing reaches the console, and there is no way back
+ * without a reload the user has no reason to try.
+ *
+ * So: retry once, because the common causes are transient, then show
+ * `LazyLoadError` and log past the suppressed handler.
+ */
+
+/** One retry. A second failure is a real one, not a blip. */
+const RETRY_LIMIT = 1
+
+/** Long enough for a large chart chunk on a slow link. */
+const TIMEOUT_MS = 30000
+
+export const lazyComponent = (name: string, loader: AsyncComponentLoader): Component =>
+  defineAsyncComponent({
+    loader,
+    errorComponent: LazyLoadError,
+    timeout: TIMEOUT_MS,
+    onError: (error, retry, fail, attempts) => {
+      if (attempts <= RETRY_LIMIT) {
+        retry()
+        return
+      }
+      // console.error, not the Vue error handler: that one is suppressed.
+      console.error(`[lazyComponent] ${name} failed to load`, error)
+      fail()
+    },
+  })

--- a/plugins/ui/apps/vue-mri-ui-lib/vite.config.ts
+++ b/plugins/ui/apps/vue-mri-ui-lib/vite.config.ts
@@ -7,6 +7,7 @@ import basicSsl from '@vitejs/plugin-basic-ssl'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import path from 'path'
 import { vueDir, vuetifyDir } from './vite.resolve-deps'
+import { postcssWoff2Only } from './build/postcss-woff2-only'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
@@ -169,6 +170,10 @@ export default defineConfig(({ command, mode }) => {
               },
             },
           },
+          // Library mode inlines every font a @font-face names, so each extra
+          // format is dead weight in lifecycles.js. Keep WOFF2 only.
+          // See build/postcss-woff2-only.ts.
+          postcssWoff2Only(),
         ],
       },
       preprocessorOptions: {
@@ -254,7 +259,7 @@ export default defineConfig(({ command, mode }) => {
       globals: true,
       environment: 'happy-dom',
       setupFiles: ['./vitest.setup.ts'],
-      include: ['src/**/__tests__/*.test.ts'],
+      include: ['src/**/__tests__/*.test.ts', 'build/__tests__/*.test.ts'],
       server: {
         deps: {
           inline: ['vuetify'],


### PR DESCRIPTION
Twelfth and last in the Data Exploration redesign stack. **Based on `khairul-syazwan/atlas-native-mount` (#3318), not `develop`** — review that one first.

No ticket. This finishes #3116 by making the redesign cheap to load.

## Why this is last, and not first

It was going to land before the native Atlas mount, because Atlas3 imports every plugin eagerly at boot with a 30 second timeout, so a large entry is a real risk there. The order was reversed on purpose: the ticket owner wants Atlas load benchmarks taken **before and after** this change, and that needs the mount landed first. The two compose cleanly, so this is sequencing, not dependency.

## What it does

Four performance commits, each one independently measured, plus three from review. Read the commit messages — they carry the reasoning and the numbers, and are the better record than this summary.

| Commit | Change |
| --- | --- |
| `perf(vue-mri): keep only the woff2 source in each @font-face` | Vite library mode ignores `assetsInlineLimit` and inlines every asset as base64. `@mdi/font` uses bulletproof `@font-face` syntax, so 4.69 MiB of icon binary became 6.25 MiB of the entry, for a font where browsers only read the 403 KiB woff2 |
| `perf(vue-mri): load the chart libraries on demand` | Four static paths reached plotly.js, echarts and d3. All four broken, so Rollup can split them |
| `fix(atlas): stop registering the Atlas researcher plugin` | Removes a manifest entry that produced two 404s on every portal load and never worked |
| `perf(portal): preload the active plugin first, queue the rest` | Six plugin bundles went on the wire together and starved the one the user opened |

## Measured

A/B on identical bases: this branch against its own parent, same machine, same build commands. Gzipped, kB as Vite reports them.

| Entry | Without | With | Change |
| --- | --- | --- | --- |
| portal, `resources/mri/lifecycles.js` | 4,075 kB | **938 kB** | **−77%** |
| native Atlas, `dist-atlas-native/index.system.js` | 6,701 kB | **4,047 kB** | **−40%** |

Chunk count 47 → 54. plotly.js becomes its own 1,430 kB gzipped chunk that the Cohorts page never requests.

**The Atlas number is the one that matters most.** The host fetches only the entry, eagerly, for every installed plugin at boot.

The absolute byte counts in the commit messages were measured against `develop` before the rebase and drift slightly from the table above; the percentages hold.

## Three defects found in review, fixed here

The four performance commits were written in an earlier session and had never been reviewed. Review found three, all of them created by this diff rather than pre-existing.

- **A chart that failed to load showed nothing at all, and said nothing.** This is the significant one. Making the four chart components lazy turned static imports into runtime network dependencies — a static import cannot fail once the entry has run, a chunk fetch can. And the app sets `app.config.errorHandler = () => null` in every non-debug build, in both `main.ts` and `lifecycles.ts`, so the rejection was discarded: an empty pane, nothing in the console, and no reason for the user to try a reload. A stale document asking for a chunk hash that a new deployment has replaced produces exactly that, and is the most likely cause. There is now a `lazyComponent` helper that retries once, then renders an error with a reload and logs through `console.error`, which the suppressed handler cannot swallow.
- **A queued preload was never cancelled when its plugin unregistered**, so a plugin the user had navigated away from was still downloaded, competing with whatever they opened instead. A dataset switch remounts the whole researcher container, so this is ordinary, not an edge case. Worse, `generateAppId` derives the id from the path alone, so a re-register reused the id and left two entries queued for one plugin — two background downloads, which is the exact thing the scheduler was written to prevent.
- **`foregroundInFlight` was a boolean.** Two plugins can both match the current location when their base paths nest; the first to settle resumed background draining while the second was still on the wire. Latent today, since no two current manifests overlap. It is a counter now.

Review also confirmed, by tracing: no static path to plotly, echarts or d3 survives; the now-`async` `drilldown` action is safe at its one non-awaited call site, because every synchronous `dispatch` runs before the first `await`; the hand-resolved `PatientAnalytics.vue` rebase conflict is correct; and the postcss plugin no-ops correctly on a rule with no woff2 source.

## The chart split only works if every static path is broken

One surviving static import pins the chunk back into the entry, and nothing in the build fails when that happens — the bundle just gets big again quietly. The four paths were:

- `store/modules/query.ts` — imported plotly for a single `update()` call in drilldown. **This one was the load-bearing case**: the store is built by `lifecycles.ts`, so it alone pinned the chunk to the entry. The action is now `async`, and its callers were checked.
- `PatientAnalytics.vue`, `CohortComparisonDialog.vue`, `ChartToolbar.vue`, `query-filter/components/ExecuteSidePanel.vue` — now declare their chart-bearing children with `defineAsyncComponent`.

The chart components themselves are untouched.

Section 4.4 of the project roadmap carries a follow-up: **add a build-time check that keeps plotly off the entry.** Nothing today prevents a future static import from silently undoing this.

## Blast radius

`perf(portal): preload the active plugin first` touches the **React portal's** single-spa registry — `plugins/ui/apps/portal/src/singleSpa/`. That is wider than vue-mri, and it changes the load behaviour of every plugin the portal hosts, not just this one.

Deferring a preload is only an optimisation: if a plugin is opened before its queued preload runs, single-spa calls its load function on activation and the module cache dedupes the two callers. The plugin whose route is already active still preloads immediately, which is what closes the `LOADING_SOURCE_CODE` race the eager preload was added for.

## Validation

Reported honestly; this is not a claim of full end-to-end coverage.

| Check | Result |
| --- | --- |
| Unit tests, Node 20, the command CI runs | **1083 passed, 3 skipped.** 15 new |
| `vite build` (portal) | pass |
| `vite build --config vite.config.atlas.ts` | pass |
| `vite build --config vite.config.atlas-app.ts` | pass |
| `vite build --config vite.config.atlas-native.ts` | pass |
| `prettier --check` on the files this branch adds | pass |
| **eslint** | **not run.** `plugins/ui` hoists eslint 7.32, which cannot read the app's flat config |
| Bundle A/B measurement | done, table above |
| `no-mistakes` gate | **not run.** It does not follow a treehouse worktree and targets `develop`, not this stack's parent — the same path every pull request in this stack has taken |

Portal tests run separately, through `react-scripts test`: **8 passed** in `preloadScheduler.test.ts`, 3 new.

Every new test was checked against the previous behaviour before being trusted: the two lazy-load tests fail with `RETRY_LIMIT` at 0 and no `errorComponent`, and the three scheduler tests fail with the cancel, the dedupe and the counter reverted.

Three files this branch touches — `CohortComparisonDialog.vue`, `store/modules/query.ts` and `lib/i18n.ts` — already fail `prettier --check` on the parent branch. Left alone rather than reformatted, to keep the diff readable. The two files the branch *adds* were formatted.
